### PR TITLE
fix(#28): classify CA-availability signing errors as transient

### DIFF
--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/api"
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/authority"
 	podcertificate "github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/podcertificate"
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/signer"
 
@@ -246,6 +247,12 @@ func (r *PodCertificateRequestReconciler) process(ctx context.Context, pcr *capi
 
 	cert, err := r.Signer.SignPodCertificate(pcConfig)
 	if err != nil {
+		// CA-availability failures are transient: a CA rotation can let an
+		// identical request succeed, so requeue rather than record a terminal
+		// Failed outcome the request could never recover from.
+		if errors.Is(err, authority.ErrCASignerUnusable) {
+			return nil, err
+		}
 		return nil, failed(ReasonSigningFailed, err)
 	}
 	return cert, nil

--- a/internal/controller/transient_ca_errors_test.go
+++ b/internal/controller/transient_ca_errors_test.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/authority"
+)
+
+// A CA-availability error surfaced by the signer must be classified TRANSIENT:
+// process() returns a plain error (so controller-runtime requeues) that still
+// carries authority.ErrCASignerUnusable. A request-specific signing error must
+// stay terminal (*TerminalError -> Failed/SigningFailed, recorded on the PCR).
+func TestProcessClassifiesSignerErrors(t *testing.T) {
+	cases := []struct {
+		name         string
+		signErr      error
+		wantTerminal bool
+	}{
+		{
+			name:         "expired signer is transient",
+			signErr:      fmt.Errorf("the signer has expired: NotAfter=x: %w", authority.ErrCASignerUnusable),
+			wantTerminal: false,
+		},
+		{
+			name:         "exceeds CA validity is transient",
+			signErr:      fmt.Errorf("certificate validity period exceeds the signer CA validity: %w", authority.ErrCASignerUnusable),
+			wantTerminal: false,
+		},
+		{
+			name:         "request-specific error stays terminal",
+			signErr:      errors.New("certificate not after is in the past"),
+			wantTerminal: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubSigner{name: "example.org/signer", err: tc.signErr}
+			r, pcr, ctx := newSigningHarness(t, stub)
+
+			cert, err := r.process(ctx, pcr)
+			if cert != nil {
+				t.Fatalf("process() cert = %v, want nil", cert)
+			}
+			if !stub.called {
+				t.Fatal("process() did not reach SignPodCertificate")
+			}
+
+			var te *TerminalError
+			gotTerminal := errors.As(err, &te)
+			if gotTerminal != tc.wantTerminal {
+				t.Fatalf("process() terminal = %v (err = %v), want terminal = %v", gotTerminal, err, tc.wantTerminal)
+			}
+			if !tc.wantTerminal && !errors.Is(err, authority.ErrCASignerUnusable) {
+				t.Fatalf("transient err = %v, want it to still wrap ErrCASignerUnusable", err)
+			}
+		})
+	}
+}

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -193,12 +193,12 @@ func (ca *CertificateAuthority) Sign(pcConfig *podcertificate.PodCertificateConf
 
 	nbf := now.Add(-ca.backDate)
 	if !nbf.Before(ca.certificate.NotAfter) {
-		return nil, fmt.Errorf("the signer has expired: NotAfter=%v", ca.certificate.NotAfter)
+		return nil, fmt.Errorf("the signer has expired: NotAfter=%v: %w", ca.certificate.NotAfter, ErrCASignerUnusable)
 	}
 
 	naf := nbf.Add(pcConfig.Duration)
 	if naf.After(ca.certificate.NotAfter) {
-		return nil, fmt.Errorf("certificate validity period exceeds the signer CA validity: notAfter=%v, caNotAfter=%v", naf, ca.certificate.NotAfter)
+		return nil, fmt.Errorf("certificate validity period exceeds the signer CA validity: notAfter=%v, caNotAfter=%v: %w", naf, ca.certificate.NotAfter, ErrCASignerUnusable)
 	}
 	if naf.Before(now) {
 		return nil, fmt.Errorf("certificate not after is in the past: %v", naf)

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -24,6 +24,14 @@ import (
 
 var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
+// ErrCASignerUnusable marks signing failures caused by the state of the CA
+// itself (expired signer, or a request whose lifetime cannot fit inside the
+// remaining CA validity) rather than by the request. Such failures are
+// transient from the request's perspective: a CA rotation can make an
+// identical request succeed, so the reconciler requeues instead of recording
+// a terminal outcome. Callers match it with errors.Is.
+var ErrCASignerUnusable = errors.New("ca signer unusable")
+
 // Option is a function which configures the [CertificateAuthority].
 type Option func(ca *CertificateAuthority) error
 

--- a/internal/kubernetes/authority/authority_test.go
+++ b/internal/kubernetes/authority/authority_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"net"
 	"strings"
 	"testing"
@@ -211,8 +212,15 @@ func TestSignRejectsDurationBeyondCA(t *testing.T) {
 	config := testConfig(t)
 	config.Duration = 48 * time.Hour
 
-	if _, err := ca.Sign(config); err == nil {
+	_, err = ca.Sign(config)
+	if err == nil {
 		t.Fatal("want error when certificate would outlive the CA")
+	}
+	// The error must carry ErrCASignerUnusable so the reconciler classifies it
+	// as transient (a CA rotation can let the same request succeed) rather than
+	// recording a terminal Failed outcome.
+	if !errors.Is(err, ErrCASignerUnusable) {
+		t.Errorf("Sign() err = %v, want it to wrap ErrCASignerUnusable", err)
 	}
 }
 


### PR DESCRIPTION
Implements #28 — part of the **code-quality-review** epic (#25).

Classifies CA-availability signing errors (expired signer / requested lifetime exceeds CA lifetime) as **transient** instead of writing a terminal `Failed` that permanently wedges the pod.

### Stack
- **Base branch:** `code-quality/pod-signer-seam`
- **Stack parent PR:** #40
- **Merge only after:** #40

### Changes
- `var ErrCASignerUnusable` in the authority package; the expired-signer and exceeds-CA-validity returns wrap it with `%w`.
- `process()` returns the plain (transient) error when `errors.Is(err, authority.ErrCASignerUnusable)` before mapping to `failed(ReasonSigningFailed)`. Request-specific errors stay terminal.

### TDD evidence
`TestProcessClassifiesSignerErrors` (+ `TestSignRejectsDurationBeyondCA` asserting production `Sign` wraps the sentinel) — RED → GREEN under `-race`.

Closes #28
