### PR TITLE
fix(#32): recover CA watcher and surface reload health via readyz

### DIFF
--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -202,7 +203,11 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	// Gate readiness on the CA's watcher/reload health: a replica that can no
+	// longer observe CA rotations (or whose most recent reload failed) must be
+	// pulled from readiness so it is not relied upon to publish or sign with
+	// stale material.
+	if err := mgr.AddReadyzCheck("readyz", caReadyzCheck(ca)); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
@@ -266,6 +271,21 @@ func managerOptions(scheme *runtime.Scheme, cfg managerConfig) ctrl.Options {
 				DisableFor: []client.Object{&corev1.Pod{}},
 			},
 		},
+	}
+}
+
+// caHealthChecker is the CA health surface consumed by the readiness probe.
+type caHealthChecker interface {
+	// Healthy returns a non-nil error when the CA can no longer track its
+	// on-disk material (watcher dead or reload persistently failing).
+	Healthy() error
+}
+
+// caReadyzCheck adapts a caHealthChecker into a controller-runtime readiness
+// check, so a degraded CA removes the replica from readiness.
+func caReadyzCheck(ca caHealthChecker) healthz.Checker {
+	return func(_ *http.Request) error {
+		return ca.Healthy()
 	}
 }
 

--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -204,9 +204,10 @@ func main() {
 		os.Exit(1)
 	}
 	// Gate readiness on the CA's watcher/reload health: a replica that can no
-	// longer observe CA rotations (or whose most recent reload failed) must be
-	// pulled from readiness so it is not relied upon to publish or sign with
-	// stale material.
+	// longer observe CA rotations, or whose reloads have been failing
+	// persistently, must be pulled from readiness so it is not relied upon to
+	// publish or sign with stale material. A transient reload failure keeps the
+	// replica ready, since the last-good CA is retained and signing works.
 	if err := mgr.AddReadyzCheck("readyz", caReadyzCheck(ca)); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)

--- a/cmd/podcertificate-signer/main_test.go
+++ b/cmd/podcertificate-signer/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -114,5 +115,25 @@ func TestCARunnablesLeaderElection(t *testing.T) {
 	}
 	if !leaderGated(publisher) {
 		t.Error("ctbPublisher is not leader-gated; want ClusterTrustBundle writes confined to the leader")
+	}
+}
+
+// stubHealth is a test double for the CA health surface consumed by the readyz
+// check.
+type stubHealth struct{ err error }
+
+func (s stubHealth) Healthy() error { return s.err }
+
+// TestCAReadyzCheck asserts that the readiness check passes when the CA reports
+// healthy and fails when it reports a watcher/reload problem, so a replica that
+// can no longer track CA rotations is removed from readiness.
+func TestCAReadyzCheck(t *testing.T) {
+	if err := caReadyzCheck(stubHealth{err: nil})(nil); err != nil {
+		t.Errorf("readyz check = %v, want nil when the CA is healthy", err)
+	}
+
+	want := errors.New("ca watcher is down")
+	if err := caReadyzCheck(stubHealth{err: want})(nil); err == nil {
+		t.Error("readyz check must fail when the CA reports unhealthy")
 	}
 }

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -53,14 +53,31 @@ type CertificateAuthority struct {
 	reloadAttempts int           // bounded retries for a single reload
 	reloadBackoff  time.Duration // base delay between reload attempts
 
-	// health tracks the most recent reload outcome and whether the watcher
-	// has exited unrecoverably. It is guarded by its own mutex (separate from
-	// mu) so a readiness probe can poll Healthy without contending with a
-	// reload in progress.
-	healthMu      sync.Mutex
-	lastReloadErr error
-	watcherErr    error
+	// health tracks the recent reload outcomes and whether the watcher has
+	// exited unrecoverably. It is guarded by its own mutex (separate from mu)
+	// so a readiness probe can poll Healthy without contending with a reload
+	// in progress.
+	healthMu         sync.Mutex
+	lastReloadErr    error
+	reloadFailures   int       // consecutive failed reload attempts
+	firstFailureTime time.Time // when the current failure streak started
+	watcherErr       error
 }
