### PR TITLE
ci: chain artifact publishing into the release, scope CI triggers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,10 @@
 name: Lint
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,9 +1,27 @@
 name: Release Artifacts
 
+# Tags and releases published by the release workflow are created with the
+# workflow GITHUB_TOKEN, and GitHub never triggers workflows from events
+# created by that token. The release workflow therefore invokes this one
+# directly via workflow_call. The tag push trigger covers manually pushed
+# tags, and workflow_dispatch allows backfilling artifacts for an existing
+# release.
 on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_call:
+    inputs:
+      tag:
+        description: The release tag (vX.Y.Z) to build and publish artifacts for.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The release tag (vX.Y.Z) to build and publish artifacts for.
+        required: true
+        type: string
 
 permissions: {}
 
@@ -22,9 +40,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Clone the code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -45,10 +67,9 @@ jobs:
         with:
           images: ${{ env.IMAGE_REPO }}
           tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=sha
+            type=semver,pattern=v{{version}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern=v{{major}},value=${{ env.RELEASE_TAG }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -70,9 +91,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Clone the code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Log in to GitHub Container Registry
         run: |
@@ -81,12 +106,12 @@ jobs:
 
       - name: Package the chart
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           helm package charts/podcertificate-signer \
             --version "${VERSION}" \
-            --app-version "${GITHUB_REF_NAME}"
+            --app-version "${RELEASE_TAG}"
 
       - name: Push the chart
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           helm push "podcertificate-signer-${VERSION}.tgz" "oci://${CHART_REPO}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,30 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+    outputs:
+      tag_name: ${{ steps.drafter.outputs.tag_name }}
     steps:
       # A merge labeled release/skip only updates the running release draft.
       # Any other release/* label publishes the release, which creates the
-      # v* tag and thereby triggers the image build workflow.
+      # v* tag.
       - name: Draft or publish the release
+        id: drafter
         uses: release-drafter/release-drafter@v7
         with:
           publish: ${{ !contains(github.event.pull_request.labels.*.name, 'release/skip') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # The tag above is created with the workflow GITHUB_TOKEN, which never
+  # triggers other workflows - so the artifacts workflow is invoked directly
+  # instead of relying on its tag push trigger.
+  publish-artifacts:
+    name: Publish release artifacts
+    needs: release
+    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'release/skip')
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/release-image.yml
+    with:
+      tag: ${{ needs.release.outputs.tag_name }}

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -1,7 +1,6 @@
 name: Test Chart
 
 on:
-  push:
   pull_request:
 
 permissions: {}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,7 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Tests
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ Releases are fully label-driven. Every PR targeting `main` must carry exactly on
 | `release/patch` | Publishes a release with a **patch** version bump (fixes)              |
 | `release/skip`  | No release; the change is collected into the next release draft        |
 
-Publishing the release creates the `v*` tag, which triggers the release artifacts workflow:
+Publishing the release creates the `v*` tag and chains directly into the release artifacts workflow (tags created by the workflow token never trigger workflows on their own; manually pushed `v*` tags and `workflow_dispatch` also work):
 
 - a multi-arch (`linux/amd64`, `linux/arm64`) image is built and pushed to `ghcr.io/rafpe/pod-certificate-signer` tagged `vX.Y.Z`, `vX.Y`, `vX` and `latest`
 - the Helm chart is packaged with `version: X.Y.Z` / `appVersion: vX.Y.Z` and pushed to `oci://ghcr.io/rafpe/charts/podcertificate-signer`


### PR DESCRIPTION
## Why

The v1.0.0 release published no image and no Helm chart: release-drafter creates the tag with the workflow `GITHUB_TOKEN`, and GitHub never triggers workflows from events created by that token — so the tag-push trigger of the artifacts workflow can never fire for automated releases.

Separately, the e2e and chart test workflows re-ran on every merge to `main` (and duplicated on PR branches) because of their unfiltered `push` trigger.

## What

- **Chain artifact publishing into the release**: `release-image.yml` becomes a reusable workflow (`workflow_call` with a `tag` input) and `release.yml` invokes it directly after publishing the release. The tag-push trigger remains for manually pushed tags, and `workflow_dispatch` allows backfilling artifacts for an existing release (e.g. v1.0.0). Image tags derive from the release tag input rather than the git ref, and both jobs check out the tag being released.
- **Scope CI triggers**: e2e and chart tests run only on pull requests; lint and unit tests keep a push trigger restricted to `main` as a cheap check on the actual merge commit.
- README release-process section updated accordingly.

## After merging

Backfill the missing v1.0.0 artifacts by dispatching the *Release Artifacts* workflow with `tag=v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXUr36uCauK3EmbRZP1cHw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXUr36uCauK3EmbRZP1cHw)_