### PR TITLE
refactor(#35): introduce podSigner seam on the reconciler

### DIFF
--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -85,12 +85,24 @@ func failed(reason Reason, err error) error {
 	return &TerminalError{Reason: reason, ConditionType: capiv1beta1.PodCertificateRequestConditionTypeFailed, Err: err}
 }
 
+// podSigner is the consumer-side view of the signing dependency the reconciler
+// needs. Keeping it an interface (rather than the concrete *signer.Signer) lets
+// the reconcile path be unit-tested with a stub.
+type podSigner interface {
+	SignPodCertificate(*podcertificate.PodCertificateConfig) (*podcertificate.PodCertificate, error)
+	IsSignerNameMatching(string) bool
+	Name() string
+}
+
+// Compile-time assertion that the production signer satisfies the seam.
+var _ podSigner = (*signer.Signer)(nil)
+
 // PodCertificateRequestReconciler reconciles a PodCertificateRequest object
 type PodCertificateRequestReconciler struct {
 	client.Client
 	Log           logr.Logger
 	Scheme        *runtime.Scheme
-	Signer        *signer.Signer
+	Signer        podSigner
 	ClusterFqdn   string
 	EventRecorder events.EventRecorder
 	// EnableAnnotationInterpolation allows ${...} placeholders in the

--- a/internal/controller/podsigner_seam_test.go
+++ b/internal/controller/podsigner_seam_test.go
@@ -1,0 +1,95 @@
+package controller
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/podcertificate"
+)
+
+// stubSigner is a test double for the podSigner seam on the reconciler. It
+// records whether it was invoked and the configuration it received, so tests
+// can assert the signing path was actually reached (and with which config).
+type stubSigner struct {
+	name      string
+	cert      *podcertificate.PodCertificate
+	err       error
+	called    bool
+	gotConfig *podcertificate.PodCertificateConfig
+}
+
+func (s *stubSigner) SignPodCertificate(cfg *podcertificate.PodCertificateConfig) (*podcertificate.PodCertificate, error) {
+	s.called = true
+	s.gotConfig = cfg
+	return s.cert, s.err
+}
+
+func (s *stubSigner) IsSignerNameMatching(n string) bool { return s.name == n }
+
+func (s *stubSigner) Name() string { return s.name }
+
+// newSigningHarness wires a reconciler to the given stub with a pod present and
+// a PCR carrying a valid PKIX public key, so process() runs the full pipeline
+// and reaches SignPodCertificate. The returned context carries a discard logger
+// (pcConfig.LogConfiguration reads it off the context on this path).
+func newSigningHarness(t *testing.T, stub *stubSigner) (*PodCertificateRequestReconciler, *capiv1beta1.PodCertificateRequest, context.Context) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	pkixKey, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal PKIX public key: %v", err)
+	}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "mypod", Namespace: "ns"}}
+	pcr := &capiv1beta1.PodCertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "pcr", Namespace: "ns"},
+		Spec: capiv1beta1.PodCertificateRequestSpec{
+			PodName:       "mypod",
+			PKIXPublicKey: pkixKey,
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(pod).Build()
+	r := &PodCertificateRequestReconciler{Client: cl, Log: logr.Discard(), Signer: stub}
+	ctx := logr.NewContext(context.Background(), logr.Discard())
+	return r, pcr, ctx
+}
+
+// The reconciler's Signer field must be a consumer-side interface so tests can
+// substitute a stub. With a stub returning a certificate, process() runs the
+// full pipeline and hands back exactly that certificate.
+func TestProcessReachesSigner(t *testing.T) {
+	want := podcertificate.NewPodCertificate(
+		nil, "pem-chain",
+		&podcertificate.PodCertificateConfig{},
+		time.Now(), time.Now().Add(time.Hour),
+	)
+	stub := &stubSigner{name: "example.org/signer", cert: want}
+	r, pcr, ctx := newSigningHarness(t, stub)
+
+	got, err := r.process(ctx, pcr)
+	if err != nil {
+		t.Fatalf("process() error = %v, want nil", err)
+	}
+	if !stub.called {
+		t.Fatal("process() did not reach SignPodCertificate")
+	}
+	if got != want {
+		t.Fatalf("process() cert = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Implements #35 — part of the **code-quality-review** epic (#25). Root of the controller/signing stack.

Introduces a small consumer-side `podSigner` interface so the reconcile pipeline becomes unit-testable. No behavior change.

### Stack
- **Base:** `main` (stack root)
- **Children:** #28 → #29 → #33 build on this branch.

### Changes
- `type podSigner interface { SignPodCertificate(...); IsSignerNameMatching(string) bool; Name() string }` in package `controller`; reconciler field changed to that interface; `var _ podSigner = (*signer.Signer)(nil)`. `main.go` assigns the concrete `*signer.Signer` unchanged.

### TDD evidence
`internal/controller/podsigner_seam_test.go` `TestProcessReachesSigner` — RED (compile: stub can't satisfy `*signer.Signer`) → GREEN. Provides the stub + harness reused by #28/#29.

Closes #35
