### PR TITLE
perf(#33): bypass pod cache and narrow pod RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,18 @@ kubectl logs -n pcs-system deployment/podcertificate-signer
 - Use RBAC or ValidatingAdmissionPolicy to restrict access
 - Bonus: Use MutatingAdmissionPolicy/ValidatingAdmissionPolicy to control which `unverifiedUserAnnotations` workloads are allowed to request
 
+### Controller RBAC (least privilege)
+
+The chart grants the controller only the permissions it uses. Notably, `pods`
+is **`get` only** — the controller reads the associated pod directly (uncached)
+and does not `list`/`watch` pods, so it never caches every pod in the cluster.
+
+> [!IMPORTANT]
+> Because `pods` is `get`-only, roll the chart and image out **together**. The
+> previous binary relied on a cached pod informer (`list`/`watch`); upgrading the
+> chart ahead of the image would leave an old controller without the permissions
+> it needs. The chart `appVersion` pins the image tag so they ship as a unit.
+
 🔐 Remember: No security mechanism is effective without strong authentication and authorization. In Kubernetes, security begins with controlling who can access what — user identities , RBAC policies and MutatingAdmissionPolicies/ValidatingAdmissionPolicy to form the foundation of your cluster's defense.
 
 ### 🔁 Rotating the signing CA

--- a/charts/podcertificate-signer/templates/clusterrole.yaml
+++ b/charts/podcertificate-signer/templates/clusterrole.yaml
@@ -20,8 +20,6 @@ rules:
   - pods
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - certificates.k8s.io
   resources:

--- a/charts/podcertificate-signer/templates/clusterrole.yaml
+++ b/charts/podcertificate-signer/templates/clusterrole.yaml
@@ -14,6 +14,8 @@ rules:
   verbs:
   - create
   - patch
+# Pods are read directly (uncached) by name during reconcile; get-only, with no
+# list/watch, so the controller does not run a cluster-wide pod informer.
 - apiGroups:
   - ""
   resources:

--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -121,22 +121,16 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 	restCfg := ctrl.GetConfigOrDie()
 
-	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
-		Scheme:                  scheme,
-		HealthProbeBindAddress:  healthProbeBindAddress,
-		LeaderElection:          enableLeaderElection,
-		LeaderElectionID:        leaderElectionID,
-		LeaderElectionNamespace: leaderElectionNamespace,
-		BaseContext:             func() context.Context { return ctx },
-		Metrics: server.Options{
-			BindAddress: metricsBindAddress,
-		},
-		Controller: config.Controller{
-			MaxConcurrentReconciles: maxConcurrentReconciles,
-			RecoverPanic:            new(true),
-			ReconciliationTimeout:   reconcileTimeout,
-		},
-	})
+	mgr, err := ctrl.NewManager(restCfg, managerOptions(scheme, managerConfig{
+		healthProbeBindAddress:  healthProbeBindAddress,
+		metricsBindAddress:      metricsBindAddress,
+		leaderElection:          enableLeaderElection,
+		leaderElectionID:        leaderElectionID,
+		leaderElectionNamespace: leaderElectionNamespace,
+		maxConcurrentReconciles: maxConcurrentReconciles,
+		reconcileTimeout:        reconcileTimeout,
+		baseContext:             ctx,
+	}))
 
 	if err != nil {
 		setupLog.Error(err, "unable to create controller manager")
@@ -267,6 +261,40 @@ func validateFlags(signerName string) error {
 		return errors.New("the --signer-name flag is required")
 	}
 	return nil
+}
+
+// managerConfig carries the controller-manager settings resolved from CLI
+// flags. It exists so the option construction can be unit-tested without
+// parsing flags.
+type managerConfig struct {
+	healthProbeBindAddress  string
+	metricsBindAddress      string
+	leaderElection          bool
+	leaderElectionID        string
+	leaderElectionNamespace string
+	maxConcurrentReconciles int
+	reconcileTimeout        time.Duration
+	baseContext             context.Context
+}
+
+// managerOptions builds the controller-manager options from cfg.
+func managerOptions(scheme *runtime.Scheme, cfg managerConfig) ctrl.Options {
+	return ctrl.Options{
+		Scheme:                  scheme,
+		HealthProbeBindAddress:  cfg.healthProbeBindAddress,
+		LeaderElection:          cfg.leaderElection,
+		LeaderElectionID:        cfg.leaderElectionID,
+		LeaderElectionNamespace: cfg.leaderElectionNamespace,
+		BaseContext:             func() context.Context { return cfg.baseContext },
+		Metrics: server.Options{
+			BindAddress: cfg.metricsBindAddress,
+		},
+		Controller: config.Controller{
+			MaxConcurrentReconciles: cfg.maxConcurrentReconciles,
+			RecoverPanic:            new(true),
+			ReconciliationTimeout:   cfg.reconcileTimeout,
+		},
+	}
 }
 
 // displayCommandlineFlags visits all CLI flags and prints them.

