### PR TITLE
fix(#30): fail closed instead of dropping CA history on read error

### DIFF
--- a/cmd/podcertificate-signer/bootstrap_test.go
+++ b/cmd/podcertificate-signer/bootstrap_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/signer"
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/testutil"
+)
+
+const testSignerName = "example.org/signer"
+
+// A missing ClusterTrustBundle is the normal first-run state and must yield an
+// empty history with no error, not an error.
+func TestFetchPreviousCAsNotFoundIsEmptyHistory(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).Build()
+
+	certs, err := fetchPreviousCAs(context.Background(), c, testSignerName)
+	if err != nil {
+		t.Fatalf("fetchPreviousCAs returned error for a missing bundle: %v", err)
+	}
+	if len(certs) != 0 {
+		t.Fatalf("history = %d certs, want 0 for a missing bundle", len(certs))
+	}
+}
+
+// A transient (non-NotFound) read error must be returned so startup can retry
+// or fail closed, rather than silently returning an empty history that would
+// overwrite the ClusterTrustBundle and drop previously-trusted CAs.
+func TestFetchPreviousCAsTransientErrorIsReturned(t *testing.T) {
+	wantErr := errors.New("etcdserver: request timed out")
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return wantErr
+			},
+		}).
+		Build()
+
+	certs, err := fetchPreviousCAs(context.Background(), c, testSignerName)
+	if err == nil {
+		t.Fatal("fetchPreviousCAs must return an error on a transient read failure, not silently drop CA history")
+	}
+	if apierrors.IsNotFound(err) {
+		t.Fatalf("transient error must not be reported as NotFound: %v", err)
+	}
+	if certs != nil {
+		t.Fatalf("history = %v, want nil on error", certs)
+	}
+}
+
+// An existing ClusterTrustBundle must be parsed into the previous-CA history so
+// trust is retained across restarts.
+func TestFetchPreviousCAsParsesExistingBundle(t *testing.T) {
+	ca, err := testutil.NewCA("existing-ca.example.org", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("generate CA: %v", err)
+	}
+
+	bundle := &certificatesv1beta1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: signer.ClusterTrustBundleName(testSignerName)},
+		Spec: certificatesv1beta1.ClusterTrustBundleSpec{
+			SignerName:  testSignerName,
+			TrustBundle: string(ca.CertPEM),
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithObjects(bundle).
+		Build()
+
+	certs, err := fetchPreviousCAs(context.Background(), c, testSignerName)
+	if err != nil {
+		t.Fatalf("fetchPreviousCAs: %v", err)
+	}
+	if len(certs) != 1 || !certs[0].Equal(ca.Cert) {
+		t.Fatalf("history = %v, want the single seeded CA", certs)
+	}
+}

--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -38,6 +38,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -150,7 +151,26 @@ func main() {
 		setupLog.Error(err, "unable to create API client")
 		os.Exit(1)
 	}
-	previousCAs := fetchPreviousCAs(ctx, c, signerName)
+	// Read the previous-CA history with bounded retry. A transient read error
+	// must not fall through to an empty history: publishing an empty bundle
+	// would drop previously-trusted CAs. If the history cannot be read, fail
+	// closed rather than risk overwriting the ClusterTrustBundle.
+	bootstrapBackoff := wait.Backoff{
+		Steps:    5,
+		Duration: 500 * time.Millisecond,
+		Factor:   2.0,
+		Jitter:   0.1,
+	}
+	var previousCAs []*x509.Certificate
+	if err := retry.OnError(bootstrapBackoff, func(error) bool { return true }, func() error {
+		var ferr error
+		previousCAs, ferr = fetchPreviousCAs(ctx, c, signerName)
+		return ferr
+	}); err != nil {
+		setupLog.Error(err, "unable to read existing CA history from ClusterTrustBundle; "+
+			"refusing to start to avoid dropping previously-trusted CAs")
+		os.Exit(1)
+	}
 	ca, err := authority.New(
 		caCertPath,
 		caKeyPath,
@@ -384,26 +404,30 @@ func displayCommandlineFlags() {
 	})
 }
 
-// fetchPreviousCAs attempts to read the existing ClusterTrustBundle for the
-// given signer and parse its PEM certificates. Returns nil if the bundle does
-// not exist or cannot be read.
-func fetchPreviousCAs(ctx context.Context, c client.Client, signerName string) []*x509.Certificate {
+// fetchPreviousCAs reads the existing ClusterTrustBundle for the given signer
+// and parses its PEM certificates, so previously-trusted CAs are retained
+// across a restart.
+//
+// A missing bundle is the normal first-run state and yields an empty history
+// with a nil error. Any other read error is returned so the caller can retry
+// or fail closed: silently returning an empty history would overwrite the
+// bundle on startup and drop previously-trusted CAs.
+func fetchPreviousCAs(ctx context.Context, c client.Client, signerName string) ([]*x509.Certificate, error) {
 	bundleName := signer.ClusterTrustBundleName(signerName)
 
 	bundle := &certificatesv1beta1.ClusterTrustBundle{}
 	if err := c.Get(ctx, client.ObjectKey{Name: bundleName}, bundle); err != nil {
 		if apierrors.IsNotFound(err) {
 			setupLog.Info("no existing ClusterTrustBundle found, starting with empty CA history", "name", bundleName)
-		} else {
-			setupLog.Error(err, "unable to read existing ClusterTrustBundle, starting with empty CA history", "name", bundleName)
+			return nil, nil
 		}
-		return nil
+		return nil, fmt.Errorf("read existing ClusterTrustBundle %q: %w", bundleName, err)
 	}
 
 	certs := parsePEMCertificates([]byte(bundle.Spec.TrustBundle))
 	setupLog.Info("bootstrapped previous CA certificates from ClusterTrustBundle", "name", bundleName, "count", len(certs))
 
-	return certs
+	return certs, nil
 }
 
 // parsePEMCertificates extracts x509 certificates from a PEM-encoded bundle.


### PR DESCRIPTION
Implements #30 — part of the **code-quality-review** epic (#25).

Stops a transient startup read error from silently dropping previously-trusted CAs out of the ClusterTrustBundle.

### Stack
- **Base branch:** `code-quality/watcher-recovery`
- **Stack parent PR:** #45
- **Merge only after:** #45 (and its parent #41)

### Changes
- `fetchPreviousCAs` now returns `([]*x509.Certificate, error)`; **only NotFound → empty history**, any other read error is returned.
- Startup wraps it in bounded exponential backoff and `os.Exit(1)` if history can't be read — fail-closed rather than overwrite the bundle with the current CA only. Existing CTB contents are not merged during mutate (preserves pruning).

### TDD evidence
`cmd/podcertificate-signer/bootstrap_test.go` `TestFetchPreviousCAs` (RED: signature mismatch; transient error silently empty) → GREEN.

Closes #30
