### PR TITLE
feat: eku annotation to restrict extended key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Below is the table with the annotations and example values:
 | `{signer-name}-cn`       | No       | `{pod-name}`                                                                        | `mysigner.example.com/foobar-cn: my-pod.default.pod.cluster.local`                                   |
 | `{signer-name}-san`      | No       | `{pod-name}.{namespace}.pod.cluster.local,{pod-name}.{namespace}.svc.cluster.local` | `mysigner.example.com/foobar-san: my-pod.default.pod.cluster.local,my-pod.default.svc.cluster.local` |
 | `{signer-name}-ip-san`   | No       | `(empty)`                                                                           | `mysigner.example.com/foobar-ip-san: 10.96.0.10,2001:db8::1`                                         |
+| `{signer-name}-eku`      | No       | `server,client`                                                                     | `mysigner.example.com/foobar-eku: client`                                                            |
 | `{signer-name}-uris`     | No       | `(empty)`                                                                           | `mysigner.example.com/foobar-uris: spiffe://cluster.local/ns/default/sa/my-service`                  |
 | `{signer-name}-duration` | No       | `24h`                                                                               | `mysigner.example.com/foobar-duration: 12h`                                                          |
 | `{signer-name}-refresh`  | No       | `15m`                                                                               | `mysigner.example.com/foobar-refresh: 30m`                                                           |
@@ -420,6 +421,7 @@ The certificate configuration is validated against the constraints kube-apiserve
 
 - The certificate duration must be at least `1h` (kube-apiserver minimum) and must not exceed the request's `spec.maxExpirationSeconds` (set by the pod author on the projected volume, defaulted to `24h` by kube-apiserver). The default duration is automatically clamped to `maxExpirationSeconds`.
 - The refresh hint must lie within the window kube-apiserver accepts for `beginRefreshAt`: `refresh` must be at least `10m` and at most the certificate duration minus `10m`.
+- The `eku` annotation accepts the tokens `client` and `server` (comma-separated); unknown tokens deny the request. Certificates for non-RSA keys carry only the `digitalSignature` key usage.
 
 ## ⌘ Controller commandline options
 Controller is customizable and supports the following arguments along with their default values

--- a/internal/kubernetes/authority/authority_test.go
+++ b/internal/kubernetes/authority/authority_test.go
@@ -178,6 +178,28 @@ func TestSignIncludesIPAddresses(t *testing.T) {
 	}
 }
 
