### PR TITLE
fix(docker): point the OCI source label at the correct repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-LABEL org.opencontainers.image.source https://github.com/rafpe/kubernetes-podcertificate-signer
+LABEL org.opencontainers.image.source=https://github.com/rafpe/pod-certificate-signer
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
## Why

The `org.opencontainers.image.source` label referenced the old repository name (`kubernetes-podcertificate-signer`). GHCR uses this label to link a container package to its repository on creation, so newly created packages would not connect to this repo and would not inherit its Actions access.

Related to the v1.0.0 artifact backfill: the 403 on push comes from a pre-existing private `pod-certificate-signer` package (from earlier manual pushes) that is not linked to this repository — that needs a one-time access grant in the package settings; this label fix keeps future package creations correctly linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXUr36uCauK3EmbRZP1cHw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXUr36uCauK3EmbRZP1cHw)_