### PR TITLE
fix(#36): repair build target and chart flag rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,11 @@ kind-stop:  ## Tear down the local development Kind cluster.
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet | $(LOCALBIN)  ## Build manager binary.
+build: generate fmt vet | $(LOCALBIN)  ## Build manager binary.
 	$(GOCMD) build -o $(LOCALBIN)/manager cmd/podcertificate-signer/main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
+run: generate fmt vet ## Run a controller from your host.
 	$(GOCMD) run ./cmd/podcertificate-signer/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
@@ -180,6 +180,9 @@ HELM_NAMESPACE ?= pcs-system
 HELM_RELEASE ?= podcertificate-signer
 ## Additional arguments to pass to helm commands
 HELM_EXTRA_ARGS ?=
+## Signer name to deploy with. The chart has no default (--signer-name is
+## required), so the example deploy must set one explicitly.
+SIGNER_NAME ?= example.org/signer
 
 ## Dev deployments target the local kind cluster explicitly, so a stray
 ## kubeconfig context can never point them at a real cluster. The cluster
@@ -218,6 +221,7 @@ helm-install: dev-ca  ## Install the chart against the dev kind cluster with an 
 		--set image.repository=$(IMAGE_REPO) \
 		--set image.tag=$(IMAGE_TAG) \
 		--set 'volumes[0].secret.secretName=$(DEV_CA_SECRET)' \
+		--set signer.name=$(SIGNER_NAME) \
 		--wait \
 		--timeout 5m \
 		--values examples/helm-values.yaml \

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ helm-install: dev-ca  ## Install the chart against the dev kind cluster with an 
 		--namespace $(HELM_NAMESPACE) \
 		--set image.repository=$(IMAGE_REPO) \
 		--set image.tag=$(IMAGE_TAG) \
-		--set 'volumes[0].secret.secretName=$(DEV_CA_SECRET)' \
+		--set signer.ca.secretRef.name=$(DEV_CA_SECRET) \
 		--set signer.name=$(SIGNER_NAME) \
 		--wait \
 		--timeout 5m \

--- a/charts/podcertificate-signer/README.md
+++ b/charts/podcertificate-signer/README.md
@@ -11,10 +11,8 @@ README](../../README.md).
 
 - Kubernetes **≥ 1.35** with the `PodCertificateRequest` feature gate and the
   `certificates.k8s.io/v1beta1` runtime config enabled (`kubeVersion: ">= 1.35.0"`).