+// A restricted ExtKeyUsage from the configuration must be embedded verbatim.
+func TestSignHonorsExtKeyUsage(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	config := testConfig(t)
+	config.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+
+	pc, err := ca.Sign(config)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	leaf := parseChain(t, []byte(pc.CertificateChain()))[0]
+	if len(leaf.ExtKeyUsage) != 1 || leaf.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
+		t.Errorf("leaf ExtKeyUsage = %v, want [ClientAuth] only", leaf.ExtKeyUsage)
+	}
+}
+
 func TestSignRejectsDurationBeyondCA(t *testing.T) {
 	dir := t.TempDir()
 	writeCA(t, dir, "short-ca.example.org", time.Hour)

--- a/internal/kubernetes/podcertificate/eku_test.go
+++ b/internal/kubernetes/podcertificate/eku_test.go
@@ -1,0 +1,77 @@
+package podcertificate
+
+import (
+	"crypto/x509"
+	"reflect"
+	"testing"
+)
+
+func TestEKUAnnotation(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  []x509.ExtKeyUsage
+	}{
+		{"client only", "client", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}},
+		{"server only", "server", []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}},
+		{"both", "client,server", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}},
+		{"whitespace and duplicates", " server , server ", []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pcr := testPCR(map[string]string{testSignerName + "-eku": tc.value})
+			config, err := NewPodCertificateConfig(pcr, testPod(nil), Options{}, nil, 0)
+			if err != nil {
+				t.Fatalf("NewPodCertificateConfig: %v", err)
+			}
+			if !reflect.DeepEqual(config.ExtKeyUsage, tc.want) {
+				t.Errorf("ExtKeyUsage = %v, want %v", config.ExtKeyUsage, tc.want)
+			}
+		})
+	}
+}
+
+func TestEKUAnnotationInvalid(t *testing.T) {
+	for name, value := range map[string]string{
+		"unknown token": "client,ssl",
+		"empty list":    " , ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			pcr := testPCR(map[string]string{testSignerName + "-eku": value})
+			if _, err := NewPodCertificateConfig(pcr, testPod(nil), Options{}, nil, 0); err == nil {
+				t.Fatalf("want error for eku %q, got nil", value)
+			}
+		})
+	}
+}
+
+func TestEKUDefaultUnchanged(t *testing.T) {
+	config, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), Options{}, nil, 0)
+	if err != nil {
+		t.Fatalf("NewPodCertificateConfig: %v", err)
+	}
+	want := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	if !reflect.DeepEqual(config.ExtKeyUsage, want) {
+		t.Errorf("ExtKeyUsage = %v, want default %v", config.ExtKeyUsage, want)
+	}
+}
+
+func TestKeyUsagePerAlgorithm(t *testing.T) {
+	cases := []struct {
+		alg  x509.PublicKeyAlgorithm
+		want x509.KeyUsage
+	}{
+		{x509.RSA, x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment},
+		{x509.ECDSA, x509.KeyUsageDigitalSignature},
+		{x509.Ed25519, x509.KeyUsageDigitalSignature},
+	}
+	for _, tc := range cases {
+		config, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), Options{}, nil, tc.alg)
+		if err != nil {
+			t.Fatalf("NewPodCertificateConfig: %v", err)
+		}
+		if config.KeyUsage != tc.want {
+			t.Errorf("alg %v: KeyUsage = %v, want %v", tc.alg, config.KeyUsage, tc.want)
+		}
+	}
+}

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -62,6 +62,9 @@ const (
 	AnnotationSuffixSAN = "san"
 	// AnnotationSuffixIPSAN configures the certificate IP SANs (comma-separated).
 	AnnotationSuffixIPSAN = "ip-san"
+	// AnnotationSuffixEKU configures the certificate extended key usage
+	// (comma-separated tokens: "client", "server").
+	AnnotationSuffixEKU = "eku"
 	// AnnotationSuffixDuration configures the certificate duration.
 	AnnotationSuffixDuration = "duration"
 	// AnnotationSuffixRefreshBefore configures how long before expiry the
@@ -242,7 +245,7 @@ func NewPodCertificateConfig(
 		Duration:           duration,
 		RefreshBefore:      DefaultRefreshBefore,
 		MaxExpiration:      maxExpiration,
-		KeyUsage:           x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:           keyUsageFor(publicKeyAlgorithm),
 		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		PublicKey:          publicKey,
 		PublicKeyAlgorithm: publicKeyAlgorithm,
@@ -287,6 +290,12 @@ func NewPodCertificateConfig(
 	case opts.HonorCSRSANs && len(opts.CSRIPAddresses) > 0:
 		config.IPAddresses = opts.CSRIPAddresses
 	}
+
+	extKeyUsage, err := resolveExtKeyUsage(lookup, expand, config.ExtKeyUsage, signerName)
+	if err != nil {
+		return nil, err
+	}
+	config.ExtKeyUsage = extKeyUsage
 
 	if uris, ok := lookup(AnnotationSuffixURIs); ok {
 		uris, err := expand(AnnotationSuffixURIs, uris)
@@ -355,6 +364,7 @@ func (pcc *PodCertificateConfig) LogConfiguration(ctx context.Context) {
 		"commonName", pcc.CommonName,
 		"dnsNames", pcc.DNSNames,
 		"uris", pcc.URIs,
+		"extKeyUsage", pcc.ExtKeyUsage,
 		"duration", pcc.Duration.String(),
 		"refreshBefore", pcc.RefreshBefore.String())
 }
@@ -429,6 +439,7 @@ func checkUnrecognizedUserAnnotations(annotations map[string]string, signerName 
 		annotationKey(signerName, AnnotationSuffixDuration):      {},
 		annotationKey(signerName, AnnotationSuffixRefreshBefore): {},
 		annotationKey(signerName, AnnotationSuffixURIs):          {},
+		annotationKey(signerName, AnnotationSuffixEKU):           {},
 	}
 
 	for key := range annotations {
@@ -452,6 +463,63 @@ func splitAndTrim(value string) []string {
 	}
 
 	return result
+}
+
+// keyUsageFor returns the KeyUsage bits appropriate for the subject key type.
+// keyEncipherment only has meaning for RSA key transport; for ECDSA and
+// Ed25519 keys digitalSignature is the only applicable usage.
+func keyUsageFor(alg x509.PublicKeyAlgorithm) x509.KeyUsage {
+	if alg == x509.RSA {
+		return x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	}
+	return x509.KeyUsageDigitalSignature
+}
+
+// resolveExtKeyUsage resolves the eku annotation, if present, into ExtKeyUsage
+// values, falling back to current when the annotation is absent.
+func resolveExtKeyUsage(lookup func(string) (string, bool), expand func(string, string) (string, error), current []x509.ExtKeyUsage, signerName string) ([]x509.ExtKeyUsage, error) {
+	eku, ok := lookup(AnnotationSuffixEKU)
+	if !ok {
+		return current, nil
+	}
+	eku, err := expand(AnnotationSuffixEKU, eku)
+	if err != nil {
+		return nil, err
+	}
+	usages, err := parseEKU(eku)
+	if err != nil {
+		return nil, fmt.Errorf("annotation %q: %w", annotationKey(signerName, AnnotationSuffixEKU), err)
+	}
+	return usages, nil
+}
+
+// parseEKU parses a comma-separated list of extended key usage tokens.
+// Recognized tokens: "client" (TLS client auth), "server" (TLS server auth).
+// Duplicates collapse; order of first occurrence is preserved.
+func parseEKU(value string) ([]x509.ExtKeyUsage, error) {
+	tokens := splitAndTrim(value)
+	if len(tokens) == 0 {
+		return nil, errors.New("contains no extended key usage tokens")
+	}
+
+	seen := make(map[string]struct{}, len(tokens))
+	usages := make([]x509.ExtKeyUsage, 0, len(tokens))
+	for _, token := range tokens {
+		if _, dup := seen[token]; dup {
+			continue
+		}
+		seen[token] = struct{}{}
+		switch token {
+		case "client":
+			usages = append(usages, x509.ExtKeyUsageClientAuth)
+		case "server":
+			usages = append(usages, x509.ExtKeyUsageServerAuth)
+		default:
+			return nil, fmt.Errorf("unknown extended key usage %q (valid: client, server)", token)
+		}
+	}
+
+	return usages, nil
 }
 
 // parseIPs parses a comma-separated list of IP addresses.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -357,6 +357,22 @@ var _ = Describe("Manager", Ordered, func() {
 				fmt.Sprintf("%s.%s.svc.cluster.local", podName, workloadNamespace),
 			), "DNS SANs must be the controller defaults when no san annotation is set")
 		})
