### PR TITLE
test(#35): real feature-gated envtest reconcile suite

### DIFF
--- a/internal/controller/podcertificaterequest_controller_test.go
+++ b/internal/controller/podcertificaterequest_controller_test.go
@@ -29,20 +29,27 @@ import (
 
 	capiv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// durationAnnotation is the spec.unverifiedUserAnnotations key the signer
-// reads the requested certificate duration from. Spelled out here rather than
-// built from the podcertificate constants, which carry a deprecation notice
-// aimed at the pod-annotation fallback.
-const durationAnnotation = testSignerName + "-duration"
+const (
+	// durationAnnotation is the spec.unverifiedUserAnnotations key the signer
+	// reads the requested certificate duration from. Spelled out here rather
+	// than built from the podcertificate constants, which carry a deprecation
+	// notice aimed at the pod-annotation fallback.
+	durationAnnotation = testSignerName + "-duration"
+
+	// foreignSignerName belongs to no controller in this suite, so requests
+	// created under it are never reconciled.
+	foreignSignerName = "example.com/some-other-signer"
+)
 
 var _ = Describe("PodCertificateRequest Controller", func() {
 	Context("When reconciling a request for this signer", func() {
 		It("issues a certificate the API server accepts", func() {
-			pcr := createPodAndRequest("issued", nil)
+			pcr := createPodAndRequest("issued", testSignerName, nil)
 
 			By("waiting for the controller to record the Issued condition")
 			issued := waitForCondition(pcr, capiv1beta1.PodCertificateRequestConditionTypeIssued)
@@ -77,7 +84,7 @@ var _ = Describe("PodCertificateRequest Controller", func() {
 		It("records a terminal Denied status the API server accepts", func() {
 			// The signer rejects durations below kube-apiserver's one hour
 			// minimum, so this drives the reconciler down the terminal path.
-			pcr := createPodAndRequest("denied", map[string]string{durationAnnotation: "30m"})
+			pcr := createPodAndRequest("denied", testSignerName, map[string]string{durationAnnotation: "30m"})
 
 			By("waiting for the controller to record the Denied condition")
 			denied := waitForCondition(pcr, capiv1beta1.PodCertificateRequestConditionTypeDenied)
@@ -96,14 +103,7 @@ var _ = Describe("PodCertificateRequest Controller", func() {
 
 	Context("When the request belongs to another signer", func() {
 		It("leaves the request untouched", func() {
-			pcr := createPodAndRequest("other-signer", nil)
-			pcr.Spec.SignerName = "example.com/some-other-signer"
-
-			// Recreate under the foreign signer name: the spec is immutable,
-			// so the name has to be set at creation time.
-			Expect(k8sClient.Delete(ctx, pcr)).To(Succeed())
-			pcr.ResourceVersion = ""
-			Expect(k8sClient.Create(ctx, pcr)).To(Succeed())
+			pcr := createPodAndRequest("other-signer", foreignSignerName, nil)
 
 			Consistently(func(g Gomega) {
 				var got capiv1beta1.PodCertificateRequest
@@ -112,12 +112,38 @@ var _ = Describe("PodCertificateRequest Controller", func() {
 			}, 3*time.Second, 250*time.Millisecond).Should(Succeed())
 		})
 	})
+
+	Context("When a status write violates the API server's own rules", func() {
+		// This is what makes the specs above meaningful: they assert that the
+		// API server accepted the controller's writes, which only says
+		// something if the API server rejects bad ones. The request is created
+		// for a foreign signer so the controller leaves it alone and the
+		// status below is the only write it ever sees.
+		It("is rejected", func() {
+			pcr := createPodAndRequest("invalid-status", foreignSignerName, nil)
+
+			pcr.Status.Conditions = []metav1.Condition{{
+				Type:               capiv1beta1.PodCertificateRequestConditionTypeIssued,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(ReasonCertificateIssued),
+				Message:            "Certificate successfully issued",
+			}}
+			pcr.Status.CertificateChain = "not a PEM certificate"
+
+			err := k8sClient.Status().Update(ctx, pcr)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected an Invalid error, got %v", err)
+		})
+	})
 })
 
 // createPodAndRequest creates a pod and a PodCertificateRequest referring to
 // it, both named after suffix, and registers their cleanup. The request
 // carries the pod's live UID, which the reconciler gates on before signing.
-func createPodAndRequest(suffix string, userAnnotations map[string]string) *capiv1beta1.PodCertificateRequest {
+// The signer name is a parameter because the request spec is immutable, so it
+// has to be right at creation time.
+func createPodAndRequest(suffix, signerName string, userAnnotations map[string]string) *capiv1beta1.PodCertificateRequest {
 	GinkgoHelper()
 
 	name := "pcr-" + suffix
@@ -138,7 +164,7 @@ func createPodAndRequest(suffix string, userAnnotations map[string]string) *capi
 	pcr := &capiv1beta1.PodCertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
 		Spec: capiv1beta1.PodCertificateRequestSpec{
-			SignerName:                testSignerName,
+			SignerName:                signerName,
 			PodName:                   pod.Name,
 			PodUID:                    pod.UID,
 			ServiceAccountName:        "default",

--- a/internal/controller/podcertificaterequest_controller_test.go
+++ b/internal/controller/podcertificaterequest_controller_test.go
@@ -17,16 +17,176 @@ limitations under the License.
 package controller
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// durationAnnotation is the spec.unverifiedUserAnnotations key the signer
+// reads the requested certificate duration from. Spelled out here rather than
+// built from the podcertificate constants, which carry a deprecation notice
+// aimed at the pod-annotation fallback.
+const durationAnnotation = testSignerName + "-duration"
+
 var _ = Describe("PodCertificateRequest Controller", func() {
-	Context("When reconciling a resource", func() {
+	Context("When reconciling a request for this signer", func() {
+		It("issues a certificate the API server accepts", func() {
+			pcr := createPodAndRequest("issued", nil)
 
-		It("should successfully reconcile the resource", func() {
+			By("waiting for the controller to record the Issued condition")
+			issued := waitForCondition(pcr, capiv1beta1.PodCertificateRequestConditionTypeIssued)
+			Expect(issued.Reason).To(Equal(string(ReasonCertificateIssued)))
 
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+			By("reading back the status the API server persisted")
+			// Getting the object back with these fields set is the assertion
+			// that matters: kube-apiserver validates the certificate chain and
+			// the lifetime/refresh bounds on the status subresource, so a
+			// rejected write would leave the status empty and time out above.
+			var got capiv1beta1.PodCertificateRequest
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pcr), &got)).To(Succeed())
+
+			Expect(got.Status.CertificateChain).NotTo(BeEmpty())
+			block, _ := pem.Decode([]byte(got.Status.CertificateChain))
+			Expect(block).NotTo(BeNil(), "certificate chain is not PEM")
+			Expect(block.Type).To(Equal("CERTIFICATE"))
+			leaf, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(leaf.Subject.CommonName).To(Equal(got.Spec.PodName))
+
+			Expect(got.Status.NotBefore).NotTo(BeNil())
+			Expect(got.Status.NotAfter).NotTo(BeNil())
+			Expect(got.Status.BeginRefreshAt).NotTo(BeNil())
+			Expect(got.Status.NotAfter.Time).To(BeTemporally(">", got.Status.NotBefore.Time))
+			Expect(got.Status.NotAfter.Sub(got.Status.NotBefore.Time)).
+				To(BeNumerically("<=", time.Duration(testMaxExpirationSeconds)*time.Second))
+		})
+	})
+
+	Context("When the request carries an invalid configuration", func() {
+		It("records a terminal Denied status the API server accepts", func() {
+			// The signer rejects durations below kube-apiserver's one hour
+			// minimum, so this drives the reconciler down the terminal path.
+			pcr := createPodAndRequest("denied", map[string]string{durationAnnotation: "30m"})
+
+			By("waiting for the controller to record the Denied condition")
+			denied := waitForCondition(pcr, capiv1beta1.PodCertificateRequestConditionTypeDenied)
+			Expect(denied.Reason).To(Equal(string(ReasonInvalidUserAnnotations)))
+
+			By("checking the API server accepted the terminal write with cleared certificate fields")
+			var got capiv1beta1.PodCertificateRequest
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pcr), &got)).To(Succeed())
+
+			Expect(got.Status.CertificateChain).To(BeEmpty())
+			Expect(got.Status.NotBefore).To(BeNil())
+			Expect(got.Status.NotAfter).To(BeNil())
+			Expect(got.Status.BeginRefreshAt).To(BeNil())
+		})
+	})
+
+	Context("When the request belongs to another signer", func() {
+		It("leaves the request untouched", func() {
+			pcr := createPodAndRequest("other-signer", nil)
+			pcr.Spec.SignerName = "example.com/some-other-signer"
+
+			// Recreate under the foreign signer name: the spec is immutable,
+			// so the name has to be set at creation time.
+			Expect(k8sClient.Delete(ctx, pcr)).To(Succeed())
+			pcr.ResourceVersion = ""
+			Expect(k8sClient.Create(ctx, pcr)).To(Succeed())
+
+			Consistently(func(g Gomega) {
+				var got capiv1beta1.PodCertificateRequest
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pcr), &got)).To(Succeed())
+				g.Expect(got.Status.Conditions).To(BeEmpty())
+			}, 3*time.Second, 250*time.Millisecond).Should(Succeed())
 		})
 	})
 })
+
+// createPodAndRequest creates a pod and a PodCertificateRequest referring to
+// it, both named after suffix, and registers their cleanup. The request
+// carries the pod's live UID, which the reconciler gates on before signing.
+func createPodAndRequest(suffix string, userAnnotations map[string]string) *capiv1beta1.PodCertificateRequest {
+	GinkgoHelper()
+
+	name := "pcr-" + suffix
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec: corev1.PodSpec{
+			NodeName:   "envtest-node",
+			Containers: []corev1.Container{{Name: "app", Image: "busybox"}},
+		},
+	}
+	Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+	Expect(pod.UID).NotTo(BeEmpty())
+	DeferCleanup(func() {
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, pod))).To(Succeed())
+	})
+
+	maxExpirationSeconds := testMaxExpirationSeconds
+	pcr := &capiv1beta1.PodCertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec: capiv1beta1.PodCertificateRequestSpec{
+			SignerName:                testSignerName,
+			PodName:                   pod.Name,
+			PodUID:                    pod.UID,
+			ServiceAccountName:        "default",
+			ServiceAccountUID:         "envtest-serviceaccount-uid",
+			NodeName:                  "envtest-node",
+			NodeUID:                   "envtest-node-uid",
+			MaxExpirationSeconds:      &maxExpirationSeconds,
+			StubPKCS10Request:         newStubPKCS10Request(),
+			UnverifiedUserAnnotations: userAnnotations,
+		},
+	}
+	Expect(k8sClient.Create(ctx, pcr)).To(Succeed())
+	DeferCleanup(func() {
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, pcr))).To(Succeed())
+	})
+
+	return pcr
+}
+
+// newStubPKCS10Request returns the DER-encoded PKCS#10 request kubelet would
+// attach to a PodCertificateRequest. kube-apiserver verifies its signature
+// during admission, which is what proves possession of the private key.
+func newStubPKCS10Request() []byte {
+	GinkgoHelper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	csr, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{}, key)
+	Expect(err).NotTo(HaveOccurred())
+
+	return csr
+}
+
+// waitForCondition polls the request until the controller records the given
+// condition type, and returns it.
+func waitForCondition(pcr *capiv1beta1.PodCertificateRequest, conditionType string) metav1.Condition {
+	GinkgoHelper()
+
+	var found metav1.Condition
+	Eventually(func(g Gomega) {
+		var got capiv1beta1.PodCertificateRequest
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pcr), &got)).To(Succeed())
+		g.Expect(got.Status.Conditions).To(HaveLen(1))
+		g.Expect(got.Status.Conditions[0].Type).To(Equal(conditionType))
+		g.Expect(got.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+		found = got.Status.Conditions[0]
+	}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+
+	return found
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -21,22 +21,50 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/authority"
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/signer"
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/testutil"
 	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+//
+// Unlike the unit tests in this package, which drive the reconciler against a
+// fake client, this suite runs it against a real kube-apiserver. That is the
+// only place where the status writes the controller performs are actually
+// validated: kube-apiserver enforces a set of rules on PodCertificateRequest
+// status (certificate chain parses, lifetime bounds, refresh window, cleared
+// fields on terminal outcomes) which no fake client checks.
+
+const (
+	// testSignerName is the signer this suite's reconciler is responsible for.
+	testSignerName = "example.com/envtest-signer"
+
+	// testNamespace is where the suite creates its pods and requests.
+	testNamespace = "default"
+
+	// testMaxExpirationSeconds bounds the certificate lifetime. It is set
+	// comfortably above the signer's 24h default duration so the issued
+	// certificate sits strictly inside the bound rather than on it.
+	testMaxExpirationSeconds = int32(48 * 60 * 60)
+)
 
 var (
 	ctx       context.Context
@@ -57,17 +85,19 @@ var _ = BeforeSuite(func() {
 
 	ctx, cancel = context.WithCancel(context.TODO())
 
-	var err error
-	err = certificatesv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(certificatesv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// +kubebuilder:scaffold:scheme
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
-	}
+	testEnv = &envtest.Environment{}
+
+	// PodCertificateRequest is a built-in API behind a feature gate, not a
+	// CRD, so there is nothing to install from disk. The apiserver has to be
+	// told both to enable the gate and to serve the beta API group version.
+	testEnv.ControlPlane.GetAPIServer().Configure().
+		Append("feature-gates", "PodCertificateRequest=true").
+		Append("runtime-config", "certificates.k8s.io/v1beta1=true")
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
 	if getFirstFoundEnvTestBinaryDir() != "" {
@@ -75,6 +105,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	// cfg is defined in this file globally.
+	var err error
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -82,6 +113,9 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	By("starting the PodCertificateRequest controller")
+	startTestManager()
 })
 
 var _ = AfterSuite(func() {
@@ -90,6 +124,66 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+// startTestManager wires the real reconciler - a real CA, a real signer, and
+// the manager's own client, API reader and event recorder - into a manager
+// running against the envtest apiserver, mirroring how cmd/podcertificate-signer
+// assembles it in production.
+func startTestManager() {
+	GinkgoHelper()
+
+	// The CA must outlive the certificates it issues: authority.Sign refuses
+	// to issue past its own NotAfter, and that refusal is classified as
+	// transient, so a short-lived CA would make specs requeue until they time
+	// out instead of failing usefully.
+	ca, err := testutil.NewCA("envtest-ca", 90*24*time.Hour)
+	Expect(err).NotTo(HaveOccurred())
+
+	// authority.New loads the CA through tls.LoadX509KeyPair, so the key pair
+	// has to reach it as files.
+	dir, err := os.MkdirTemp("", "envtest-ca")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(os.RemoveAll(dir)).To(Succeed())
+	})
+	certPath, keyPath, err := ca.WriteFiles(dir)
+	Expect(err).NotTo(HaveOccurred())
+
+	certificateAuthority, err := authority.New(certPath, keyPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	pcrSigner, err := signer.New(testSignerName, certificateAuthority)
+	Expect(err).NotTo(HaveOccurred())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 scheme.Scheme,
+		Metrics:                server.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		// Pods are excluded from the cache in production; keep the same
+		// wiring here so the suite exercises the live-read path.
+		Client: client.Options{
+			Cache: &client.CacheOptions{DisableFor: []client.Object{&corev1.Pod{}}},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&PodCertificateRequestReconciler{
+		Client:        mgr.GetClient(),
+		APIReader:     mgr.GetAPIReader(),
+		Log:           ctrl.Log.WithName("envtest"),
+		Scheme:        mgr.GetScheme(),
+		Signer:        pcrSigner,
+		ClusterFqdn:   "cluster.local",
+		EventRecorder: mgr.GetEventRecorder("podcertificate-signer"),
+	}).SetupWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+	Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+}
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
 // ENVTEST-based tests depend on specific binaries, usually located in paths set by


### PR DESCRIPTION
Part of the **code-quality-review** epic (#25); completes the real-envtest portion of #35 (the empty scaffold called out there).

Replaces the assertion-free envtest scaffold with a **real feature-gated reconcile suite** that exercises the controller against a live kube-apiserver — the one thing the fake client can't validate (server-side PCR status validation).

### Stack
- **Base branch:** `code-quality/disable-pod-cache`
- **Stack parent PR:** #44
- **Merge only after:** #44 (and its parents #43, #42, #40)

### What it does
- Configures `envtest` with `--feature-gates=PodCertificateRequest=true` + `--runtime-config=certificates.k8s.io/v1beta1=true` so the built-in type is served; drops the bogus `CRDDirectoryPaths` (this is not a CRD); removes the empty TODO spec.
- Starts a manager with the real reconciler (CA from `testutil.NewCA`, real `signer.New`, `APIReader = mgr.GetAPIReader()`, pod-cache bypass) and runs **4 specs**:
  1. **Issued** — persisted status has a PEM chain whose leaf CN is the pod name, with NotBefore/NotAfter/BeginRefreshAt set and lifetime within `maxExpirationSeconds`.
  2. **Denied** — `duration: 30m` (below the apiserver 1h floor) → terminal `Denied/InvalidUserConfig` with cert fields cleared.
  3. **Foreign signer** — request left untouched.
  4. **Negative control** — an invalid status write (non-PEM chain) is rejected `Invalid`, proving "the apiserver accepted our write" is meaningful.

### Evidence
`KUBEBUILDER_ASSETS=... go test ./internal/controller/ -run TestControllers -race` → **4 Passed, 0 Failed (~7s)**, verified after rebasing onto the current stack. Mutation-tested (a non-matching signer name makes the condition specs fail on timeout, so they aren't vacuous). Test-only changes; `gofmt`/`go vet`/`go build` clean. Label `release/skip`.

Closes #35 is intentionally NOT set (the seam PR #40 owns that issue); this PR completes its envtest follow-up.
