### PR TITLE
fix(#31): reconcile the ClusterTrustBundle durably with retry and drift repair

### DIFF
--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -25,11 +25,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -48,6 +50,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/controller"
@@ -67,6 +70,7 @@ const (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	metrics.Registry.MustRegister(ctbPublishFailuresTotal)
 
 	// +kubebuilder:scaffold:scheme
 }
@@ -232,6 +236,13 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
+	// Also gate readiness on the ClusterTrustBundle publisher: a leader whose
+	// publishes keep failing must be pulled from readiness so the failure is
+	// visible and traffic/leadership can move elsewhere.
+	if err := mgr.AddReadyzCheck("clustertrustbundle", caReadyzCheck(ctbUpdater)); err != nil {
+		setupLog.Error(err, "unable to set up ClusterTrustBundle ready check")
+		os.Exit(1)
+	}
 
 	displayCommandlineFlags()
 
@@ -331,30 +342,63 @@ func (r *caWatchRunnable) Start(ctx context.Context) error {
 // NeedLeaderElection reports false so the CA watcher runs on every replica.
 func (*caWatchRunnable) NeedLeaderElection() bool { return false }
 
-// ctbPublisher keeps the signer's ClusterTrustBundle in sync with the current
-// CA. It publishes once when it starts and again on every CA reload event. It
+// ctbDriftRepairInterval is how often the publisher re-publishes the
+// ClusterTrustBundle even without a CA reload event, to repair external drift
+// (e.g. a manual edit or a lost event).
+const ctbDriftRepairInterval = 10 * time.Minute
+
+// ctbPublishFailuresTotal counts ClusterTrustBundle publish attempts that
+// failed after exhausting their retry budget. It is registered with the
+// controller-runtime metrics registry so it is scraped on the manager's
+// metrics endpoint.
+var ctbPublishFailuresTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "ctb_publish_failures_total",
+	Help: "Total number of ClusterTrustBundle publish attempts that failed after retries.",
+})
+
+// ctbPublisher reconciles the signer's ClusterTrustBundle towards the current
+// CA. It publishes when it starts, on every CA reload event, and on a periodic
+// drift-repair tick. Publishes are retried with exponential backoff and are
+// single-flight (a reconcile triggered while one is in flight is coalesced). It
 // is leader-gated so only the elected leader writes the shared resource.
 type ctbPublisher struct {
-	client client.Client
-	signer *signer.Signer
-	ca     *authority.CertificateAuthority
-	events <-chan struct{}
+	client   client.Client
+	signer   *signer.Signer
+	ca       *authority.CertificateAuthority
+	events   <-chan struct{}
+	interval time.Duration
+	backoff  wait.Backoff
+	failures prometheus.Counter
+
+	// runMu is a single-flight guard: TryLock lets a reconcile skip when
+	// another is already publishing.
+	runMu sync.Mutex
+
+	// healthMu guards the most recent publish outcome, polled by readiness.
+	healthMu       sync.Mutex
+	lastPublishErr error
 }
 
 // Start publishes the ClusterTrustBundle on startup, so a newly-elected leader
-// publishes from the current in-memory CA, and then again on every CA reload
-// event, until ctx is canceled.
+// publishes from the current in-memory CA, then on every CA reload event and on
+// a periodic drift-repair tick, until ctx is canceled.
 func (r *ctbPublisher) Start(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName("cluster-trust-bundle")
-	logger.Info("starting ClusterTrustBundle updater")
+	logger.Info("starting ClusterTrustBundle publisher", "driftRepairInterval", r.interval)
 
-	r.publish(ctx, logger)
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	r.reconcile(ctx, logger)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-r.events:
-			r.publish(ctx, logger)
+			r.reconcile(ctx, logger)
+		case <-ticker.C:
+			// Periodic drift repair, independent of fsnotify events.
+			r.reconcile(ctx, logger)
 		}
 	}
 }
