### PR TITLE
refactor: RBAC permissions for controller to interact with Pods

### DIFF
--- a/manifests/pcs-controller-latest.yaml
+++ b/manifests/pcs-controller-latest.yaml
@@ -46,6 +46,8 @@ rules:
   - get
   - patch
   - update
+  - list      # REQUIRED for watching
+  - watch     # REQUIRED for watching  
 
 # PodCertificateRequests - monitor only
 - apiGroups:


### PR DESCRIPTION
* Added missing permissions for controller to be able to properly interact with Pods within the cluster