+
+		It("should deliver a client-only certificate when eku restricts it", func() {
+			const podName = "pcs-eku-client"
+			By("creating a workload pod with an eku annotation")
+			applyCertTestPod(podName, map[string]string{
+				signerName + "-cn":  "eku-demo.example.org",
+				signerName + "-eku": "client",
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := waitForIssuedChain(podName)[0]
+
+			By("verifying the certificate is restricted to client auth")
+			Expect(leaf.ExtKeyUsage).To(ConsistOf(x509.ExtKeyUsageClientAuth),
+				"eku=client must yield a client-auth-only certificate")
+		})
 	})
 
 	Context("ClusterTrustBundle", func() {


### PR DESCRIPTION
## Summary
- New `eku` config annotation restricts a certificate's ExtendedKeyUsage to `client`, `server`, or both (comma-separated). Absent the annotation, behavior is unchanged (`[ServerAuth, ClientAuth]`).
- KeyUsage tightening: `keyEncipherment` is now RSA-only (key-transport semantics); ECDSA/Ed25519 keys carry `digitalSignature` alone.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go vet -tags e2e ./test/...`
- [x] `go test ./internal/...` (TestControllers/envtest fails locally without etcd, as expected; all other tests pass)
- [x] `golangci-lint run --build-tags e2e` — 0 issues
- [x] `helm lint charts/podcertificate-signer` — 0 failures
- [x] E2E Tests CI job (Kind cluster) — verify green in CI