+
+// Readiness grace period for CA reload failures. A failed reload leaves the
+// last-good CA in place, so signing keeps working; failing readiness on the
+// first blip only flaps the replica in and out of the Service for a condition
+// that usually resolves on the next write. Readiness therefore fails only once
+// the CA has been unloadable persistently: both thresholds must be crossed.
+const (
+	// reloadFailureThreshold is the number of consecutive failed reload
+	// attempts required before readiness may fail.
+	reloadFailureThreshold = 3
+
+	// reloadFailureGracePeriod is how long the failure streak must have
+	// lasted, measured from its first failure, before readiness may fail.
+	reloadFailureGracePeriod = 10 * time.Minute
+)
 
 // WithBackDate is an [Option], which configures the [CertificateAuthority] to
 // use the given backdate when signing certificate requests.
@@ -381,13 +398,11 @@ func (ca *CertificateAuthority) watchLoop(
 			logger.Info("reloading CA certificate")
 			if err := ca.reloadWithRetry(ctx, logger); err != nil {
 				// The last-good CA is retained, so signing keeps working.
-				// Stay watching so a later good write recovers, but record
-				// the failure for the readiness probe.
+				// Stay watching so a later good write recovers; readiness is
+				// only affected once the failures persist (see Healthy).
 				logger.Error(err, "failed to reload CA certificate after retries")
-				ca.recordReloadResult(err)
 				continue
 			}
-			ca.recordReloadResult(nil)
 			logger.Info("CA certificate reloaded successfully")
 
 			// Don't block here, so that reloading the CA can proceed as
@@ -432,6 +447,7 @@ func (ca *CertificateAuthority) drainEvents(ctx context.Context, logger logr.Log
 // reloadWithRetry attempts to reload the CA, retrying on a bounded linear
 // backoff. A failed attempt leaves the last-good CA in place (see load), so
 // callers keep signing with the previous material until a good reload succeeds.
+// Every attempt is recorded for the readiness probe (see Healthy).
 // It returns nil on the first successful reload, ctx.Err() if ctx is canceled,
 // or the final error once the attempt budget is exhausted.
 func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr.Logger) error {
@@ -440,13 +456,23 @@ func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr
 	var err error
 	for attempt := 1; ; attempt++ {
 		if err = ca.load(); err == nil {
+			ca.recordReloadResult(nil)
+
 			return nil
 		}
+
+		// Record each failed attempt rather than only the exhausted burst:
+		// nothing reloads again until the next filesystem event, so a CA that
+		// stays unloadable must be able to cross the readiness threshold
+		// without one.
+		failures := ca.recordReloadResult(err)
 		if attempt >= ca.reloadAttempts {
-			return fmt.Errorf("reload failed after %d attempt(s): %w", attempt, err)
+			return fmt.Errorf("reload failed after %d attempt(s), %d consecutive failure(s): %w",
+				attempt, failures, err)
 		}
 		logger.Error(err, "failed to reload CA certificate, retrying",
-			"attempt", attempt, "maxAttempts", ca.reloadAttempts)
+			"attempt", attempt, "maxAttempts", ca.reloadAttempts,
+			"consecutiveFailures", failures)
 
 		timer := time.NewTimer(min(ca.reloadBackoff*time.Duration(attempt), maxBackoff))
 		select {
@@ -458,11 +484,37 @@ func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr
 	}
 }
 
-// recordReloadResult stores the outcome of the most recent reload attempt.
-func (ca *CertificateAuthority) recordReloadResult(err error) {
+// recordReloadResult stores the outcome of the most recent reload attempt and
+// returns the resulting number of consecutive failures, so callers can report
+// the streak alongside the failure. A successful reload clears the streak.
+func (ca *CertificateAuthority) recordReloadResult(err error) int {
 	ca.healthMu.Lock()
 	defer ca.healthMu.Unlock()
+
 	ca.lastReloadErr = err
+	if err == nil {
+		ca.reloadFailures = 0
+		ca.firstFailureTime = time.Time{}
+
+		return 0
+	}
+
+	if ca.reloadFailures == 0 {
+		ca.firstFailureTime = ca.now()
+	}
+	ca.reloadFailures++
+
+	return ca.reloadFailures
+}
+
+// now returns the current time from the configured clock, which tests replace
+// to exercise time-dependent behavior without sleeping.
+func (ca *CertificateAuthority) now() time.Time {
+	if ca.nowFunc != nil {
+		return ca.nowFunc()
+	}
+
+	return time.Now()
 }
 
 // failWatcher records the watcher's terminal error and returns it, so a caller
@@ -475,14 +527,29 @@ func (ca *CertificateAuthority) failWatcher(err error) error {
 }
 
 // Healthy reports whether the CA is still tracking its on-disk material. It
-// returns a non-nil error if the file watcher has exited unrecoverably or the
-// most recent reload attempt ultimately failed. It is safe for concurrent use
-// and is intended to back a readiness probe.
+// returns a non-nil error if the file watcher has exited unrecoverably, or if
+// reloads have been failing persistently: at least reloadFailureThreshold
+// consecutive attempts spanning at least reloadFailureGracePeriod. Reload
+// failures within that grace period are reported as healthy, because the
+// last-good CA is retained and signing keeps working. It is safe for concurrent
+// use and is intended to back a readiness probe.
 func (ca *CertificateAuthority) Healthy() error {
 	ca.healthMu.Lock()
 	defer ca.healthMu.Unlock()
+
+	// A dead watcher is not a transient file blip: CA rotations would never be
+	// observed again, so it fails readiness immediately.
 	if ca.watcherErr != nil {
 		return ca.watcherErr
 	}
-	return ca.lastReloadErr
+	if ca.lastReloadErr == nil || ca.reloadFailures < reloadFailureThreshold {
+		return nil
+	}
+	failingFor := ca.now().Sub(ca.firstFailureTime)
+	if failingFor < reloadFailureGracePeriod {
+		return nil
+	}
+
+	return fmt.Errorf("CA reload failing for %s across %d consecutive attempts: %w",
+		failingFor.Round(time.Second), ca.reloadFailures, ca.lastReloadErr)
 }

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/podcertificate"
@@ -46,6 +47,19 @@ type CertificateAuthority struct {
 	nowFunc              func() time.Time
 	backDate             time.Duration
 	mu                   sync.Mutex
+
+	// Watch/reload tuning. Set to sane defaults in New; overridable in tests.
+	drainWindow    time.Duration // coalesce window for a burst of fs events
+	reloadAttempts int           // bounded retries for a single reload
+	reloadBackoff  time.Duration // base delay between reload attempts
+
+	// health tracks the most recent reload outcome and whether the watcher
+	// has exited unrecoverably. It is guarded by its own mutex (separate from
+	// mu) so a readiness probe can poll Healthy without contending with a
+	// reload in progress.
+	healthMu      sync.Mutex
+	lastReloadErr error
+	watcherErr    error
 }
 
 // WithBackDate is an [Option], which configures the [CertificateAuthority] to
@@ -105,6 +119,9 @@ func New(caFile, caKeyFile string, opts ...Option) (*CertificateAuthority, error
 		nowFunc:              time.Now,
 		maxPreviousCerts:     1,
 		previousCertificates: make([]*x509.Certificate, 0),
+		drainWindow:          500 * time.Millisecond,
+		reloadAttempts:       5,
+		reloadBackoff:        200 * time.Millisecond,
 	}
 
 	// Additional configuration of the CA with the given options.
@@ -286,6 +303,10 @@ func (ca *CertificateAuthority) TrustBundlePEM() []byte {
 	return bundle
 }
 
+// errWatchChannelClosed indicates that fsnotify closed one of its channels.
+// This cannot be recovered in place, so the watcher must fail and be restarted.
+var errWatchChannelClosed = errors.New("ca-watcher: fsnotify channel closed unexpectedly")
+
 // Watch starts a [fsnotify.Watcher], which reloads the CA cert and private key
 // when the underlying files change.
 //
@@ -293,12 +314,15 @@ func (ca *CertificateAuthority) TrustBundlePEM() []byte {
 // If notifications are not needed, callers must provide nil as the notification
 // channel.
 //
-// This method blocks until the given [context.Context] is canceled.
+// This method blocks until the given [context.Context] is canceled. It returns
+// nil on a clean shutdown and a non-nil error if the watch cannot be
+// established or fsnotify closes a channel; in the latter case [Healthy] also
+// reports the failure so a readiness probe can surface it.
 func (ca *CertificateAuthority) Watch(ctx context.Context, notify chan<- struct{}) error {
 	logger := log.FromContext(ctx).WithName("ca-watcher")
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return fmt.Errorf("ca-watcher: unable to create fsnotify.Watcher: %w", err)
+		return ca.failWatcher(fmt.Errorf("ca-watcher: unable to create fsnotify.Watcher: %w", err))
 	}
 	defer watcher.Close() // nolint:errcheck
 
@@ -311,58 +335,154 @@ func (ca *CertificateAuthority) Watch(ctx context.Context, notify chan<- struct{
 	for _, path := range slices.Compact(paths) {
 		logger.Info("watching CA directory for changes", "path", path)
 		if err := watcher.Add(path); err != nil {
-			return fmt.Errorf("ca-watcher: unable to add watch directory %s: %w", path, err)
+			return ca.failWatcher(fmt.Errorf("ca-watcher: unable to add watch directory %s: %w", path, err))
 		}
 	}
 
-L:
+	return ca.watchLoop(ctx, logger, watcher.Events, watcher.Errors, notify)
+}
+
+// watchLoop consumes filesystem events until ctx is canceled, reloading the CA
+// (with bounded retry) whenever the mounted files change. It returns nil on a
+// clean shutdown (ctx canceled) and a non-nil error if fsnotify closes a
+// channel, so the caller can fail fast and be restarted rather than spinning on
+// zero values read from a closed channel.
+func (ca *CertificateAuthority) watchLoop(
+	ctx context.Context,
+	logger logr.Logger,
+	events <-chan fsnotify.Event,
+	errs <-chan error,
+	notify chan<- struct{},
+) error {
 	for {
 		select {
 		case <-ctx.Done():
-			break L
-		case event := <-watcher.Events:
+			return nil
+		case event, ok := <-events:
+			if !ok {
+				return ca.failWatcher(errWatchChannelClosed)
+			}
 			if !event.Has(fsnotify.Create) && !event.Has(fsnotify.Write) && !event.Has(fsnotify.Rename) {
 				continue
 			}
 
-			// Drain the filesystem events channel in order to avoid
-			// needless reloads in a short time window, as multiple
-			// events will be triggered when the CA cert and key are
-			// updated.
-			draining := true
-			drainTimer := time.NewTimer(500 * time.Millisecond)
-			for draining {
-				select {
-				case <-ctx.Done():
-					drainTimer.Stop()
-					break L
-				case e := <-watcher.Events:
-					logger.V(1).Info("draining fsnotify event", "event", e.Op.String(), "name", e.Name)
-					continue
-				case <-drainTimer.C:
-					draining = false
-				}
+			// Coalesce the burst of events a single (near-atomic) CA update
+			// produces before reloading.
+			switch err := ca.drainEvents(ctx, logger, events); {
+			case err == nil:
+				// Burst settled; fall through to reload.
+			case errors.Is(err, errWatchChannelClosed):
+				return ca.failWatcher(err)
+			default:
+				// ctx canceled while draining.
+				return nil
 			}
 
 			logger.Info("reloading CA certificate")
-			if err := ca.load(); err != nil {
-				logger.Error(err, "failed to reload CA certificate")
+			if err := ca.reloadWithRetry(ctx, logger); err != nil {
+				// The last-good CA is retained, so signing keeps working.
+				// Stay watching so a later good write recovers, but record
+				// the failure for the readiness probe.
+				logger.Error(err, "failed to reload CA certificate after retries")
+				ca.recordReloadResult(err)
 				continue
 			}
-
-			// Don't block here, so that reloading the CA can
-			// proceed as usual, even if we have slow consumers.
+			ca.recordReloadResult(nil)
 			logger.Info("CA certificate reloaded successfully")
+
+			// Don't block here, so that reloading the CA can proceed as
+			// usual, even if we have slow consumers.
 			if notify != nil {
 				select {
 				case notify <- struct{}{}:
 				default:
 				}
 			}
-		case err := <-watcher.Errors:
+		case err, ok := <-errs:
+			if !ok {
+				return ca.failWatcher(errWatchChannelClosed)
+			}
 			logger.Error(err, "error watching CA certificate")
 		}
 	}
+}
 
-	return nil
+// drainEvents coalesces a burst of filesystem events into a single reload. It
+// returns nil once the burst settles (drain window elapses), ctx.Err() if ctx
+// is canceled, or errWatchChannelClosed if the events channel is closed.
+func (ca *CertificateAuthority) drainEvents(ctx context.Context, logger logr.Logger, events <-chan fsnotify.Event) error {
+	timer := time.NewTimer(ca.drainWindow)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case e, ok := <-events:
+			if !ok {
+				return errWatchChannelClosed
+			}
+			logger.V(1).Info("draining fsnotify event", "event", e.Op.String(), "name", e.Name)
+		case <-timer.C:
+			return nil
+		}
+	}
+}
+
+// reloadWithRetry attempts to reload the CA, retrying on a bounded linear
+// backoff. A failed attempt leaves the last-good CA in place (see load), so
+// callers keep signing with the previous material until a good reload succeeds.
+// It returns nil on the first successful reload, ctx.Err() if ctx is canceled,
+// or the final error once the attempt budget is exhausted.
+func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr.Logger) error {
+	const maxBackoff = 5 * time.Second
+
+	var err error
+	for attempt := 1; ; attempt++ {
+		if err = ca.load(); err == nil {
+			return nil
+		}
+		if attempt >= ca.reloadAttempts {
+			return fmt.Errorf("reload failed after %d attempt(s): %w", attempt, err)
+		}
+		logger.Error(err, "failed to reload CA certificate, retrying",
+			"attempt", attempt, "maxAttempts", ca.reloadAttempts)
+
+		timer := time.NewTimer(min(ca.reloadBackoff*time.Duration(attempt), maxBackoff))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// recordReloadResult stores the outcome of the most recent reload attempt.
+func (ca *CertificateAuthority) recordReloadResult(err error) {
+	ca.healthMu.Lock()
+	defer ca.healthMu.Unlock()
+	ca.lastReloadErr = err
+}
+
+// failWatcher records the watcher's terminal error and returns it, so a caller
+// can surface health and fail its runnable in a single step.
+func (ca *CertificateAuthority) failWatcher(err error) error {
+	ca.healthMu.Lock()
+	ca.watcherErr = err
+	ca.healthMu.Unlock()
+	return err
+}
+
+// Healthy reports whether the CA is still tracking its on-disk material. It
+// returns a non-nil error if the file watcher has exited unrecoverably or the
+// most recent reload attempt ultimately failed. It is safe for concurrent use
+// and is intended to back a readiness probe.
+func (ca *CertificateAuthority) Healthy() error {
+	ca.healthMu.Lock()
+	defer ca.healthMu.Unlock()
+	if ca.watcherErr != nil {
+		return ca.watcherErr
+	}
+	return ca.lastReloadErr
 }

--- a/internal/kubernetes/authority/authority_readiness_test.go
+++ b/internal/kubernetes/authority/authority_readiness_test.go
@@ -1,0 +1,202 @@
+package authority
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/testutil"
+)
+
+// fakeClock is a manually advanced clock, so the readiness grace period can be
+// exercised without sleeping. Its Now method is safe for concurrent use.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.now
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.now = c.now.Add(d)
+}
+
+// newTestCA returns a CA backed by freshly generated material on disk, wired to
+// the given clock for its health bookkeeping, along with the directory holding
+// that material so tests can rewrite it.
+func newTestCA(t *testing.T, clock *fakeClock) (*CertificateAuthority, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeCA(t, dir, "ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ca.nowFunc = clock.Now
+
+	return ca, dir
+}
+
+// Readiness must tolerate a transient CA reload failure: the last-good CA is
+// retained and signing keeps working, so pulling the replica out of the Service
+// on the first blip only causes flapping. Readiness fails only once the CA has
+// been unloadable persistently, which is both at least 3 consecutive failed
+// reload attempts and at least 10 minutes since the first of them.
+func TestHealthyGracePeriodForReloadFailures(t *testing.T) {
+	reloadErr := errors.New("failed to load key pair")
+
+	tests := []struct {
+		name         string
+		failures     int
+		elapsed      time.Duration
+		thenSucceeds bool
+		wantHealthy  bool
+	}{
+		{
+			name:        "single transient failure stays ready",
+			failures:    1,
+			wantHealthy: true,
+		},
+		{
+			name:        "single failure long past the grace period stays ready",
+			failures:    1,
+			elapsed:     30 * time.Minute,
+			wantHealthy: true,
+		},
+		{
+			name:        "threshold reached within the grace period stays ready",
+			failures:    3,
+			elapsed:     5 * time.Minute,
+			wantHealthy: true,
+		},
+		{
+			name:        "threshold reached and grace period elapsed fails readiness",
+			failures:    3,
+			elapsed:     10 * time.Minute,
+			wantHealthy: false,
+		},
+		{
+			name:        "sustained failures well past the grace period fail readiness",
+			failures:    5,
+			elapsed:     30 * time.Minute,
+			wantHealthy: false,
+		},
+		{
+			name:         "successful reload resets the failure streak",
+			failures:     5,
+			elapsed:      30 * time.Minute,
+			thenSucceeds: true,
+			wantHealthy:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := newFakeClock()
+			ca, _ := newTestCA(t, clock)
+
+			// Record the first failure, let the clock run, then record the
+			// remaining ones: the elapsed guard must be measured from the
+			// first failure and must not be reset by later failures.
+			if tt.failures > 0 {
+				ca.recordReloadResult(reloadErr)
+				clock.advance(tt.elapsed)
+				for i := 1; i < tt.failures; i++ {
+					ca.recordReloadResult(reloadErr)
+				}
+			}
+			if tt.thenSucceeds {
+				ca.recordReloadResult(nil)
+			}
+
+			err := ca.Healthy()
+			if gotHealthy := err == nil; gotHealthy != tt.wantHealthy {
+				t.Errorf("Healthy() after %d failure(s) over %v = %v, want healthy = %t",
+					tt.failures, tt.elapsed, err, tt.wantHealthy)
+			}
+		})
+	}
+}
+
+// The grace period must be reachable in production, not just by poking the
+// health bookkeeping directly: a CA that stays unloadable across a full retry
+// budget must eventually fail readiness once the grace period elapses.
+func TestPersistentlyUnloadableCAEventuallyFailsReadiness(t *testing.T) {
+	clock := newFakeClock()
+	ca, dir := newTestCA(t, clock)
+	ca.reloadAttempts = 3
+	ca.reloadBackoff = time.Millisecond
+
+	// Permanently bad material on disk: a non-CA certificate.
+	nonCA, err := testutil.NewNonCA("not-a-ca.example.org", time.Hour)
+	if err != nil {
+		t.Fatalf("generate non-CA: %v", err)
+	}
+	if _, _, err := nonCA.WriteFiles(dir); err != nil {
+		t.Fatalf("write non-CA files: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := ca.reloadWithRetry(ctx, log.FromContext(ctx)); err == nil {
+		t.Fatal("reloadWithRetry() = nil, want error for a permanently unloadable CA")
+	}
+
+	// Still inside the grace window: the last-good CA keeps signing, so the
+	// replica must stay ready.
+	if err := ca.Healthy(); err != nil {
+		t.Errorf("Healthy() immediately after a failed reload = %v, want nil", err)
+	}
+
+	clock.advance(10 * time.Minute)
+	if err := ca.Healthy(); err == nil {
+		t.Error("Healthy() = nil after the grace period elapsed, want an error")
+	}
+}
+
+// A dead watcher is a real failure rather than a transient file blip: the CA
+// can no longer observe rotations at all, so readiness must fail immediately
+// without waiting out the reload grace period.
+func TestHealthyFailsImmediatelyOnWatcherExit(t *testing.T) {
+	clock := newFakeClock()
+	ca, _ := newTestCA(t, clock)
+
+	events := make(chan fsnotify.Event)
+	errs := make(chan error) // open, never sends
+	close(events)
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() { done <- ca.watchLoop(ctx, log.FromContext(ctx), events, errs, nil) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, errWatchChannelClosed) {
+			t.Fatalf("watchLoop() = %v, want %v", err, errWatchChannelClosed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchLoop did not return after the events channel closed")
+	}
+
+	// No clock advance: the watcher error is not subject to the grace period.
+	if err := ca.Healthy(); !errors.Is(err, errWatchChannelClosed) {
+		t.Errorf("Healthy() after the watcher exited = %v, want %v", err, errWatchChannelClosed)
+	}
+}

--- a/internal/kubernetes/authority/authority_recovery_test.go
+++ b/internal/kubernetes/authority/authority_recovery_test.go
@@ -1,0 +1,211 @@
+package authority
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/testutil"
+)
+
+// A failed reload must not discard the in-memory CA; a later good write must
+// reload cleanly. Retaining the last-good CA keeps signing working across a
+// transient bad update on disk.
+func TestReloadRetainsLastGoodCAOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	good := writeCA(t, dir, "good-ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Overwrite with a non-CA certificate: the reload must fail.
+	nonCA, err := testutil.NewNonCA("not-a-ca.example.org", time.Hour)
+	if err != nil {
+		t.Fatalf("generate non-CA: %v", err)
+	}
+	if _, _, err := nonCA.WriteFiles(dir); err != nil {
+		t.Fatalf("write non-CA files: %v", err)
+	}
+
+	if err := ca.load(); err == nil {
+		t.Fatal("want error reloading a non-CA certificate")
+	}
+	if got := parseChain(t, ca.TrustBundlePEM()); len(got) == 0 || !got[0].Equal(good.Cert) {
+		t.Fatal("must retain the last-good CA after a failed reload")
+	}
+
+	// A subsequent good write must reload.
+	good2 := writeCA(t, dir, "good-ca-2.example.org", 24*time.Hour)
+	if err := ca.load(); err != nil {
+		t.Fatalf("reload after good write: %v", err)
+	}
+	if got := parseChain(t, ca.TrustBundlePEM()); !got[0].Equal(good2.Cert) {
+		t.Fatal("must reload the new good CA")
+	}
+}
+
+// A mismatched cert/key pair on disk (e.g. observed mid-rotation, before the
+// key catches up) must be retried, not abandoned, so an eventually-consistent
+// good pair is picked up.
+func TestReloadWithRetryRecoversFromTransientBadPair(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "good-ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ca.reloadBackoff = 20 * time.Millisecond
+	ca.reloadAttempts = 100
+
+	// Write a mismatched pair: certificate of one CA, key of another. This
+	// fails tls.LoadX509KeyPair's public/private key consistency check.
+	a, err := testutil.NewCA("a.example.org", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("generate CA a: %v", err)
+	}
+	b, err := testutil.NewCA("b.example.org", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("generate CA b: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), a.CertPEM, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), b.KeyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if err := ca.load(); err == nil {
+		t.Fatal("want error for mismatched key pair")
+	}
+
+	// After a short delay a consistent good pair appears on disk.
+	rotated, err := testutil.NewCA("recovered.example.org", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("generate rotated CA: %v", err)
+	}
+	go func() {
+		time.Sleep(120 * time.Millisecond)
+		_ = os.WriteFile(filepath.Join(dir, "tls.key"), rotated.KeyPEM, 0o600)
+		_ = os.WriteFile(filepath.Join(dir, "tls.crt"), rotated.CertPEM, 0o600)
+	}()
+
+	ctx := context.Background()
+	if err := ca.reloadWithRetry(ctx, log.FromContext(ctx)); err != nil {
+		t.Fatalf("reloadWithRetry did not recover from a transient bad pair: %v", err)
+	}
+	if got := parseChain(t, ca.TrustBundlePEM()); !got[0].Equal(rotated.Cert) {
+		t.Fatal("must load the recovered CA after retrying")
+	}
+}
+
+// reloadWithRetry must give up (and stop looping) once ctx is canceled, rather
+// than blocking forever on a permanently bad pair.
+func TestReloadWithRetryHonorsContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "good-ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ca.reloadBackoff = 50 * time.Millisecond
+	ca.reloadAttempts = 1_000_000
+
+	// Permanently bad: a non-CA certificate.
+	nonCA, err := testutil.NewNonCA("bad.example.org", time.Hour)
+	if err != nil {
+		t.Fatalf("generate non-CA: %v", err)
+	}
+	if _, _, err := nonCA.WriteFiles(dir); err != nil {
+		t.Fatalf("write non-CA files: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- ca.reloadWithRetry(ctx, log.FromContext(ctx)) }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("reloadWithRetry must return an error when it cannot reload before ctx is canceled")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reloadWithRetry ignored context cancellation")
+	}
+}
+
+// A closed fsnotify events channel must terminate the watch loop promptly and
+// mark the CA unhealthy, rather than spinning on zero values.
+func TestWatchLoopReturnsOnClosedEventsChannel(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	events := make(chan fsnotify.Event)
+	errs := make(chan error) // open, never sends
+	close(events)
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() { done <- ca.watchLoop(ctx, log.FromContext(ctx), events, errs, nil) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("watchLoop must return an error when the events channel closes")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchLoop spun on a closed events channel instead of returning")
+	}
+	if ca.Healthy() == nil {
+		t.Error("Healthy must report the failure after the watch loop dies")
+	}
+}
+
+// A closed fsnotify errors channel must likewise terminate the watch loop.
+func TestWatchLoopReturnsOnClosedErrorsChannel(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	events := make(chan fsnotify.Event) // open, never sends
+	errs := make(chan error)
+	close(errs)
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() { done <- ca.watchLoop(ctx, log.FromContext(ctx), events, errs, nil) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("watchLoop must return an error when the errors channel closes")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchLoop spun on a closed errors channel instead of returning")
+	}
+}
+
+// A freshly-loaded CA with a live watch loop must report healthy.
+func TestHealthyReportsNilForLiveCA(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := ca.Healthy(); err != nil {
+		t.Errorf("Healthy = %v, want nil for a freshly-loaded CA", err)
+	}
+}


### PR DESCRIPTION
Implements #32 — part of the **code-quality-review** epic (#25).

Makes CA hot-reload failures recoverable and observable instead of silently abandoning them.

### Stack
- **Base branch:** `code-quality/ungate-ca-watch`
- **Stack parent PR:** #41
- **Merge only after:** #41

### Changes
- `Watch` delegates to `watchLoop`, which treats a **closed** fsnotify Events/Errors channel as `errWatchChannelClosed` (fails the runnable → manager stops → k8s restarts) instead of spinning on zero values.
- `reloadWithRetry` retries a failed reload on bounded backoff; last-good CA is retained on failure (now pinned by a test).
- `Healthy() error` surfaces watcher exit / last reload error, wired to a `readyz` check.

### Review note (design choice to confirm)
`Healthy()` currently includes `lastReloadErr`, so a persistently-unloadable CA fails readiness **even though signing still works from the retained last-good CA** — i.e. it pulls a still-functional signer from Service endpoints. Flagging for a fail-visible vs keep-serving decision.

### TDD evidence
`internal/kubernetes/authority/authority_recovery_test.go` — RED → GREEN under `-race`.

Closes #32