@@ -363,25 +407,62 @@ func (r *ctbPublisher) Start(ctx context.Context) error {
 // ClusterTrustBundle.
 func (*ctbPublisher) NeedLeaderElection() bool { return true }
 
-// publish reconciles the ClusterTrustBundle to the current CA trust bundle,
-// retrying on optimistic-concurrency conflicts.
-func (r *ctbPublisher) publish(ctx context.Context, logger logr.Logger) {
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		logger.Info("updating ClusterTrustBundle with new CA certificate")
-		bundle := r.signer.ClusterTrustBundle()
-		// Use the direct API client: reading through the manager's
-		// cache-backed client would start an informer for ClusterTrustBundles,
-		// which requires list/watch RBAC permissions this controller does not
-		// need.
-		_, err := controllerutil.CreateOrPatch(ctx, r.client, bundle, func() error {
-			bundle.Spec.TrustBundle = string(r.ca.TrustBundlePEM())
-			return nil
-		})
-		return err
+// reconcile publishes the current CA trust bundle to the ClusterTrustBundle,
+// retrying with exponential backoff. It is single-flight: if a publish is
+// already in flight the call is skipped, since the in-flight publish will use
+// the latest in-memory CA state anyway. It returns true if a publish ran and
+// false if it was skipped.
+func (r *ctbPublisher) reconcile(ctx context.Context, logger logr.Logger) bool {
+	if !r.runMu.TryLock() {
+		logger.V(1).Info("ClusterTrustBundle publish already in progress, skipping")
+		return false
+	}
+	defer r.runMu.Unlock()
+
+	err := retry.OnError(r.backoff, func(error) bool { return true }, func() error {
+		return r.publishOnce(ctx, logger)
+	})
+	r.recordPublishResult(err)
+	if err != nil {
+		r.failures.Inc()
+		logger.Error(err, "unable to update ClusterTrustBundle after retries")
+	}
+	return true
+}
+
+// publishOnce performs a single CreateOrPatch of the ClusterTrustBundle to the
+// current CA trust bundle. The mutate function overwrites (never merges) the
+// trust bundle, so CA pruning in the rolling window is preserved.
+func (r *ctbPublisher) publishOnce(ctx context.Context, logger logr.Logger) error {
+	bundle := r.signer.ClusterTrustBundle()
+	// Use the direct API client: reading through the manager's cache-backed
+	// client would start an informer for ClusterTrustBundles, which requires
+	// list/watch RBAC permissions this controller does not need.
+	op, err := controllerutil.CreateOrPatch(ctx, r.client, bundle, func() error {
+		bundle.Spec.TrustBundle = string(r.ca.TrustBundlePEM())
+		return nil
 	})
 	if err != nil {
-		logger.Error(err, "unable to update ClusterTrustBundle")
+		return err
 	}
+	logger.Info("reconciled ClusterTrustBundle", "name", bundle.Name, "operation", op)
+	return nil
+}
+
+// recordPublishResult stores the outcome of the most recent reconcile.
+func (r *ctbPublisher) recordPublishResult(err error) {
+	r.healthMu.Lock()
+	defer r.healthMu.Unlock()
+	r.lastPublishErr = err
+}
+
+// Healthy reports a non-nil error when the most recent ClusterTrustBundle
+// publish failed after retries, so a persistently failing publisher fails
+// readiness. It is safe for concurrent use.
+func (r *ctbPublisher) Healthy() error {
+	r.healthMu.Lock()
+	defer r.healthMu.Unlock()
+	return r.lastPublishErr
 }
 
 // newCARunnables wires the CA file watcher and the ClusterTrustBundle publisher
@@ -390,7 +471,20 @@ func (r *ctbPublisher) publish(ctx context.Context, logger logr.Logger) {
 func newCARunnables(c client.Client, s *signer.Signer, ca *authority.CertificateAuthority) (*caWatchRunnable, *ctbPublisher) {
 	events := make(chan struct{}, 2)
 	watcher := &caWatchRunnable{ca: ca, notify: events}
-	publisher := &ctbPublisher{client: c, signer: s, ca: ca, events: events}
+	publisher := &ctbPublisher{
+		client:   c,
+		signer:   s,
+		ca:       ca,
+		events:   events,
+		interval: ctbDriftRepairInterval,
+		backoff: wait.Backoff{
+			Steps:    5,
+			Duration: 500 * time.Millisecond,
+			Factor:   2.0,
+			Jitter:   0.1,
+		},
+		failures: ctbPublishFailuresTotal,
+	}
 	return watcher, publisher
 }
 

--- a/cmd/podcertificate-signer/reconcile_test.go
+++ b/cmd/podcertificate-signer/reconcile_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"

--- a/cmd/podcertificate-signer/reconcile_test.go
+++ b/cmd/podcertificate-signer/reconcile_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/authority"
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/signer"
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/testutil"
+)
+
+// newTestPublisher builds a ctbPublisher backed by a real CA and signer, and
+// the given client, with fast retry/tick settings suitable for tests.
+func newTestPublisher(t *testing.T, c client.Client) *ctbPublisher {
+	t.Helper()
+
+	dir := t.TempDir()
+	kp, err := testutil.NewCA("ca.example.org", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("generate CA: %v", err)
+	}
+	if _, _, err := kp.WriteFiles(dir); err != nil {
+		t.Fatalf("write CA files: %v", err)
+	}
+	ca, err := authority.New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("authority.New: %v", err)
+	}
+	s, err := signer.New(testSignerName, ca)
+	if err != nil {
+		t.Fatalf("signer.New: %v", err)
+	}
+
+	return &ctbPublisher{
+		client:   c,
+		signer:   s,
+		ca:       ca,
+		events:   make(chan struct{}),
+		interval: time.Hour,
+		backoff:  wait.Backoff{Steps: 8, Duration: time.Millisecond, Factor: 2.0},
+		failures: prometheus.NewCounter(prometheus.CounterOpts{Name: "test_ctb_publish_failures_total"}),
+	}
+}
+
+// A publish that fails transiently must be retried (with backoff) until it
+// succeeds, rather than being abandoned after a single attempt.
+func TestReconcileRetriesTransientFailure(t *testing.T) {
+	var getCalls atomic.Int32
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if getCalls.Add(1) <= 2 {
+					return errors.New("etcdserver: leader changed")
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	p := newTestPublisher(t, c)
+	ctx := context.Background()
+	if !p.reconcile(ctx, log.FromContext(ctx)) {
+		t.Fatal("reconcile should have run")
+	}
+
+	if got := getCalls.Load(); got < 3 {
+		t.Errorf("Get was called %d times, want >= 3 (transient failures retried)", got)
+	}
+	if err := p.Healthy(); err != nil {
+		t.Errorf("Healthy = %v, want nil after a successful retry", err)
+	}
+	if got := promtestutil.ToFloat64(p.failures); got != 0 {
+		t.Errorf("ctb_publish_failures_total = %v, want 0 after eventual success", got)
+	}
+}
+
+// The publisher must re-publish on a periodic tick, independent of any fsnotify
+// event, so drift in the ClusterTrustBundle is repaired even when the CA files
+// never change.
+func TestReconcileTickerRepairsDrift(t *testing.T) {
+	var getCalls atomic.Int32
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				getCalls.Add(1)
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	p := newTestPublisher(t, c)
+	p.interval = 20 * time.Millisecond // drift-repair tick, no events ever fire
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- p.Start(ctx) }()
+
+	// Initial publish plus at least one drift-repair tick, with no event sent.
+	deadline := time.After(2 * time.Second)
+	for getCalls.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("ticker did not repair drift: Get called %d times, want >= 2", getCalls.Load())
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+}
+
+// Only one publish may run at a time: a reconcile triggered while another is in
+// flight must be skipped (coalesced), not run concurrently.
+func TestReconcileSingleFlight(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				entered <- struct{}{}
+				<-release
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	p := newTestPublisher(t, c)
+	ctx := context.Background()
+
+	ran := make(chan bool, 1)
+	go func() { ran <- p.reconcile(ctx, log.FromContext(ctx)) }()
+
+	<-entered // first reconcile is inside the publish, holding the single-flight lock
+	if p.reconcile(ctx, log.FromContext(ctx)) {
+		t.Error("a concurrent reconcile must be skipped while a publish is in flight")
+	}
+
+	close(release)
+	if got := <-ran; !got {
+		t.Error("the first reconcile should report that it ran")
+	}
+}
+
+// A publish that keeps failing must be surfaced: the publisher becomes
+// unhealthy (failing readiness) and the ctb_publish_failures_total counter is
+// incremented.
+func TestReconcilePersistentFailureSurfaced(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return errors.New("etcdserver: request timed out")
+			},
+		}).
+		Build()
+
+	p := newTestPublisher(t, c)
+	ctx := context.Background()
+	p.reconcile(ctx, log.FromContext(ctx))
+
+	if p.Healthy() == nil {
+		t.Error("Healthy must report an error after a persistent publish failure")
+	}
+	if got := promtestutil.ToFloat64(p.failures); got < 1 {
+		t.Errorf("ctb_publish_failures_total = %v, want >= 1 after persistent failure", got)
+	}
+}
+
+// A successful publish after a failure must clear the unhealthy state.
+func TestReconcileClearsHealthOnSuccess(t *testing.T) {
+	var fail atomic.Bool
+	fail.Store(true)
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if fail.Load() {
+					return errors.New("transient")
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	p := newTestPublisher(t, c)
+	p.backoff = wait.Backoff{Steps: 2, Duration: time.Millisecond}
+	ctx := context.Background()
+
+	p.reconcile(ctx, log.FromContext(ctx))
+	if p.Healthy() == nil {
+		t.Fatal("Healthy must report an error while publishing keeps failing")
+	}
+
+	fail.Store(false)
+	p.reconcile(ctx, log.FromContext(ctx))
+	if err := p.Healthy(); err != nil {
+		t.Errorf("Healthy = %v, want nil after a successful publish", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
+	github.com/prometheus/client_golang v1.23.2
 	go.uber.org/zap v1.28.0
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
@@ -43,11 +44,11 @@ require (
 	github.com/google/pprof v0.0.0-20260507013755-92041b743c96 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect


### PR DESCRIPTION
Implements #31 — part of the **code-quality-review** epic (#25). Top of the CA/CTB reliability stack.

Makes ClusterTrustBundle publication a durable reconciliation instead of a one-shot that's abandoned on failure.

### Stack
- **Base branch:** `code-quality/ca-history-bootstrap`
- **Stack parent PR:** #46
- **Merge only after:** #46 (and its parents #45, #41)

### Changes
- `reconcile` = exponential-backoff retry + single-flight (`runMu.TryLock`), driven by a `time.Ticker` (10-min drift repair) as well as events.
- `publishOnce` logs the `CreateOrPatch` `OperationResult` and overwrites (never merges) `Spec.TrustBundle`, preserving pruning.
- Persistent failure surfaced via a `readyz` check and a `ctb_publish_failures_total` counter on the controller-runtime metrics registry.

### TDD evidence
`cmd/podcertificate-signer/reconcile_test.go` (retry, drift repair, single-flight, failure surfaced) — RED → GREEN under `-race`.

Closes #31