-- A **CA key pair** made available to the controller as a mounted secret. You
-  provide your own CA — the chart does **not** ship one. Create it, then point
-  the chart's `volumes`/`volumeMounts` at it so the files land at
-  `signer.ca_cert_path` / `signer.ca_key_path` (defaults under `/app/signer/ca`).
+- A **CA key pair**. You provide your own CA — the chart does **not** ship one.
+  Create a Secret and reference it (see [Providing the CA](#providing-the-ca)):
 
 ```bash
 kubectl create secret tls podcertificate-signer-ca \
@@ -23,14 +21,54 @@ kubectl create secret tls podcertificate-signer-ca \
 
 ## Install
 
-`signer.name` is **required** — there is no default, so it must be set explicitly:
+`signer.name` and a CA source are **required**:
 
 ```bash
 helm install pcs oci://ghcr.io/rafpe/charts/podcertificate-signer \
   -n pcs-system --create-namespace \
   --set signer.name=example.org/signer \
-  -f my-values.yaml     # must mount the CA secret via volumes/volumeMounts
+  --set signer.ca.secretRef.name=podcertificate-signer-ca
 ```
+
+## Providing the CA
+
+The signing CA is configured under `signer.ca` with an explicit `source`:
+
+- **`secretRef` (recommended, default):** mount an existing Secret. The private
+  key stays in a Secret, the chart wires a **read-only** volume for you, and only
+  the CA cert + key are projected into the pod — no `volumes`/`volumeMounts` to
+  plumb. `signer.ca.secretRef.name` is **required**; an empty name fails
+  `helm install`/`upgrade` at render time rather than crash-looping the pod.
+
+  ```yaml
+  signer:
+    ca:
+      source: secretRef
+      secretRef:
+        name: podcertificate-signer-ca   # existing kubernetes.io/tls or Opaque Secret
+        certKey: tls.crt                  # key in the Secret holding the cert
+        keyKey: tls.key                   # key in the Secret holding the private key
+        mountPath: /app/signer/ca
+  ```
+
+- **`file` (advanced / BYO mount):** you mount the cert/key yourself via
+  `.Values.volumes` / `.Values.volumeMounts` and point at them:
+
+  ```yaml
+  signer:
+    ca:
+      source: file
+      file:
+        certPath: /app/signer/ca/tls.crt
+        keyPath: /app/signer/ca/tls.key
+  volumes: [ ... ]        # your own mount landing the files at the paths above
+  volumeMounts: [ ... ]
+  ```
+
+> Chart values changed here: the old `signer.ca_cert_path` / `signer.ca_key_path`
+> are replaced by the `signer.ca` block above. `secretRef` mode replaces the
+> manual `volumes`/`volumeMounts` CA wiring; use `source: file` to keep the old
+> bring-your-own-mount behaviour.
 
 ## Values
 
@@ -45,7 +83,10 @@ helm install pcs oci://ghcr.io/rafpe/charts/podcertificate-signer \
 | `log.level` / `log.encoder` / `log.time_encoding` | zap logging config. | `info` / `console` / `rfc3339` |
 | **`signer.name`** | **Required.** Signer name this controller claims (`spec.signerName`). Empty makes the controller fail fast at startup. | `""` |
 | **`signer.cluster_fqdn`** | Cluster FQDN used to build the default certificate DNS names (`<pod>.<ns>.pod.<fqdn>` / `<pod>.<ns>.svc.<fqdn>`); rendered as `--cluster-fqdn`. | `cluster.local` |
-| `signer.ca_cert_path` / `signer.ca_key_path` | Mounted CA cert / key paths. | `/app/signer/ca/tls.crt` / `.../tls.key` |
+| `signer.ca.source` | CA source: `secretRef` (recommended) or `file`. See [Providing the CA](#providing-the-ca). | `secretRef` |
+| `signer.ca.secretRef.name` | Existing Secret with the CA cert+key. **Required** when `source=secretRef`. | `""` |
+| `signer.ca.secretRef.certKey` / `.keyKey` / `.mountPath` | Secret keys projected and where they mount. | `tls.crt` / `tls.key` / `/app/signer/ca` |
+| `signer.ca.file.certPath` / `.keyPath` | CA paths when `source=file` (you mount them yourself). | `/app/signer/ca/tls.crt` / `.../tls.key` |
 | `signer.max_previous_ca_certs` | Previous CAs retained in the ClusterTrustBundle across rotation. | `2` |
 | `signer.enable_annotation_interpolation` | Allow `${...}` placeholders in `cn`/`san`/`uris`, resolved from verified request fields. | `false` |
 | `signer.honor_csr_sans` | Honor SANs from the kubelet PKCS#10 CSR (forward-compat; kubelet emits empty CSRs today). | `false` |
@@ -54,7 +95,7 @@ helm install pcs oci://ghcr.io/rafpe/charts/podcertificate-signer \
 | `manager.reconcile_timeout` | Per-reconcile timeout. | `"5m"` |
 | `resources` | Container resource requests/limits (unset by default — set them in production). | `{}` |
 | `serviceAccount.create` / `serviceAccount.automount` | ServiceAccount management. | `true` / `true` |
-| `volumes` / `volumeMounts` | Mount the CA secret at `signer.ca_*_path` (required). | `[]` |
+| `volumes` / `volumeMounts` | Extra volumes/mounts. Only needed to mount the CA yourself when `signer.ca.source=file`; `secretRef` mode wires the CA volume for you. | `[]` |
 | `podSecurityContext` / `securityContext` | PSS-restricted defaults (non-root, seccomp `RuntimeDefault`, read-only rootfs, drop `ALL`). | see `values.yaml` |
 | `autoscaling.enabled` | HPA (of limited use for a leader-elected controller). | `false` |
 

--- a/charts/podcertificate-signer/README.md
+++ b/charts/podcertificate-signer/README.md
@@ -1,0 +1,73 @@
+# podcertificate-signer (Helm chart)
+
+Deploys the **pod-certificate-signer** controller — a signer for the built-in
+`certificates.k8s.io/v1beta1` `PodCertificateRequest` API that issues short-lived
+pod certificates and publishes its CA as a `ClusterTrustBundle`.
+
+For what the signer does and how workloads consume it, see the [repository
+README](../../README.md).
+
+## Prerequisites
+
+- Kubernetes **≥ 1.35** with the `PodCertificateRequest` feature gate and the
+  `certificates.k8s.io/v1beta1` runtime config enabled (`kubeVersion: ">= 1.35.0"`).
+- A **CA key pair** made available to the controller as a mounted secret. You
+  provide your own CA — the chart does **not** ship one. Create it, then point
+  the chart's `volumes`/`volumeMounts` at it so the files land at
+  `signer.ca_cert_path` / `signer.ca_key_path` (defaults under `/app/signer/ca`).
+
+```bash
+kubectl create secret tls podcertificate-signer-ca \
+  --cert=ca.crt --key=ca.key -n <namespace>
+```
+
+## Install
+
+`signer.name` is **required** — there is no default, so it must be set explicitly:
+
+```bash
+helm install pcs oci://ghcr.io/rafpe/charts/podcertificate-signer \
+  -n pcs-system --create-namespace \
+  --set signer.name=example.org/signer \
+  -f my-values.yaml     # must mount the CA secret via volumes/volumeMounts
+```
+
+## Values
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `replicaCount` | Replicas (leader-elected; extras are warm standbys). | `2` |
+| `image.repository` / `image.tag` | Image; a `sha256:`-prefixed tag is treated as a digest. | `ghcr.io/rafpe/pod-certificate-signer` / chart `appVersion` |
+| `leader_election.enabled` | Enable leader election. | `true` |
+| `health.bind_address` | Health/readiness bind address; rendered as both the container port **and** the `--health-probe-bind-address` flag. | `":8081"` |
+| `metrics.enable_scraping` | Expose the metrics port and Prometheus scrape annotations. | `true` |
+| `metrics.bind_address` | Metrics server bind address. | `":9090"` |
+| `log.level` / `log.encoder` / `log.time_encoding` | zap logging config. | `info` / `console` / `rfc3339` |
+| **`signer.name`** | **Required.** Signer name this controller claims (`spec.signerName`). Empty makes the controller fail fast at startup. | `""` |
+| **`signer.cluster_fqdn`** | Cluster FQDN used to build the default certificate DNS names (`<pod>.<ns>.pod.<fqdn>` / `<pod>.<ns>.svc.<fqdn>`); rendered as `--cluster-fqdn`. | `cluster.local` |
+| `signer.ca_cert_path` / `signer.ca_key_path` | Mounted CA cert / key paths. | `/app/signer/ca/tls.crt` / `.../tls.key` |
+| `signer.max_previous_ca_certs` | Previous CAs retained in the ClusterTrustBundle across rotation. | `2` |
+| `signer.enable_annotation_interpolation` | Allow `${...}` placeholders in `cn`/`san`/`uris`, resolved from verified request fields. | `false` |
+| `signer.honor_csr_sans` | Honor SANs from the kubelet PKCS#10 CSR (forward-compat; kubelet emits empty CSRs today). | `false` |
+| `manager.max_concurrent_reconciles` | Concurrent reconciles. | `5` |
+| `manager.reconcile_timeout` | Per-reconcile timeout. | `"5m"` |
+| `resources` | Container resource requests/limits (unset by default — set them in production). | `{}` |
+| `serviceAccount.create` / `serviceAccount.automount` | ServiceAccount management. | `true` / `true` |
+| `volumes` / `volumeMounts` | Mount the CA secret at `signer.ca_*_path` (required). | `[]` |
+| `podSecurityContext` / `securityContext` | PSS-restricted defaults (non-root, seccomp `RuntimeDefault`, read-only rootfs, drop `ALL`). | see `values.yaml` |
+| `autoscaling.enabled` | HPA (of limited use for a leader-elected controller). | `false` |
+
+## Notes for this release
+
+- **`signer.name` is now required.** Earlier chart versions defaulted it to the
+  placeholder `example.org/signer`, which let two default installs collide on the
+  same signer name. Set it explicitly (`--set signer.name=...`).
+- **`signer.cluster_fqdn` is now configurable.** Previously every install was
+  pinned to `cluster.local`; set this to your cluster's domain so the default
+  certificate DNS names resolve.
+- **`health.bind_address` now drives the flag too.** Earlier it changed only the
+  container port, leaving the manager on `:8081` — changing the value now moves
+  both, so the probes and the listener stay in sync.
+
+Every value is also documented inline in
+[`values.yaml`](./values.yaml).

--- a/charts/podcertificate-signer/README.md
+++ b/charts/podcertificate-signer/README.md
@@ -49,6 +49,7 @@ helm install pcs oci://ghcr.io/rafpe/charts/podcertificate-signer \
 | `signer.max_previous_ca_certs` | Previous CAs retained in the ClusterTrustBundle across rotation. | `2` |
 | `signer.enable_annotation_interpolation` | Allow `${...}` placeholders in `cn`/`san`/`uris`, resolved from verified request fields. | `false` |
 | `signer.honor_csr_sans` | Honor SANs from the kubelet PKCS#10 CSR (forward-compat; kubelet emits empty CSRs today). | `false` |
+| **`signer.allow_unverified_identities`** | **Security escape hatch.** When `false`, annotation `cn`/`san`/`ip-san`/`uris` values must resolve to the pod's verified identity, and IP SANs are denied. See [Identity constraints](#identity-constraints-security). | `false` |
 | `manager.max_concurrent_reconciles` | Concurrent reconciles. | `5` |
 | `manager.reconcile_timeout` | Per-reconcile timeout. | `"5m"` |
 | `resources` | Container resource requests/limits (unset by default — set them in production). | `{}` |
@@ -56,6 +57,32 @@ helm install pcs oci://ghcr.io/rafpe/charts/podcertificate-signer \
 | `volumes` / `volumeMounts` | Mount the CA secret at `signer.ca_*_path` (required). | `[]` |
 | `podSecurityContext` / `securityContext` | PSS-restricted defaults (non-root, seccomp `RuntimeDefault`, read-only rootfs, drop `ALL`). | see `values.yaml` |
 | `autoscaling.enabled` | HPA (of limited use for a leader-elected controller). | `false` |
+
+## Identity constraints (security)
+
+By default (`signer.allow_unverified_identities: false`) the controller issues
+certificates **only for the requesting pod's own verified identity**. Annotation
+`cn`/`san`/`uris` values are accepted only when they resolve to an identity
+derived from the apiserver-verified request fields (the pod name, its canonical
+`*.pod`/`*.svc` DNS forms, its SPIFFE ID, and its service account); anything else
+is **Denied**. `ip-san` values are denied (no verified derivation), and the
+default extended key usage is `serverAuth` only.
+
+Set `signer.allow_unverified_identities: true` **only** if you intentionally trust
+pod authors to request arbitrary identities — ideally alongside a
+`ValidatingAdmissionPolicy` that restricts which `userAnnotations` workloads may
+set. Enabling it renders `--allow-unverified-identities` on the controller.
+
+> [!WARNING]
+> **Breaking change.** Literal identity values and `clientAuth` in the default
+> EKU are no longer granted by default. To keep the old behaviour set
+> `signer.allow_unverified_identities: true` and add the `eku: server,client`
+> annotation; prefer migrating to `${...}` interpolation. See the
+> [repository README](../../README.md#-identity-constraints-default-secure).
+
+> The `signer.allow_unverified_identities` value and this behaviour are
+> introduced together with the identity-constraint change (issue #26 / PR #38);
+> until that merges, the value is inert.
 
 ## Notes for this release
 

--- a/charts/podcertificate-signer/templates/_helpers.tpl
+++ b/charts/podcertificate-signer/templates/_helpers.tpl
@@ -51,6 +51,44 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+CA cert/key paths passed to the controller, derived from the configured CA source.
+For secretRef the files live under the chart-managed mount; for file the operator
+supplies the paths (and mounts them via .Values.volumes/.volumeMounts).
+*/}}
+{{- define "podcertificate-signer.caCertPath" -}}
+{{- $ca := .Values.signer.ca -}}
+{{- if eq $ca.source "secretRef" -}}
+{{- printf "%s/%s" $ca.secretRef.mountPath $ca.secretRef.certKey -}}
+{{- else -}}
+{{- $ca.file.certPath -}}
+{{- end -}}
+{{- end }}
+
+{{- define "podcertificate-signer.caKeyPath" -}}
+{{- $ca := .Values.signer.ca -}}
+{{- if eq $ca.source "secretRef" -}}
+{{- printf "%s/%s" $ca.secretRef.mountPath $ca.secretRef.keyKey -}}
+{{- else -}}
+{{- $ca.file.keyPath -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Fail fast (at template time) on an invalid or incomplete CA source, so a
+misconfiguration is caught by `helm install`/`upgrade` rather than crash-looping
+the controller.
+*/}}
+{{- define "podcertificate-signer.validateCA" -}}
+{{- $ca := .Values.signer.ca -}}
+{{- if not (has $ca.source (list "secretRef" "file")) -}}
+{{- fail (printf "signer.ca.source must be \"secretRef\" or \"file\", got %q" $ca.source) -}}
+{{- end -}}
+{{- if and (eq $ca.source "secretRef") (not $ca.secretRef.name) -}}
+{{- fail "signer.ca.source=secretRef requires signer.ca.secretRef.name (an existing Secret holding the CA cert and key)" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "podcertificate-signer.serviceAccountName" -}}

--- a/charts/podcertificate-signer/templates/deployment.yaml
+++ b/charts/podcertificate-signer/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
             - --ca-cert-path={{ .Values.signer.ca_cert_path }}
             - --ca-key-path={{ .Values.signer.ca_key_path }}
             - --signer-name={{ .Values.signer.name }}
+            - --cluster-fqdn={{ .Values.signer.cluster_fqdn }}
+            - --health-probe-bind-address={{ .Values.health.bind_address }}
             - --zap-log-level={{ .Values.log.level }}
             - --zap-encoder={{ .Values.log.encoder }}
             - --zap-time-encoding={{ .Values.log.time_encoding }}

--- a/charts/podcertificate-signer/templates/deployment.yaml
+++ b/charts/podcertificate-signer/templates/deployment.yaml
@@ -45,8 +45,9 @@ spec:
             - --leader-elect={{ .Values.leader_election.enabled }}
             - --leader-election-id={{ include "podcertificate-signer.fullname" . }}
             - --leader-election-namespace={{ .Release.Namespace }}
-            - --ca-cert-path={{ .Values.signer.ca_cert_path }}
-            - --ca-key-path={{ .Values.signer.ca_key_path }}
+            {{- include "podcertificate-signer.validateCA" . }}
+            - --ca-cert-path={{ include "podcertificate-signer.caCertPath" . }}
+            - --ca-key-path={{ include "podcertificate-signer.caKeyPath" . }}
             - --signer-name={{ .Values.signer.name }}
             - --cluster-fqdn={{ .Values.signer.cluster_fqdn }}
             - --health-probe-bind-address={{ .Values.health.bind_address }}
@@ -90,13 +91,34 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.volumeMounts }}
+          {{- if or (eq .Values.signer.ca.source "secretRef") .Values.volumeMounts }}
           volumeMounts:
+            {{- if eq .Values.signer.ca.source "secretRef" }}
+            - name: signing-ca
+              mountPath: {{ .Values.signer.ca.secretRef.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or (eq .Values.signer.ca.source "secretRef") .Values.volumes }}
       volumes:
+        {{- if eq .Values.signer.ca.source "secretRef" }}
+        - name: signing-ca
+          secret:
+            secretName: {{ .Values.signer.ca.secretRef.name }}
+            optional: false
+            # Project only the CA cert and key, never any other secret keys.
+            items:
+              - key: {{ .Values.signer.ca.secretRef.certKey }}
+                path: {{ .Values.signer.ca.secretRef.certKey }}
+              - key: {{ .Values.signer.ca.secretRef.keyKey }}
+                path: {{ .Values.signer.ca.secretRef.keyKey }}
+        {{- end }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/podcertificate-signer/values.yaml
+++ b/charts/podcertificate-signer/values.yaml
@@ -26,9 +26,25 @@ metrics:
 
 # PodCertificateRequest Signer settings
 signer:
-  # CA cert and private key
-  ca_cert_path: /app/signer/ca/tls.crt
-  ca_key_path: /app/signer/ca/tls.key
+  # Signing CA (certificate + private key) source.
+  #   secretRef — mount an existing Secret (RECOMMENDED). The private key stays in
+  #               a Secret and the chart wires a read-only volume for you; nothing
+  #               to plumb under .Values.volumes/.volumeMounts.
+  #   file      — you provide the cert/key files yourself via .Values.volumes and
+  #               .Values.volumeMounts at the paths below (advanced / BYO mount).
+  ca:
+    source: secretRef
+    secretRef:
+      # Name of an existing Secret (kubernetes.io/tls or Opaque) holding the CA
+      # cert and key. REQUIRED when source=secretRef; only these two keys are
+      # projected into the pod.
+      name: ""
+      certKey: tls.crt
+      keyKey: tls.key
+      mountPath: /app/signer/ca
+    file:
+      certPath: /app/signer/ca/tls.crt
+      keyPath: /app/signer/ca/tls.key
 
   # Name of the signer. Required - there is no default, so it must be set
   # explicitly (e.g. --set signer.name=example.org/signer). An empty value

--- a/charts/podcertificate-signer/values.yaml
+++ b/charts/podcertificate-signer/values.yaml
@@ -30,8 +30,14 @@ signer:
   ca_cert_path: /app/signer/ca/tls.crt
   ca_key_path: /app/signer/ca/tls.key
 
-  # Name of the signer
-  name: example.org/signer
+  # Name of the signer. Required - there is no default, so it must be set
+  # explicitly (e.g. --set signer.name=example.org/signer). An empty value
+  # makes the controller fail fast at startup.
+  name: ""
+
+  # FQDN of the cluster, used to build the default certificate DNS names
+  # (<pod>.<ns>.pod.<fqdn> / <pod>.<ns>.svc.<fqdn>).
+  cluster_fqdn: cluster.local
 
   # Max number of previous CA certificates to keep during a CA cert reload
   max_previous_ca_certs: 2

--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -75,7 +76,7 @@ func main() {
 	var enableLeaderElection, enableAnnotationInterpolation, honorCSRSANs bool
 	var reconcileTimeout time.Duration
 
-	flag.StringVar(&signerName, "signer-name", "example.org/signer", "Only sign CSR with this .spec.signerName.")
+	flag.StringVar(&signerName, "signer-name", "", "Only sign CSR with this .spec.signerName. Required.")
 	flag.StringVar(&caCertPath, "ca-cert-path", "", "CA certificate file.")
 	flag.StringVar(&caKeyPath, "ca-key-path", "", "CA private key file.")
 	flag.StringVar(&clusterFqdn, "cluster-fqdn", "cluster.local", "The FQDN of the cluster")
@@ -106,6 +107,12 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if err := validateFlags(signerName); err != nil {
+		setupLog.Error(err, "invalid command-line flags")
+		os.Exit(1)
+	}
+
 	ctx := ctrl.SetupSignalHandler()
 	restCfg := ctrl.GetConfigOrDie()
 
@@ -242,6 +249,17 @@ func main() {
 		setupLog.Error(err, "unable to start controller manager")
 		os.Exit(1)
 	}
+}
+
+// validateFlags checks required command-line flags. An empty --signer-name is
+// rejected here so the controller fails fast at startup - mirroring the
+// required --ca-cert-path - instead of only surfacing the problem later, after
+// a Kubernetes API connection has been established.
+func validateFlags(signerName string) error {
+	if signerName == "" {
+		return errors.New("the --signer-name flag is required")
+	}
+	return nil
 }
 
 // displayCommandlineFlags visits all CLI flags and prints them.

--- a/cmd/podcertificate-signer/main_test.go
+++ b/cmd/podcertificate-signer/main_test.go
@@ -31,6 +31,8 @@ func TestDeploymentRendersConfiguredFlags(t *testing.T) {
 	out, err := exec.Command(
 		"helm", "template", "podcertificate-signer", chartDir(t),
 		"--kube-version", "1.36.0",
+		// A CA source is required (the chart fails fast otherwise).
+		"--set", "signer.ca.secretRef.name=test-ca",
 	).CombinedOutput()
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)

--- a/cmd/podcertificate-signer/main_test.go
+++ b/cmd/podcertificate-signer/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// An empty --signer-name must be rejected fast, before the controller attempts
+// any Kubernetes API calls, mirroring the required --ca-cert-path handling.
+func TestValidateFlagsRequiresSignerName(t *testing.T) {
+	if err := validateFlags(""); err == nil {
+		t.Error("validateFlags(\"\") = nil, want error for empty signer name")
+	}
+	if err := validateFlags("example.org/signer"); err != nil {
+		t.Errorf("validateFlags(%q) = %v, want nil", "example.org/signer", err)
+	}
+}
+
+// The rendered Deployment must pass --cluster-fqdn and
+// --health-probe-bind-address to the manager, so the corresponding chart
+// values actually reach the controller instead of silently falling back to the
+// binary defaults.
+func TestDeploymentRendersConfiguredFlags(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skipf("helm not installed: %v", err)
+	}
+
+	out, err := exec.Command(
+		"helm", "template", "podcertificate-signer", chartDir(t),
+		"--kube-version", "1.36.0",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+
+	for _, want := range []string{"--cluster-fqdn=", "--health-probe-bind-address="} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("rendered Deployment is missing flag %q", want)
+		}
+	}
+}
+
+func chartDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", "charts", "podcertificate-signer")
+}

--- a/examples/helm-values.yaml
+++ b/examples/helm-values.yaml
@@ -1,10 +1,13 @@
-volumes:
-  - name: podcertificate-signer-ca
-    secret:
-      secretName: podcertificate-signer-ca
-      optional: false
-
-volumeMounts:
-  - name: podcertificate-signer-ca
-    mountPath: /app/signer/ca
-    readOnly: true
+# Recommended: provide the signing CA from an existing Secret. The chart wires a
+# read-only volume for you at signer.ca.secretRef.mountPath — no volumes /
+# volumeMounts plumbing required.
+#
+# Create the Secret first, e.g.:
+#   kubectl create secret tls podcertificate-signer-ca \
+#     --cert=ca.crt --key=ca.key -n <namespace>
+signer:
+  name: example.org/signer
+  ca:
+    source: secretRef
+    secretRef:
+      name: podcertificate-signer-ca


### PR DESCRIPTION
Implements #36 — part of the **code-quality-review** epic (#25).

Repairs the broken `make build`/`run` targets and the chart's missing flag rendering.

### Stack
- **Base:** `main` (independent)

### Changes
- Drop the undefined `manifests` prerequisite from Makefile `build`/`run` (there is no `config/` dir; the project owns no CRDs).
- Render `--cluster-fqdn` (new `signer.cluster_fqdn` value) and `--health-probe-bind-address` in the deployment.
- Make `--signer-name` required (fail fast when empty, mirroring `--ca-cert-path`); remove the placeholder default from `values.yaml`. `make helm-install` passes `--set signer.name=$(SIGNER_NAME)` so the example install still works.

### TDD evidence
`cmd/podcertificate-signer/main_test.go` `TestValidateFlagsRequiresSignerName` / `TestDeploymentRendersConfiguredFlags` — RED (`undefined: validateFlags`; flags absent from render) → GREEN; `make build` now succeeds.

### Note
Touches `Makefile` (also touched by #34) and `cmd/.../main.go` (also touched by #26) — rebase/resolve those pairs at merge.

Closes #36
