### PR TITLE
fix(#29): verify pod identity with a live UID-aware read

### DIFF
--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -226,6 +226,7 @@ func main() {
 
 	if err := (&controller.PodCertificateRequestReconciler{
 		Client:                        mgr.GetClient(),
+		APIReader:                     mgr.GetAPIReader(),
 		Log:                           ctrl.Log.WithName(DefaultControllerName),
 		Scheme:                        mgr.GetScheme(),
 		Signer:                        pcrSigner,

--- a/internal/api/helper.go
+++ b/internal/api/helper.go
@@ -56,8 +56,10 @@ func GetPodAnnotation(pod *corev1.Pod, annotationKey string) (string, bool) {
 	return value, true
 }
 
-// GetPod fetches the pod with the given name and namespace.
-func GetPod(ctx context.Context, c client.Client, podName, podNamespace string) (*corev1.Pod, error) {
+// GetPod fetches the pod with the given name and namespace. It takes a
+// client.Reader so callers can pass either the cached manager client or the
+// cache-bypassing APIReader.
+func GetPod(ctx context.Context, c client.Reader, podName, podNamespace string) (*corev1.Pod, error) {
 	var pod corev1.Pod
 	podKey := types.NamespacedName{
 		Name:      podName,

--- a/internal/controller/live_pod_uid_test.go
+++ b/internal/controller/live_pod_uid_test.go
@@ -74,6 +74,10 @@ func TestProcessCacheMissReadsLive(t *testing.T) {
 	if cert == nil {
 		t.Fatal("process() cert = nil, want the signed certificate")
 	}
+	// The config must be built from the pod found on the live read.
+	if stub.gotConfig == nil || stub.gotConfig.CommonName != "mypod" {
+		t.Fatalf("signed config = %+v, want CommonName %q from the live pod", stub.gotConfig, "mypod")
+	}
 }
 
 // When the pod that exists has a UID different from the request's PodUID, the

--- a/internal/controller/live_pod_uid_test.go
+++ b/internal/controller/live_pod_uid_test.go
@@ -1,0 +1,97 @@
+package controller
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/podcertificate"
+)
+
+// livePCR returns a PCR carrying a valid PKIX public key that expects the pod
+// identified by requestUID, plus a pod object stamped with podUID.
+func livePCR(t *testing.T, requestUID, podUID types.UID) (*capiv1beta1.PodCertificateRequest, *corev1.Pod) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	pkixKey, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal PKIX public key: %v", err)
+	}
+
+	pcr := &capiv1beta1.PodCertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "pcr", Namespace: "ns"},
+		Spec: capiv1beta1.PodCertificateRequestSpec{
+			PodName:       "mypod",
+			PodUID:        requestUID,
+			PKIXPublicKey: pkixKey,
+		},
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "mypod", Namespace: "ns", UID: podUID}}
+	return pcr, pod
+}
+
+func stubCert() *podcertificate.PodCertificate {
+	return podcertificate.NewPodCertificate(
+		nil, "pem-chain",
+		&podcertificate.PodCertificateConfig{},
+		time.Now(), time.Now().Add(time.Hour),
+	)
+}
+
+// When the manager cache misses but the pod exists on a live read, the
+// controller must re-read via the APIReader and proceed to sign, instead of
+// recording a terminal AssociatedPodNotFound on a cache/creation race.
+func TestProcessCacheMissReadsLive(t *testing.T) {
+	pcr, pod := livePCR(t, "uid-1", "uid-1")
+	cache := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build() // pod absent from cache
+	live := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(pod).Build()
+	stub := &stubSigner{name: "example.org/signer", cert: stubCert()}
+	r := &PodCertificateRequestReconciler{Client: cache, APIReader: live, Log: logr.Discard(), Signer: stub}
+	ctx := logr.NewContext(context.Background(), logr.Discard())
+
+	cert, err := r.process(ctx, pcr)
+	if err != nil {
+		t.Fatalf("process() error = %v, want nil (live read should find the pod)", err)
+	}
+	if !stub.called {
+		t.Fatal("process() did not reach the signer after the live re-read")
+	}
+	if cert == nil {
+		t.Fatal("process() cert = nil, want the signed certificate")
+	}
+}
+
+// When the pod that exists has a UID different from the request's PodUID, the
+// request is stale: the controller must drop it (nil, nil) and must NOT sign
+// with the wrong pod's identity.
+func TestProcessStalePodUIDDropped(t *testing.T) {
+	pcr, stalePod := livePCR(t, "uid-1", "uid-stale")
+	cache := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(stalePod).Build()
+	live := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(stalePod).Build()
+	stub := &stubSigner{name: "example.org/signer", cert: stubCert()}
+	r := &PodCertificateRequestReconciler{Client: cache, APIReader: live, Log: logr.Discard(), Signer: stub}
+	ctx := logr.NewContext(context.Background(), logr.Discard())
+
+	cert, err := r.process(ctx, pcr)
+	if cert != nil || err != nil {
+		t.Fatalf("got (%v, %v), want (nil, nil) drop for a UID-mismatched pod", cert, err)
+	}
+	if stub.called {
+		t.Fatal("signer must not run for a UID-mismatched (stale) pod")
+	}
+}

--- a/internal/controller/live_pod_uid_test.go
+++ b/internal/controller/live_pod_uid_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/podcertificate"
@@ -88,7 +89,10 @@ func TestProcessStalePodUIDDropped(t *testing.T) {
 	cache := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(stalePod).Build()
 	live := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(stalePod).Build()
 	stub := &stubSigner{name: "example.org/signer", cert: stubCert()}
-	r := &PodCertificateRequestReconciler{Client: cache, APIReader: live, Log: logr.Discard(), Signer: stub}
+	// The drop path emits an event; see TestReconcileDroppedGonePodEmitsEvent.
+	r := &PodCertificateRequestReconciler{
+		Client: cache, APIReader: live, Log: logr.Discard(), Signer: stub, EventRecorder: events.NewFakeRecorder(10),
+	}
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 
 	cert, err := r.process(ctx, pcr)

--- a/internal/controller/outcome_test.go
+++ b/internal/controller/outcome_test.go
@@ -43,7 +43,7 @@ func TestRecordTerminal(t *testing.T) {
 		err      error
 		wantType string
 	}{
-		{"failed clears fields", failed(ReasonSigningFailed, errors.New("sign broke")), "Failed"},
+		{"failed clears fields", failed(errors.New("sign broke")), "Failed"},
 		{"denied clears fields", denied(ReasonUnsupportedKeyType, errors.New("bad key")), "Denied"},
 	}
 

--- a/internal/controller/pod_gone_event_test.go
+++ b/internal/controller/pod_gone_event_test.go
@@ -1,0 +1,113 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Dropping a request whose pod is confirmed gone leaves no trace in the PCR
+// status (that would be a terminal outcome, which #29 deliberately removed), so
+// the only operator-visible breadcrumb is an event. Reconcile must emit exactly
+// one warning event and write no condition, on both confirmed-gone paths: the
+// pod absent from a live read, and a live read that confirms a pod UID other
+// than the one the request asked for. The two paths share a reason but carry
+// different notes, because a replaced pod is not a missing one: the note names
+// both the requested and the observed UID so an operator need not read the logs.
+func TestReconcileDroppedGonePodEmitsEvent(t *testing.T) {
+	const (
+		signerName = "example.org/signer"
+		// The reason as operators see it on the event, not via the constant.
+		wantReason = "AssociatedPodGone"
+	)
+
+	cases := []struct {
+		name string
+		// livePodUID stamps the pod visible to both the cached and the live
+		// read; empty means no pod exists at all.
+		livePodUID types.UID
+		wantNote   string
+	}{
+		{
+			name:     "pod absent on the live read",
+			wantNote: "associated pod ns/mypod (uid uid-1) not found; dropping request",
+		},
+		{
+			name:       "live read confirms a different pod UID",
+			livePodUID: "uid-stale",
+			wantNote:   "associated pod ns/mypod was replaced (request uid uid-1, live uid uid-stale); dropping request",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pcr, pod := livePCR(t, "uid-1", tc.livePodUID)
+			pcr.Spec.SignerName = signerName
+
+			var pods []client.Object
+			if tc.livePodUID != "" {
+				pods = append(pods, pod)
+			}
+			cache := fake.NewClientBuilder().
+				WithScheme(newTestScheme(t)).
+				WithObjects(append([]client.Object{pcr}, pods...)...).
+				WithStatusSubresource(&capiv1beta1.PodCertificateRequest{}).
+				Build()
+			live := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(pods...).Build()
+
+			stub := &stubSigner{name: signerName, cert: stubCert()}
+			rec := events.NewFakeRecorder(10)
+			r := &PodCertificateRequestReconciler{
+				Client: cache, APIReader: live, Log: logr.Discard(), Signer: stub, EventRecorder: rec,
+			}
+
+			res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pcr)})
+			if err != nil {
+				t.Fatalf("Reconcile() error = %v, want nil (a gone pod is dropped, not retried)", err)
+			}
+			if res != (ctrl.Result{}) {
+				t.Errorf("Reconcile() result = %+v, want empty (no requeue)", res)
+			}
+			if stub.called {
+				t.Error("signer must not run for a request whose pod is gone")
+			}
+
+			got := &capiv1beta1.PodCertificateRequest{}
+			if err := cache.Get(context.Background(), client.ObjectKeyFromObject(pcr), got); err != nil {
+				t.Fatalf("get PodCertificateRequest: %v", err)
+			}
+			if len(got.Status.Conditions) != 0 {
+				t.Errorf("Reconcile() wrote conditions = %+v, want none (the drop must not be terminal)", got.Status.Conditions)
+			}
+
+			select {
+			case e := <-rec.Events:
+				if !strings.Contains(e, corev1.EventTypeWarning) {
+					t.Errorf("event = %q, want a %s event", e, corev1.EventTypeWarning)
+				}
+				if !strings.Contains(e, wantReason) {
+					t.Errorf("event = %q, want reason %s", e, wantReason)
+				}
+				if !strings.Contains(e, tc.wantNote) {
+					t.Errorf("event = %q, want it to contain %q", e, tc.wantNote)
+				}
+			default:
+				t.Fatal("no event recorded, want one warning event for the dropped request")
+			}
+			select {
+			case e := <-rec.Events:
+				t.Errorf("second event = %q, want exactly one event on the drop", e)
+			default:
+			}
+		})
+	}
+}

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -45,13 +45,21 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// Reason identifies a terminal/issued outcome recorded on a PodCertificateRequest.
+// Reason identifies an outcome reported for a PodCertificateRequest: a
+// terminal/issued condition recorded on the object, or an event-only outcome
+// where noted below.
 type Reason string
 
 const (
 	ReasonAssociatedPodNotFound Reason = "AssociatedPodNotFound"
 	ReasonSigningFailed         Reason = "SigningFailed"
 	ReasonCertificateIssued     Reason = "CertificateIssued"
+
+	// ReasonAssociatedPodGone is event-only and is never written as a
+	// condition: a request whose pod a live read confirms is gone (absent, or
+	// replaced by a different pod) is dropped, not failed. The event note says
+	// which of the two it was.
+	ReasonAssociatedPodGone Reason = "AssociatedPodGone"
 
 	// Well-known condition reasons defined by the certificates v1beta1 API.
 	ReasonUnsupportedKeyType     Reason = Reason(capiv1beta1.PodCertificateRequestConditionUnsupportedKeyType)
@@ -200,7 +208,10 @@ func (r *PodCertificateRequestReconciler) Reconcile(ctx context.Context, req ctr
 
 // process runs the signing pipeline for a PodCertificateRequest. It returns:
 //   - (cert, nil)  on success
-//   - (nil, nil)   when there is nothing to do (the associated pod is being deleted)
+//   - (nil, nil)   when there is nothing to do: the associated pod is being
+//     deleted, or a live read confirms it is gone (absent, or carrying a
+//     different UID than the request asked for). A confirmed-gone drop emits a
+//     warning event and writes no status; a pod being deleted is silent.
 //   - (nil, *TerminalError) for permanent failures (recorded on the PCR, no retry)
 //   - (nil, err)   for transient failures (requeued with backoff)
 func (r *PodCertificateRequestReconciler) process(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest) (*podcertificate.PodCertificate, error) {
@@ -226,6 +237,8 @@ func (r *PodCertificateRequestReconciler) process(ctx context.Context, pcr *capi
 			// The pod is gone on a live read too: the request is stale, not a
 			// terminal failure to sign. Drop it.
 			log.Info("associated pod not found on a live read; dropping stale request")
+			r.recordPodGone(pcr, "associated pod %s/%s (uid %s) not found; dropping request",
+				pcr.Namespace, pcr.Spec.PodName, pcr.Spec.PodUID)
 			return nil, nil
 		case err != nil:
 			return nil, err // transient
@@ -236,6 +249,8 @@ func (r *PodCertificateRequestReconciler) process(ctx context.Context, pcr *capi
 	if crPod.UID != pcr.Spec.PodUID {
 		log.Info("associated pod UID does not match the request; dropping stale request",
 			"podUID", crPod.UID, "requestPodUID", pcr.Spec.PodUID)
+		r.recordPodGone(pcr, "associated pod %s/%s was replaced (request uid %s, live uid %s); dropping request",
+			pcr.Namespace, pcr.Spec.PodName, pcr.Spec.PodUID, crPod.UID)
 		return nil, nil
 	}
 
@@ -318,6 +333,15 @@ func (r *PodCertificateRequestReconciler) recordFailure(ctx context.Context, pcr
 func (r *PodCertificateRequestReconciler) recordTerminal(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest, te *TerminalError) error {
 	r.clearPodCertificateRequestStatusFields(pcr)
 	return r.recordOutcome(ctx, pcr, te.ConditionType, te.Reason, te.Err.Error(), corev1.EventTypeWarning)
+}
+
+// recordPodGone emits the warning event for a request dropped because a live
+// read confirmed its pod is gone. The note is supplied by the caller, since
+// "absent" and "replaced by a different pod" are different facts for whoever
+// reads the event. Deliberately no status write: the drop is not a terminal
+// outcome, and the event is the only breadcrumb an operator gets.
+func (r *PodCertificateRequestReconciler) recordPodGone(pcr *capiv1beta1.PodCertificateRequest, noteFmt string, args ...any) {
+	r.EventRecorder.Eventf(pcr, nil, corev1.EventTypeWarning, string(ReasonAssociatedPodGone), "SignPodCertificateRequest", noteFmt, args...)
 }
 
 func (r *PodCertificateRequestReconciler) recordIssued(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest, cert *podcertificate.PodCertificate) error {

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -184,7 +184,9 @@ func (r *PodCertificateRequestReconciler) Reconcile(ctx context.Context, req ctr
 		return r.recordFailure(ctx, &pcr, err)
 	}
 	if cert == nil {
-		return ctrl.Result{}, nil // pod is being deleted -> nothing to do
+		// Nothing to sign: the pod is being deleted, or the request is stale
+		// (pod absent or UID-mismatched on the live read). Drop without requeue.
+		return ctrl.Result{}, nil
 	}
 
 	log.Info("Successfully signed the certificate")
@@ -204,13 +206,39 @@ func (r *PodCertificateRequestReconciler) Reconcile(ctx context.Context, req ctr
 func (r *PodCertificateRequestReconciler) process(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest) (*podcertificate.PodCertificate, error) {
 	log := logf.FromContext(ctx)
 
+	// Read the pod from the manager cache first. The cache can be stale in two
+	// ways that matter here: it may miss a just-created pod (racing the
+	// request), or it may still hold a previous pod that shared this name. In
+	// both cases re-read directly from the API server and gate on the pod's
+	// live UID, so a certificate is never issued against the wrong pod.
 	crPod, err := api.GetPod(ctx, r.Client, pcr.Spec.PodName, pcr.Namespace)
 	switch {
 	case apierrors.IsNotFound(err):
-		return nil, failed(ReasonAssociatedPodNotFound, err)
+		// Cache miss; fall through to the live read below.
 	case err != nil:
 		return nil, err // transient
 	}
+
+	if crPod == nil || crPod.UID != pcr.Spec.PodUID {
+		crPod, err = api.GetPod(ctx, r.APIReader, pcr.Spec.PodName, pcr.Namespace)
+		switch {
+		case apierrors.IsNotFound(err):
+			// The pod is gone on a live read too: the request is stale, not a
+			// terminal failure to sign. Drop it.
+			log.Info("associated pod not found on a live read; dropping stale request")
+			return nil, nil
+		case err != nil:
+			return nil, err // transient
+		}
+	}
+
+	// Identity gate: only sign for the exact pod the request was created for.
+	if crPod.UID != pcr.Spec.PodUID {
+		log.Info("associated pod UID does not match the request; dropping stale request",
+			"podUID", crPod.UID, "requestPodUID", pcr.Spec.PodUID)
+		return nil, nil
+	}
+
 	if !crPod.DeletionTimestamp.IsZero() {
 		log.Info("Pod has been deleted.")
 		return nil, nil

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -89,9 +89,11 @@ func denied(reason Reason, err error) error {
 }
 
 // failed wraps err as a terminal "Failed" outcome: the signer could not issue
-// the certificate (e.g. the associated pod is gone, signing itself failed).
-func failed(reason Reason, err error) error {
-	return &TerminalError{Reason: reason, ConditionType: capiv1beta1.PodCertificateRequestConditionTypeFailed, Err: err}
+// the certificate. The only remaining Failed reason is SigningFailed (a missing
+// pod is now dropped, not failed), so the reason is fixed rather than a
+// parameter; unlike denied, whose reason varies.
+func failed(err error) error {
+	return &TerminalError{Reason: ReasonSigningFailed, ConditionType: capiv1beta1.PodCertificateRequestConditionTypeFailed, Err: err}
 }
 
 // podSigner is the consumer-side view of the signing dependency the reconciler
@@ -301,7 +303,7 @@ func (r *PodCertificateRequestReconciler) process(ctx context.Context, pcr *capi
 		if errors.Is(err, authority.ErrCASignerUnusable) {
 			return nil, err
 		}
-		return nil, failed(ReasonSigningFailed, err)
+		return nil, failed(err)
 	}
 	return cert, nil
 }

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -101,6 +101,11 @@ var _ podSigner = (*signer.Signer)(nil)
 // PodCertificateRequestReconciler reconciles a PodCertificateRequest object
 type PodCertificateRequestReconciler struct {
 	client.Client
+	// APIReader reads directly from the API server, bypassing the manager
+	// cache. It is used to re-read the associated pod when the cached read
+	// misses or returns a stale (UID-mismatched) object, so the request is
+	// verified against live pod identity before signing.
+	APIReader     client.Reader
 	Log           logr.Logger
 	Scheme        *runtime.Scheme
 	Signer        podSigner

--- a/internal/controller/podsigner_seam_test.go
+++ b/internal/controller/podsigner_seam_test.go
@@ -55,17 +55,18 @@ func newSigningHarness(t *testing.T, stub *stubSigner) (*PodCertificateRequestRe
 		t.Fatalf("marshal PKIX public key: %v", err)
 	}
 
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "mypod", Namespace: "ns"}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "mypod", Namespace: "ns", UID: "pod-uid"}}
 	pcr := &capiv1beta1.PodCertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{Name: "pcr", Namespace: "ns"},
 		Spec: capiv1beta1.PodCertificateRequestSpec{
 			PodName:       "mypod",
+			PodUID:        "pod-uid",
 			PKIXPublicKey: pkixKey,
 		},
 	}
 
 	cl := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(pod).Build()
-	r := &PodCertificateRequestReconciler{Client: cl, Log: logr.Discard(), Signer: stub}
+	r := &PodCertificateRequestReconciler{Client: cl, APIReader: cl, Log: logr.Discard(), Signer: stub}
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	return r, pcr, ctx
 }

--- a/internal/controller/reconcile_classification_test.go
+++ b/internal/controller/reconcile_classification_test.go
@@ -28,7 +28,10 @@ func testPCR() *capiv1beta1.PodCertificateRequest {
 // a live read: the request is stale, not a terminal failure to sign.
 func TestProcessPodNotFoundDropsAsStale(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
-	r := &PodCertificateRequestReconciler{Client: cl, APIReader: cl, Log: logr.Discard()}
+	// The drop path emits an event; see TestReconcileDroppedGonePodEmitsEvent.
+	r := &PodCertificateRequestReconciler{
+		Client: cl, APIReader: cl, Log: logr.Discard(), EventRecorder: events.NewFakeRecorder(10),
+	}
 
 	cert, err := r.process(context.Background(), testPCR())
 	if cert != nil || err != nil {

--- a/internal/controller/reconcile_classification_test.go
+++ b/internal/controller/reconcile_classification_test.go
@@ -24,18 +24,15 @@ func testPCR() *capiv1beta1.PodCertificateRequest {
 	}
 }
 
-// process() must classify a missing pod as terminal AssociatedPodNotFound.
-func TestProcessPodNotFoundIsTerminal(t *testing.T) {
+// process() must drop (nil, nil) when the pod is absent from both the cache and
+// a live read: the request is stale, not a terminal failure to sign.
+func TestProcessPodNotFoundDropsAsStale(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
-	r := &PodCertificateRequestReconciler{Client: cl, Log: logr.Discard()}
+	r := &PodCertificateRequestReconciler{Client: cl, APIReader: cl, Log: logr.Discard()}
 
 	cert, err := r.process(context.Background(), testPCR())
-	if cert != nil {
-		t.Fatalf("cert = %v, want nil", cert)
-	}
-	var te *TerminalError
-	if !errors.As(err, &te) || te.Reason != ReasonAssociatedPodNotFound {
-		t.Fatalf("err = %v, want terminal ReasonAssociatedPodNotFound", err)
+	if cert != nil || err != nil {
+		t.Fatalf("got (%v, %v), want (nil, nil) drop for a stale request", cert, err)
 	}
 }
 

--- a/internal/controller/reconcile_classification_test.go
+++ b/internal/controller/reconcile_classification_test.go
@@ -92,7 +92,7 @@ func TestRecordFailureTerminalWritesCondition(t *testing.T) {
 		Build()
 	r := &PodCertificateRequestReconciler{Client: cl, Log: logr.Discard(), EventRecorder: events.NewFakeRecorder(10)}
 
-	res, err := r.recordFailure(context.Background(), pcr, failed(ReasonSigningFailed, errors.New("x")))
+	res, err := r.recordFailure(context.Background(), pcr, failed(errors.New("x")))
 	if err != nil {
 		t.Fatalf("recordFailure returned err = %v, want nil", err)
 	}
@@ -149,7 +149,7 @@ func TestRecordFailureWriteErrorRequeues(t *testing.T) {
 		Build()
 	r := &PodCertificateRequestReconciler{Client: cl, Log: logr.Discard(), EventRecorder: events.NewFakeRecorder(10)}
 
-	if _, err := r.recordFailure(context.Background(), pcr, failed(ReasonSigningFailed, errors.New("boom"))); !errors.Is(err, writeErr) {
+	if _, err := r.recordFailure(context.Background(), pcr, failed(errors.New("boom"))); !errors.Is(err, writeErr) {
 		t.Fatalf("err = %v, want the status-write error returned for requeue", err)
 	}
 }

--- a/internal/controller/terminal_error_test.go
+++ b/internal/controller/terminal_error_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestTerminalError(t *testing.T) {
 	base := errors.New("boom")
-	err := failed(ReasonSigningFailed, base)
+	err := failed(base)
 
 	if err.Error() != "boom" {
 		t.Fatalf("Error() = %q, want %q", err.Error(), "boom")


### PR DESCRIPTION
Implements #29 — part of the **code-quality-review** epic (#25).

Verifies pod identity with a live, UID-aware read: fixes both the cache-miss terminal wedge and the stale same-name pod misissuance.

### Stack
- **Base branch:** `code-quality/transient-ca-errors`
- **Stack parent PR:** #42
- **Merge only after:** #42 (and its parent #40)

### Changes
- Add an `APIReader client.Reader` field (wired from `mgr.GetAPIReader()`); `api.GetPod` widened to `client.Reader`.
- On cache-NotFound **or** `crPod.UID != pcr.Spec.PodUID`, re-read once via the uncached reader, gate on live UID, and **drop** stale requests `(nil,nil)` instead of recording terminal `Failed`. Transient live-read errors still requeue.

### Behavior change
`ReasonAssociatedPodNotFound` is retired as a producible terminal outcome — a confirmed-missing pod's PCR is dropped (kubelet GC's it via its ownerReference). The existing contract test was updated (`TestProcessPodNotFoundIsTerminal` → `TestProcessPodNotFoundDropsAsStale`), not deleted.

### TDD evidence
`internal/controller/live_pod_uid_test.go` (cache-miss reads live; UID mismatch not signed; missing pod dropped) — RED → GREEN under `-race`.

Closes #29