--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -32,6 +32,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -293,6 +294,15 @@ func managerOptions(scheme *runtime.Scheme, cfg managerConfig) ctrl.Options {
 			MaxConcurrentReconciles: cfg.maxConcurrentReconciles,
 			RecoverPanic:            new(true),
 			ReconciliationTimeout:   cfg.reconcileTimeout,
+		},
+		// Pods are excluded from the manager cache: the controller only does
+		// point Gets by name (and re-reads live via the APIReader for
+		// identity), so a cluster-wide pod informer would waste memory and
+		// require list/watch RBAC. Pod reads fall through to the API server.
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&corev1.Pod{}},
+			},
 		},
 	}
 }

--- a/cmd/podcertificate-signer/main_test.go
+++ b/cmd/podcertificate-signer/main_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"context"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 // An empty --signer-name must be rejected fast, before the controller attempts
@@ -52,4 +56,27 @@ func chartDir(t *testing.T) string {
 		t.Fatal("runtime.Caller failed")
 	}
 	return filepath.Join(filepath.Dir(file), "..", "..", "charts", "podcertificate-signer")
+}
+
+// The manager must bypass the cache for Pods: the controller only does point
+// Gets by name (and re-reads live via the APIReader for identity), so a
+// cluster-wide pod informer wastes memory and forces list/watch RBAC the
+// controller does not otherwise need.
+func TestManagerOptionsDisablesPodCache(t *testing.T) {
+	opts := managerOptions(k8sruntime.NewScheme(), managerConfig{baseContext: context.Background()})
+
+	if opts.Client.Cache == nil {
+		t.Fatal("Client.Cache is nil, want pod caching disabled via DisableFor")
+	}
+
+	found := false
+	for _, obj := range opts.Client.Cache.DisableFor {
+		if _, ok := obj.(*corev1.Pod); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Client.Cache.DisableFor = %v, want it to include *corev1.Pod", opts.Client.Cache.DisableFor)
+	}
 }

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -138,7 +138,7 @@ type PodCertificateRequestReconciler struct {
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=clustertrustbundles,verbs=get;create;update;patch
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=signers,verbs=sign;attest
 // +kubebuilder:rbac:groups=core;events.k8s.io,resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get
 
 func (r *PodCertificateRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// MaxConcurrentReconciles is inherited from the manager-wide controller


### PR DESCRIPTION
Implements #33 — part of the **code-quality-review** epic (#25). Top of the controller/signing stack.

Stops caching every Pod cluster-wide (memory scaled with cluster size) and narrows Pod RBAC.

### Stack
- **Base branch:** `code-quality/live-pod-uid`
- **Stack parent PR:** #43
- **Merge only after:** #43 (and its parents #42, #40)

### Changes
- `manager.Options.Client.Cache.DisableFor = []client.Object{&corev1.Pod{}}` (verified controller-runtime v0.24.1 API), via an extracted testable `managerOptions` helper. Pairs with #29's live read.
- Narrow the `+kubebuilder:rbac` pods marker and `clusterrole.yaml` pods verbs `get;list;watch` → `get`.

### ⚠️ Rollout ordering
`pods: get` is only safe against the new binary. **Ship the chart and image together** (a chart upgrade landing before the image would leave an old controller — pod informer enabled — without list/watch and wedge it). Chart appVersion pins the tag.

### TDD evidence
`TestManagerOptionsDisablesPodCache` (RED: `Client.Cache is nil`) → GREEN; `helm template` renders `pods: [get]`.

Closes #33
