### PR TITLE
feat: IP SANs via ip-san annotation + groundwork for CSR-requested SANs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ Unknown variables and unterminated placeholders deny the request with reason `In
 
 ### 🔮 CSR-requested SANs (forward compatibility)
 
-Upstream Kubernetes plans to let pod authors request DNS and IP SANs which kubelet embeds in the PKCS#10 CSR of the `PodCertificateRequest` (today kubelet generates completely empty CSRs). The controller is ready for this behind the `--honor-csr-sans` feature flag (Helm: `signer.honor_csr_sans`, disabled by default): when enabled, CSR-requested DNS and IP SANs are used unless a `san` annotation overrides them. While disabled, CSR SANs are ignored, which the Kubernetes API contract explicitly allows for signers.
+Upstream Kubernetes plans to let pod authors request DNS and IP SANs which kubelet embeds in the PKCS#10 CSR of the `PodCertificateRequest` (today kubelet generates completely empty CSRs). The controller is ready for this behind the `--honor-csr-sans` feature flag (Helm: `signer.honor_csr_sans`, disabled by default): when enabled, CSR-requested DNS and IP SANs are used unless a `san`/`ip-san` annotation overrides them. While disabled, CSR SANs are ignored, which the Kubernetes API contract explicitly allows for signers.
+
+Until then, IP SANs can be requested via the `ip-san` annotation — once kubelet gains native SAN support, the same values move into the pod spec and the annotation simply becomes the override.
 
 ### 🏷️ Configuration via Pod Annotations (deprecated)
 
@@ -238,6 +240,7 @@ Below is the table with the annotations and example values:
 | ------------------------ | -------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `{signer-name}-cn`       | No       | `{pod-name}`                                                                        | `mysigner.example.com/foobar-cn: my-pod.default.pod.cluster.local`                                   |
 | `{signer-name}-san`      | No       | `{pod-name}.{namespace}.pod.cluster.local,{pod-name}.{namespace}.svc.cluster.local` | `mysigner.example.com/foobar-san: my-pod.default.pod.cluster.local,my-pod.default.svc.cluster.local` |
+| `{signer-name}-ip-san`   | No       | `(empty)`                                                                           | `mysigner.example.com/foobar-ip-san: 10.96.0.10,2001:db8::1`                                         |
 | `{signer-name}-uris`     | No       | `(empty)`                                                                           | `mysigner.example.com/foobar-uris: spiffe://cluster.local/ns/default/sa/my-service`                  |
 | `{signer-name}-duration` | No       | `24h`                                                                               | `mysigner.example.com/foobar-duration: 12h`                                                          |
 | `{signer-name}-refresh`  | No       | `15m`                                                                               | `mysigner.example.com/foobar-refresh: 30m`                                                           |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [📝 Usage](#-usage)
     - [🏷️ Configuration via `unverifiedUserAnnotations`](#️-configuration-via-unverifieduserannotations)
     - [🧩 Interpolating pod identity into certificate values](#-interpolating-pod-identity-into-certificate-values)
+    - [🔮 CSR-requested SANs (forward compatibility)](#-csr-requested-sans-forward-compatibility)
     - [🏷️ Configuration via Pod Annotations (deprecated)](#️-configuration-via-pod-annotations-deprecated)
       - [🔗 Example configuration](#-example-configuration)
     - [Requesting PodCertificates for your workload](#requesting-podcertificates-for-your-workload)
@@ -219,6 +220,10 @@ Available variables - all resolved from fields of the `PodCertificateRequest` th
 | `${cluster.fqdn}`           | Cluster FQDN from the `-cluster-fqdn` flag   |
 
 Unknown variables and unterminated placeholders deny the request with reason `InvalidUnverifiedUserAnnotations`. Values are validated after expansion, including the 64 character common name limit from RFC 5280.
+
+### 🔮 CSR-requested SANs (forward compatibility)
+
+Upstream Kubernetes plans to let pod authors request DNS and IP SANs which kubelet embeds in the PKCS#10 CSR of the `PodCertificateRequest` (today kubelet generates completely empty CSRs). The controller is ready for this behind the `--honor-csr-sans` feature flag (Helm: `signer.honor_csr_sans`, disabled by default): when enabled, CSR-requested DNS and IP SANs are used unless a `san` annotation overrides them. While disabled, CSR SANs are ignored, which the Kubernetes API contract explicitly allows for signers.
 
 ### 🏷️ Configuration via Pod Annotations (deprecated)
 
@@ -426,6 +431,8 @@ Controller is customizable and supports the following arguments along with their
     	Allow ${...} placeholders (e.g. ${pod.name}, ${pod.serviceAccountName}) in certificate configuration annotations, resolved from the verified fields of the PodCertificateRequest.
   -health-probe-bind-address string
     	The address the probe endpoint binds to. (default ":8081")
+  -honor-csr-sans
+    	Honor DNS and IP SANs embedded in the kubelet-generated PKCS#10 CSR when no SAN annotation overrides them. Kubelet generates empty CSRs today; this prepares for upcoming Kubernetes support for requesting SANs.
   -kubeconfig string
     	Paths to a kubeconfig. Only required if out-of-cluster.
   -leader-elect

--- a/charts/podcertificate-signer/templates/deployment.yaml
+++ b/charts/podcertificate-signer/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - --reconcile-timeout={{ .Values.manager.reconcile_timeout }}
             - --max-previous-ca-certs={{ .Values.signer.max_previous_ca_certs }}
             - --enable-annotation-interpolation={{ .Values.signer.enable_annotation_interpolation }}
+            - --honor-csr-sans={{ .Values.signer.honor_csr_sans }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/podcertificate-signer/values.yaml
+++ b/charts/podcertificate-signer/values.yaml
@@ -41,6 +41,12 @@ signer:
   # resolved from the verified fields of the PodCertificateRequest.
   enable_annotation_interpolation: false
 
+  # Feature flag: honor DNS and IP SANs embedded in the kubelet-generated
+  # PKCS#10 CSR when no SAN annotation overrides them. Kubelet generates
+  # empty CSRs today; this prepares for upcoming Kubernetes support for
+  # requesting SANs on the projected volume.
+  honor_csr_sans: false
+
 # Controller manager settings
 manager:
   # Max concurrent reconciles

--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -72,7 +72,7 @@ func main() {
 	var leaderElectionID, leaderElectionNamespace string
 	var healthProbeBindAddress, metricsBindAddress string
 	var maxConcurrentReconciles, maxPreviousCACerts int
-	var enableLeaderElection, enableAnnotationInterpolation bool
+	var enableLeaderElection, enableAnnotationInterpolation, honorCSRSANs bool
 	var reconcileTimeout time.Duration
 
 	flag.StringVar(&signerName, "signer-name", "example.org/signer", "Only sign CSR with this .spec.signerName.")
@@ -93,6 +93,9 @@ func main() {
 	flag.BoolVar(&enableAnnotationInterpolation, "enable-annotation-interpolation", false,
 		"Allow ${...} placeholders (e.g. ${pod.name}, ${pod.serviceAccountName}) in certificate configuration annotations, "+
 			"resolved from the verified fields of the PodCertificateRequest.")
+	flag.BoolVar(&honorCSRSANs, "honor-csr-sans", false,
+		"Honor DNS and IP SANs embedded in the kubelet-generated PKCS#10 CSR when no SAN annotation overrides them. "+
+			"Kubelet generates empty CSRs today; this prepares for upcoming Kubernetes support for requesting SANs.")
 
 	opts := zap.Options{
 		Development:     true,
@@ -217,6 +220,7 @@ func main() {
 		ClusterFqdn:                   clusterFqdn,
 		EventRecorder:                 mgr.GetEventRecorder(DefaultControllerName),
 		EnableAnnotationInterpolation: enableAnnotationInterpolation,
+		HonorCSRSANs:                  honorCSRSANs,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PodCertificateSignerReconciler")
 		os.Exit(1)

--- a/examples/workload-pod.yaml
+++ b/examples/workload-pod.yaml
@@ -47,6 +47,7 @@ spec:
           userAnnotations:
             example.org/signer-cn: "${pod.name}.${pod.namespace}.svc.cluster.local"
             example.org/signer-san: "${pod.name}.${pod.namespace}.svc,${pod.serviceAccountName}.${pod.namespace}.svc"
+            example.org/signer-ip-san: "10.96.0.99"
       - clusterTrustBundle:
           signerName: example.org/signer
           labelSelector: {}

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -96,6 +96,9 @@ type PodCertificateRequestReconciler struct {
 	// EnableAnnotationInterpolation allows ${...} placeholders in the
 	// certificate configuration annotations (feature flag, off by default).
 	EnableAnnotationInterpolation bool
+	// HonorCSRSANs uses DNS/IP SANs embedded in the kubelet-generated CSR
+	// (feature flag, off by default; kubelet generates empty CSRs today).
+	HonorCSRSANs bool
 }
 
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=podcertificaterequests,verbs=get;list;watch
@@ -191,22 +194,28 @@ func (r *PodCertificateRequestReconciler) process(ctx context.Context, pcr *capi
 		return nil, nil
 	}
 
+	configOpts := podcertificate.Options{
+		ClusterFQDN:         r.ClusterFqdn,
+		EnableInterpolation: r.EnableAnnotationInterpolation,
+		HonorCSRSANs:        r.HonorCSRSANs,
+	}
 	var publicKey crypto.PublicKey
 	var publicKeyAlgorithm x509.PublicKeyAlgorithm
 	if len(pcr.Spec.StubPKCS10Request) > 0 {
-		publicKey, publicKeyAlgorithm, err = signer.ParseCSRPublicKey(pcr.Spec.StubPKCS10Request)
+		csrInfo, cerr := signer.ParseCSR(pcr.Spec.StubPKCS10Request)
+		if cerr != nil {
+			return nil, denied(ReasonUnsupportedKeyType, cerr)
+		}
+		publicKey, publicKeyAlgorithm = csrInfo.PublicKey, csrInfo.PublicKeyAlgorithm
+		configOpts.CSRDNSNames = csrInfo.DNSNames
+		configOpts.CSRIPAddresses = csrInfo.IPAddresses
 	} else {
 		// PKIXPublicKey is deprecated in favour of StubPKCS10Request, but is
 		// still sent by kubelets which pre-date the CSR stub.
 		publicKey, publicKeyAlgorithm, err = signer.ParsePKIXPublicKey(pcr.Spec.PKIXPublicKey) //nolint:staticcheck
-	}
-	if err != nil {
-		return nil, denied(ReasonUnsupportedKeyType, err)
-	}
-
-	configOpts := podcertificate.Options{
-		ClusterFQDN:         r.ClusterFqdn,
-		EnableInterpolation: r.EnableAnnotationInterpolation,
+		if err != nil {
+			return nil, denied(ReasonUnsupportedKeyType, err)
+		}
 	}
 	pcConfig, err := podcertificate.NewPodCertificateConfig(pcr, crPod, configOpts, publicKey, publicKeyAlgorithm)
 	if err != nil {

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -207,6 +207,7 @@ func (ca *CertificateAuthority) Sign(pcConfig *podcertificate.PodCertificateConf
 			CommonName: pcConfig.CommonName,
 		},
 		DNSNames:           pcConfig.DNSNames,
+		IPAddresses:        pcConfig.IPAddresses,
 		URIs:               pcConfig.URIs,
 		PublicKeyAlgorithm: pcConfig.PublicKeyAlgorithm,
 		PublicKey:          pcConfig.PublicKey,

--- a/internal/kubernetes/authority/authority_test.go
+++ b/internal/kubernetes/authority/authority_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -152,6 +153,28 @@ func TestSignIssuesCertificateChain(t *testing.T) {
 	}
 	if !pc.IsValid() {
 		t.Error("freshly issued certificate must be valid")
+	}
+}
+
+// IP SANs from the configuration must be embedded in the issued certificate.
+func TestSignIncludesIPAddresses(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	config := testConfig(t)
+	config.IPAddresses = []net.IP{net.ParseIP("10.9.8.7")}
+
+	pc, err := ca.Sign(config)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	leaf := parseChain(t, []byte(pc.CertificateChain()))[0]
+	if len(leaf.IPAddresses) != 1 || !leaf.IPAddresses[0].Equal(config.IPAddresses[0]) {
+		t.Errorf("leaf IPAddresses = %v, want %v", leaf.IPAddresses, config.IPAddresses)
 	}
 }
 

--- a/internal/kubernetes/podcertificate/csr_sans_test.go
+++ b/internal/kubernetes/podcertificate/csr_sans_test.go
@@ -1,0 +1,78 @@
+package podcertificate
+
+import (
+	"net"
+	"testing"
+)
+
+// CSR-requested SANs are used when the feature is enabled and no annotation
+// overrides them.
+func TestCSRSANsHonoredWhenEnabled(t *testing.T) {
+	opts := Options{
+		HonorCSRSANs:   true,
+		CSRDNSNames:    []string{"csr.example.org"},
+		CSRIPAddresses: []net.IP{net.ParseIP("10.1.2.3")},
+	}
+
+	config, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), opts, nil, 0)
+	if err != nil {
+		t.Fatalf("NewPodCertificateConfig: %v", err)
+	}
+	if len(config.DNSNames) != 1 || config.DNSNames[0] != "csr.example.org" {
+		t.Errorf("DNSNames = %v, want the CSR-requested name", config.DNSNames)
+	}
+	if len(config.IPAddresses) != 1 || !config.IPAddresses[0].Equal(net.ParseIP("10.1.2.3")) {
+		t.Errorf("IPAddresses = %v, want the CSR-requested IP", config.IPAddresses)
+	}
+}
+
+// The san annotation takes precedence over CSR-requested DNS names.
+func TestCSRSANsAnnotationTakesPrecedence(t *testing.T) {
+	pcr := testPCR(map[string]string{testSignerName + "-san": "annotated.example.org"})
+	opts := Options{
+		HonorCSRSANs: true,
+		CSRDNSNames:  []string{"csr.example.org"},
+	}
+
+	config, err := NewPodCertificateConfig(pcr, testPod(nil), opts, nil, 0)
+	if err != nil {
+		t.Fatalf("NewPodCertificateConfig: %v", err)
+	}
+	if len(config.DNSNames) != 1 || config.DNSNames[0] != "annotated.example.org" {
+		t.Errorf("DNSNames = %v, want the annotation to win over CSR SANs", config.DNSNames)
+	}
+}
+
+// With the feature disabled (default), CSR SANs are ignored - the API
+// contract explicitly allows signers to ignore CSR contents.
+func TestCSRSANsIgnoredWhenDisabled(t *testing.T) {
+	opts := Options{
+		CSRDNSNames:    []string{"csr.example.org"},
+		CSRIPAddresses: []net.IP{net.ParseIP("10.1.2.3")},
+	}
+
+	config, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), opts, nil, 0)
+	if err != nil {
+		t.Fatalf("NewPodCertificateConfig: %v", err)
+	}
+	if len(config.DNSNames) != 2 || config.DNSNames[0] != "mypod.myns.pod.cluster.local" {
+		t.Errorf("DNSNames = %v, want the defaults", config.DNSNames)
+	}
+	if len(config.IPAddresses) != 0 {
+		t.Errorf("IPAddresses = %v, want none when the feature is disabled", config.IPAddresses)
+	}
+}
+
+// Enabled but with an empty CSR (kubelet today): defaults still apply.
+func TestCSRSANsEmptyCSRKeepsDefaults(t *testing.T) {
+	config, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), Options{HonorCSRSANs: true}, nil, 0)
+	if err != nil {
+		t.Fatalf("NewPodCertificateConfig: %v", err)
+	}
+	if len(config.DNSNames) != 2 || config.DNSNames[0] != "mypod.myns.pod.cluster.local" {
+		t.Errorf("DNSNames = %v, want the defaults", config.DNSNames)
+	}
+	if len(config.IPAddresses) != 0 {
+		t.Errorf("IPAddresses = %v, want none for an empty CSR", config.IPAddresses)
+	}
+}

--- a/internal/kubernetes/podcertificate/csr_sans_test.go
+++ b/internal/kubernetes/podcertificate/csr_sans_test.go
@@ -63,6 +63,41 @@ func TestCSRSANsIgnoredWhenDisabled(t *testing.T) {
 	}
 }
 
+// The ip-san annotation sets IP SANs and takes precedence over CSR IPs.
+func TestIPSANAnnotation(t *testing.T) {
+	pcr := testPCR(map[string]string{testSignerName + "-ip-san": "10.0.0.1, 2001:db8::1"})
+	opts := Options{
+		HonorCSRSANs:   true,
+		CSRIPAddresses: []net.IP{net.ParseIP("192.168.0.1")},
+	}
+
+	config, err := NewPodCertificateConfig(pcr, testPod(nil), opts, nil, 0)
+	if err != nil {
+		t.Fatalf("NewPodCertificateConfig: %v", err)
+	}
+	if len(config.IPAddresses) != 2 ||
+		!config.IPAddresses[0].Equal(net.ParseIP("10.0.0.1")) ||
+		!config.IPAddresses[1].Equal(net.ParseIP("2001:db8::1")) {
+		t.Errorf("IPAddresses = %v, want the annotated IPs to win over CSR IPs", config.IPAddresses)
+	}
+}
+
+// Malformed ip-san values must deny the request.
+func TestIPSANAnnotationInvalid(t *testing.T) {
+	cases := map[string]string{
+		"not an IP":  "not-an-ip",
+		"empty list": " , ",
+	}
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			pcr := testPCR(map[string]string{testSignerName + "-ip-san": value})
+			if _, err := NewPodCertificateConfig(pcr, testPod(nil), Options{}, nil, 0); err == nil {
+				t.Fatalf("want error for ip-san %q, got nil", value)
+			}
+		})
+	}
+}
+
 // Enabled but with an empty CSR (kubelet today): defaults still apply.
 func TestCSRSANsEmptyCSRKeepsDefaults(t *testing.T) {
 	config, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), Options{HonorCSRSANs: true}, nil, 0)

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -32,6 +33,7 @@ type PodCertificate struct {
 type PodCertificateConfig struct {
 	CommonName    string
 	DNSNames      []string
+	IPAddresses   []net.IP
 	URIs          []*url.URL
 	Duration      time.Duration
 	RefreshBefore time.Duration
@@ -154,6 +156,17 @@ type Options struct {
 	// When disabled, values containing ${ are rejected rather than
 	// issued verbatim.
 	EnableInterpolation bool
+	// HonorCSRSANs uses the DNS and IP SANs embedded in the
+	// kubelet-generated PKCS#10 CSR (CSRDNSNames/CSRIPAddresses) when no
+	// SAN annotation overrides them. Kubelet generates empty CSRs today,
+	// so this is inert until Kubernetes starts embedding requested SANs;
+	// when disabled, CSR SANs are ignored, which the API contract
+	// explicitly allows for signers.
+	HonorCSRSANs bool
+	// CSRDNSNames are the DNS SANs requested via the PKCS#10 CSR.
+	CSRDNSNames []string
+	// CSRIPAddresses are the IP SANs requested via the PKCS#10 CSR.
+	CSRIPAddresses []net.IP
 }
 
 // NewPodCertificateConfig builds the certificate configuration for the given
@@ -241,7 +254,9 @@ func NewPodCertificateConfig(
 		config.CommonName = cn
 	}
 
-	if san, ok := lookup(AnnotationSuffixSAN); ok {
+	// DNS SAN precedence: san annotation > CSR-requested SANs > defaults.
+	switch san, ok := lookup(AnnotationSuffixSAN); {
+	case ok:
 		san, err := expand(AnnotationSuffixSAN, san)
 		if err != nil {
 			return nil, err
@@ -251,6 +266,14 @@ func NewPodCertificateConfig(
 			return nil, fmt.Errorf("annotation %q contains no DNS names", annotationKey(signerName, AnnotationSuffixSAN))
 		}
 		config.DNSNames = names
+	case opts.HonorCSRSANs && len(opts.CSRDNSNames) > 0:
+		config.DNSNames = opts.CSRDNSNames
+	}
+
+	// IP SANs can only be requested via the CSR; there is no annotation
+	// and no default for them.
+	if opts.HonorCSRSANs && len(opts.CSRIPAddresses) > 0 {
+		config.IPAddresses = opts.CSRIPAddresses
 	}
 
 	if uris, ok := lookup(AnnotationSuffixURIs); ok {

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -60,6 +60,8 @@ const (
 	AnnotationSuffixCN = "cn"
 	// AnnotationSuffixSAN configures the certificate DNS names (comma-separated).
 	AnnotationSuffixSAN = "san"
+	// AnnotationSuffixIPSAN configures the certificate IP SANs (comma-separated).
+	AnnotationSuffixIPSAN = "ip-san"
 	// AnnotationSuffixDuration configures the certificate duration.
 	AnnotationSuffixDuration = "duration"
 	// AnnotationSuffixRefreshBefore configures how long before expiry the
@@ -158,7 +160,7 @@ type Options struct {
 	EnableInterpolation bool
 	// HonorCSRSANs uses the DNS and IP SANs embedded in the
 	// kubelet-generated PKCS#10 CSR (CSRDNSNames/CSRIPAddresses) when no
-	// SAN annotation overrides them. Kubelet generates empty CSRs today,
+	// san/ip-san annotation overrides them. Kubelet generates empty CSRs today,
 	// so this is inert until Kubernetes starts embedding requested SANs;
 	// when disabled, CSR SANs are ignored, which the API contract
 	// explicitly allows for signers.
@@ -270,9 +272,19 @@ func NewPodCertificateConfig(
 		config.DNSNames = opts.CSRDNSNames
 	}
 
-	// IP SANs can only be requested via the CSR; there is no annotation
-	// and no default for them.
-	if opts.HonorCSRSANs && len(opts.CSRIPAddresses) > 0 {
+	// IP SAN precedence: ip-san annotation > CSR-requested SANs > none.
+	switch ipSAN, ok := lookup(AnnotationSuffixIPSAN); {
+	case ok:
+		ipSAN, err := expand(AnnotationSuffixIPSAN, ipSAN)
+		if err != nil {
+			return nil, err
+		}
+		ips, err := parseIPs(ipSAN)
+		if err != nil {
+			return nil, fmt.Errorf("annotation %q: %w", annotationKey(signerName, AnnotationSuffixIPSAN), err)
+		}
+		config.IPAddresses = ips
+	case opts.HonorCSRSANs && len(opts.CSRIPAddresses) > 0:
 		config.IPAddresses = opts.CSRIPAddresses
 	}
 
@@ -413,6 +425,7 @@ func checkUnrecognizedUserAnnotations(annotations map[string]string, signerName 
 	known := map[string]struct{}{
 		annotationKey(signerName, AnnotationSuffixCN):            {},
 		annotationKey(signerName, AnnotationSuffixSAN):           {},
+		annotationKey(signerName, AnnotationSuffixIPSAN):         {},
 		annotationKey(signerName, AnnotationSuffixDuration):      {},
 		annotationKey(signerName, AnnotationSuffixRefreshBefore): {},
 		annotationKey(signerName, AnnotationSuffixURIs):          {},
@@ -439,6 +452,25 @@ func splitAndTrim(value string) []string {
 	}
 
 	return result
+}
+
+// parseIPs parses a comma-separated list of IP addresses.
+func parseIPs(value string) ([]net.IP, error) {
+	ipStrings := splitAndTrim(value)
+	if len(ipStrings) == 0 {
+		return nil, errors.New("contains no IP addresses")
+	}
+
+	ips := make([]net.IP, 0, len(ipStrings))
+	for _, ipStr := range ipStrings {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid IP address %q", ipStr)
+		}
+		ips = append(ips, ip)
+	}
+
+	return ips, nil
 }
 
 // parseURIs parses a comma-separated list of absolute URIs.

--- a/internal/kubernetes/signer/csr_test.go
+++ b/internal/kubernetes/signer/csr_test.go
@@ -1,0 +1,63 @@
+package signer
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net"
+	"testing"
+)
+
+// buildCSR creates a DER-encoded PKCS#10 CSR carrying the given SANs.
+func buildCSR(t *testing.T, dnsNames []string, ipAddresses []net.IP) []byte {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject:     pkix.Name{},
+		DNSNames:    dnsNames,
+		IPAddresses: ipAddresses,
+	}, key)
+	if err != nil {
+		t.Fatalf("create CSR: %v", err)
+	}
+	return der
+}
+
+// ParseCSR must classify the public key and pass through requested SANs.
+func TestParseCSRExtractsSANs(t *testing.T) {
+	dns := []string{"svc.example.org", "alt.example.org"}
+	ips := []net.IP{net.ParseIP("10.0.0.7")}
+
+	info, err := ParseCSR(buildCSR(t, dns, ips))
+	if err != nil {
+		t.Fatalf("ParseCSR: %v", err)
+	}
+
+	if info.PublicKeyAlgorithm != x509.Ed25519 {
+		t.Errorf("PublicKeyAlgorithm = %v, want Ed25519", info.PublicKeyAlgorithm)
+	}
+	if info.PublicKey == nil {
+		t.Error("PublicKey must be set")
+	}
+	if len(info.DNSNames) != 2 || info.DNSNames[0] != dns[0] || info.DNSNames[1] != dns[1] {
+		t.Errorf("DNSNames = %v, want %v", info.DNSNames, dns)
+	}
+	if len(info.IPAddresses) != 1 || !info.IPAddresses[0].Equal(ips[0]) {
+		t.Errorf("IPAddresses = %v, want %v", info.IPAddresses, ips)
+	}
+}
+
+// A kubelet-generated CSR is completely empty today: no SANs come back.
+func TestParseCSREmptyCSR(t *testing.T) {
+	info, err := ParseCSR(buildCSR(t, nil, nil))
+	if err != nil {
+		t.Fatalf("ParseCSR: %v", err)
+	}
+	if len(info.DNSNames) != 0 || len(info.IPAddresses) != 0 {
+		t.Errorf("empty CSR must yield no SANs, got DNS=%v IP=%v", info.DNSNames, info.IPAddresses)
+	}
+}

--- a/internal/kubernetes/signer/signer.go
+++ b/internal/kubernetes/signer/signer.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
@@ -70,15 +71,41 @@ func ParsePKIXPublicKey(pkixPublicKey []byte) (crypto.PublicKey, x509.PublicKeyA
 	return classifyPublicKey(publicKey)
 }
 
-// ParseCSRPublicKey extracts and classifies the public key of a DER-encoded
-// PKCS#10 certificate request.
-func ParseCSRPublicKey(csrDER []byte) (crypto.PublicKey, x509.PublicKeyAlgorithm, error) {
+// CSRInfo holds the values extracted from a kubelet-generated PKCS#10
+// certificate request: the subject public key, and any requested subject
+// alternative names.
+//
+// Today kubelet generates completely empty CSRs, so the SAN slices are
+// always empty - the KEP plans for pod authors to request DNS and IP SANs
+// which kubelet will embed in the CSR, and extracting them now keeps the
+// signer ready for that.
+type CSRInfo struct {
+	PublicKey          crypto.PublicKey
+	PublicKeyAlgorithm x509.PublicKeyAlgorithm
+	DNSNames           []string
+	IPAddresses        []net.IP
+}
+
+// ParseCSR extracts and classifies the public key of a DER-encoded PKCS#10
+// certificate request, along with any SANs requested in it. The CSR signature
+// is already verified by the kube-apiserver during admission.
+func ParseCSR(csrDER []byte) (*CSRInfo, error) {
 	csr, err := x509.ParseCertificateRequest(csrDER)
 	if err != nil {
-		return nil, 0, fmt.Errorf("unable to parse PKCS#10 CSR: %w", err)
+		return nil, fmt.Errorf("unable to parse PKCS#10 CSR: %w", err)
 	}
 
-	return classifyPublicKey(csr.PublicKey)
+	publicKey, publicKeyAlgorithm, err := classifyPublicKey(csr.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CSRInfo{
+		PublicKey:          publicKey,
+		PublicKeyAlgorithm: publicKeyAlgorithm,
+		DNSNames:           csr.DNSNames,
+		IPAddresses:        csr.IPAddresses,
+	}, nil
 }
 
 func classifyPublicKey(publicKey crypto.PublicKey) (crypto.PublicKey, x509.PublicKeyAlgorithm, error) {

--- a/internal/kubernetes/signer/wrap_test.go
+++ b/internal/kubernetes/signer/wrap_test.go
@@ -16,9 +16,9 @@ func TestParsePKIXPublicKeyWraps(t *testing.T) {
 	}
 }
 
-// ParseCSRPublicKey must wrap the underlying x509 error so it can be unwrapped.
-func TestParseCSRPublicKeyWraps(t *testing.T) {
-	_, _, err := ParseCSRPublicKey([]byte("not-a-der-encoded-csr"))
+// ParseCSR must wrap the underlying x509 error so it can be unwrapped.
+func TestParseCSRWraps(t *testing.T) {
+	_, err := ParseCSR([]byte("not-a-der-encoded-csr"))
 	if err == nil {
 		t.Fatal("expected an error parsing junk input")
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -286,11 +287,7 @@ var _ = Describe("Manager", Ordered, func() {
 			})
 
 			By("waiting for the PodCertificateRequest to be issued")
-			var chain []*x509.Certificate
-			Eventually(func(g Gomega) {
-				chain = getIssuedCertificateChain(g, workloadPodName, workloadNamespace)
-				g.Expect(chain).NotTo(BeEmpty())
-			}, 3*time.Minute).Should(Succeed())
+			chain := waitForIssuedChain(workloadPodName)
 
 			By("verifying the leaf certificate carries the interpolated values")
 			leaf := chain[0]
@@ -314,6 +311,51 @@ var _ = Describe("Manager", Ordered, func() {
 				g.Expect(output).To(Equal("Running"),
 					"pod must start once kubelet mounts the issued credential bundle")
 			}, 3*time.Minute).Should(Succeed())
+		})
+
+		It("should deliver a custom common name and DNS SANs in the issued certificate", func() {
+			const podName = "pcs-custom-san"
+			By("creating a workload pod with static cn and san annotations")
+			applyCertTestPod(podName, map[string]string{
+				signerName + "-cn":  "custom-cn.example.org",
+				signerName + "-san": "api.example.org,web.example.org",
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := waitForIssuedChain(podName)[0]
+
+			By("verifying the configured values are delivered in the leaf certificate")
+			Expect(leaf.Subject.CommonName).To(Equal("custom-cn.example.org"),
+				"common name must match the cn annotation")
+			Expect(leaf.DNSNames).To(ConsistOf("api.example.org", "web.example.org"),
+				"DNS SANs must match the san annotation, replacing the defaults")
+			Expect(leaf.IPAddresses).To(BeEmpty(),
+				"no IP SANs were requested")
+		})
+
+		It("should deliver the requested IP SANs in the issued certificate", func() {
+			const podName = "pcs-ip-san"
+			By("creating a workload pod with an ip-san annotation")
+			applyCertTestPod(podName, map[string]string{
+				signerName + "-cn":     "ip-demo.example.org",
+				signerName + "-ip-san": "10.96.0.42,2001:db8::42",
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := waitForIssuedChain(podName)[0]
+
+			By("verifying the IP SANs are delivered in the leaf certificate")
+			Expect(leaf.IPAddresses).To(HaveLen(2), "both requested IP SANs must be present")
+			Expect(leaf.IPAddresses[0].Equal(net.ParseIP("10.96.0.42"))).To(BeTrue(),
+				"first IP SAN must be the requested IPv4 address, got %v", leaf.IPAddresses[0])
+			Expect(leaf.IPAddresses[1].Equal(net.ParseIP("2001:db8::42"))).To(BeTrue(),
+				"second IP SAN must be the requested IPv6 address, got %v", leaf.IPAddresses[1])
+
+			By("verifying the DNS SANs fall back to the defaults")
+			Expect(leaf.DNSNames).To(ConsistOf(
+				fmt.Sprintf("%s.%s.pod.cluster.local", podName, workloadNamespace),
+				fmt.Sprintf("%s.%s.svc.cluster.local", podName, workloadNamespace),
+			), "DNS SANs must be the controller defaults when no san annotation is set")
 		})
 	})
 
@@ -393,6 +435,79 @@ func applyWorkloadPod() {
 	cmd := exec.Command("kubectl", "apply", "-f", "examples/workload-pod.yaml")
 	_, err := utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred(), "Failed to create the workload pod")
+}
+
+// applyCertTestPod creates a minimal workload pod whose podCertificate
+// projected volume carries the given userAnnotations, and registers its
+// cleanup.
+func applyCertTestPod(podName string, userAnnotations map[string]string) {
+	var annotations strings.Builder
+	for key, value := range userAnnotations {
+		fmt.Fprintf(&annotations, "            %s: %q\n", key, value)
+	}
+
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  restartPolicy: Never
+  containers:
+  - name: sleeper
+    image: busybox:1.37
+    command: ["sleep", "600"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 65532
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: RuntimeDefault
+    volumeMounts:
+    - name: x509
+      mountPath: /var/run/x509
+      readOnly: true
+  volumes:
+  - name: x509
+    projected:
+      sources:
+      - podCertificate:
+          keyType: ED25519
+          signerName: %s
+          credentialBundlePath: credentialbundle.pem
+          userAnnotations:
+%s`, podName, workloadNamespace, signerName, annotations.String())
+
+	dir, err := os.MkdirTemp("", "pcs-e2e-pod")
+	Expect(err).NotTo(HaveOccurred(), "Failed to create temp dir for the pod manifest")
+	DeferCleanup(func() { _ = os.RemoveAll(dir) })
+
+	manifestFile := filepath.Join(dir, "pod.yaml")
+	Expect(os.WriteFile(manifestFile, []byte(manifest), os.FileMode(0o600))).To(Succeed())
+
+	cmd := exec.Command("kubectl", "apply", "-f", manifestFile)
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create pod %s", podName)
+
+	DeferCleanup(func() {
+		cmd := exec.Command("kubectl", "delete", "pod", podName,
+			"-n", workloadNamespace, "--ignore-not-found=true", "--wait=false")
+		_, _ = utils.Run(cmd)
+	})
+}
+
+// waitForIssuedChain waits until the PodCertificateRequest of the given pod
+// is issued and returns the parsed certificate chain.
+func waitForIssuedChain(podName string) []*x509.Certificate {
+	GinkgoHelper()
+	var chain []*x509.Certificate
+	Eventually(func(g Gomega) {
+		chain = getIssuedCertificateChain(g, podName, workloadNamespace)
+		g.Expect(chain).NotTo(BeEmpty())
+	}, 3*time.Minute).Should(Succeed())
+	return chain
 }
 
 // getIssuedCertificateChain finds the PodCertificateRequest belonging to the

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -300,6 +301,9 @@ var _ = Describe("Manager", Ordered, func() {
 				fmt.Sprintf("%s.%s.svc", workloadPodName, workloadNamespace),
 				fmt.Sprintf("default.%s.svc", workloadNamespace), // ${pod.serviceAccountName} = default
 			), "SANs must be interpolated from the pod identity")
+			Expect(leaf.IPAddresses).To(HaveLen(1), "the ip-san annotation must yield one IP SAN")
+			Expect(leaf.IPAddresses[0].Equal(net.ParseIP("10.96.0.99"))).To(BeTrue(),
+				"IP SAN must match the ip-san annotation in examples/workload-pod.yaml")
 
 			By("waiting for the pod to run with the projected certificate")
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
## Why

KEP-4317's future work lets pod authors request DNS and IP SANs which kubelet embeds in the PKCS#10 CSR of the `PodCertificateRequest`. Today kubelet generates completely empty CSRs (guaranteed by the API docs). This PR prepares the signer for that — and adds an `ip-san` annotation so IP SANs are usable **today**, with the annotation naturally becoming the override once the kubelet mechanism ships.

## What

- **`ip-san` annotation** (comma-separated IPv4/IPv6): workloads can request IP SANs now via `userAnnotations`. Malformed or empty values deny the request with reason `InvalidUnverifiedUserAnnotations`, consistent with the other configuration annotations.
- `signer.ParseCSR` replaces `ParseCSRPublicKey` and also extracts requested DNS/IP SANs from the stub CSR (signature already verified by the apiserver at admission).
- `PodCertificateConfig` gains `IPAddresses`, embedded into issued certificates by the authority.
- New `--honor-csr-sans` feature flag (Helm: `signer.honor_csr_sans`, **disabled by default**): when enabled, CSR-requested SANs are used unless annotations override them.
- **Precedence**: `san`/`ip-san` annotation > CSR-requested SANs (flag-gated) > defaults (DNS) / none (IP).
- The example workload (exercised by the e2e issuance spec) now requests an IP SAN, and the spec asserts it appears in the issued leaf certificate.
- README documents the annotation, the flag, and the forward-compatibility rationale.

## Behavior

The CSR path is inert in every configuration today — kubelet CSR SAN slices are always empty. The `ip-san` annotation is immediately functional and e2e-verified. Unit tests cover extraction (synthetic CSRs with SANs), precedence, the disabled path, IP parsing/denial, and IP SAN embedding in issued leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXUr36uCauK3EmbRZP1cHw