### PR TITLE
docs(H9): add governance files (CONTRIBUTING, CoC, PR/issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: 🐛 Bug report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill in as much detail as possible.
+        For security vulnerabilities, do **not** open a public issue — use
+        [GitHub security advisories](https://github.com/RafPe/pod-certificate-signer/security/advisories/new) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior (workload manifest, Helm values, etc.).
+      placeholder: |
+        1. Deploy the controller with ...
+        2. Create a pod with a podCertificate projected volume ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: controller-version
+    attributes:
+      label: Controller version
+      description: Image tag or chart version of pod-certificate-signer.
+      placeholder: v0.5.0
+    validations:
+      required: true
+  - type: input
+    id: kubernetes-version
+    attributes:
+      label: Kubernetes version
+      description: Output of `kubectl version`. The controller requires 1.35+ with the PodCertificateRequest feature gates enabled.
+      placeholder: v1.35.0
+    validations:
+      required: true
+  - type: dropdown
+    id: config-source
+    attributes:
+      label: Configuration source
+      description: How is the certificate configuration provided for the affected workload?
+      options:
+        - unverifiedUserAnnotations on the projected volume
+        - Pod annotations (deprecated)
+        - Defaults only (no per-workload configuration)
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Relevant configuration
+      description: The annotations / projected volume spec / Helm values involved (redact anything sensitive).
+      render: yaml
+  - type: textarea
+    id: logs
+    attributes:
+      label: Controller logs
+      description: Relevant log output from the controller pod (`kubectl logs`).
+      render: shell
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else that helps — PodCertificateRequest status, events, cluster setup, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/RafPe/pod-certificate-signer/security/advisories/new
+    about: Please report security vulnerabilities privately via GitHub security advisories, not public issues.
+  - name: 💬 Questions & troubleshooting
+    url: https://github.com/RafPe/pod-certificate-signer#-troubleshooting
+    about: Check the README troubleshooting section before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: 🚀 Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe the problem you
+        are trying to solve, not only the solution you have in mind.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case or limitation that motivates this request.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen? Include example annotations, flags or manifests if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you have considered or are using today.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else — links to Kubernetes KEPs, related issues, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Thanks for contributing! See CONTRIBUTING.md for the full workflow. -->
+
+## What does this PR do?
+
+<!-- Describe the change and the motivation behind it. -->
+
+## Related issues
+
+<!-- e.g. Fixes #123 -->
+
+## Checklist
+
+- [ ] **Exactly one `release/*` label is set** (`release/major`, `release/minor`, `release/patch` or `release/skip`) — required, CI fails without it. The label drives the next version bump and the release notes category.
+- [ ] The PR title is descriptive — it ends up verbatim in the release notes.
+- [ ] `make test` and `make lint` pass locally.
+- [ ] Tests were added/updated for new behavior.
+- [ ] Docs (README, chart docs, examples) were updated for user-facing changes.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer, [RafPe](https://github.com/RafPe), at
+**rafal@pieniazek.nl**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to pod-certificate-signer
+
+Thanks for taking the time to contribute! Bug reports, feature requests and
+pull requests are all welcome.
+
+## Prerequisites
+
+- **Go 1.26+** (see `go.mod` for the exact version)
+- **Docker** (or another container tool via `CONTAINER_TOOL=podman`)
+- **make**
+
+All other tooling — `controller-gen`, `golangci-lint`, `kind`, `helm`,
+`setup-envtest` — is pinned in `internal/tools/go.mod` and invoked through
+`go tool` by the Makefile. You do not need to install anything else manually.
+
+## Development workflow
+
+1. Create a branch off `main` (fork first if you don't have push access).
+2. Make your changes, including tests for new behavior.
+3. Run the checks below before opening a pull request.
+
+Useful make targets (`make help` shows the full list):
+
+| Target                 | What it does                                                          |
+| ---------------------- | --------------------------------------------------------------------- |
+| `make fmt` / `make vet` | Format the code and run `go vet`                                      |
+| `make lint`            | Run `golangci-lint` (`make lint-fix` applies fixes)                    |
+| `make generate`        | Regenerate DeepCopy code after changing API types                      |
+| `make test`            | Run unit tests with envtest (Kubernetes control-plane binaries are downloaded automatically) |
+| `make test-e2e`        | Run the e2e suite against a throwaway kind cluster (`pcs-e2e`)         |
+| `make build`           | Build the manager binary into `bin/`                                   |
+| `make run`             | Run the controller locally against your current kubeconfig             |
+| `make docker-build`    | Build the OCI image (`IMAGE=<repo:tag>` to override)                   |
+
+### Local cluster with kind
+
+The repository ships a kind configuration (`kind/kind-config.yaml`) that
+enables the `PodCertificateRequest`, `ClusterTrustBundle` and
+`ClusterTrustBundleProjection` feature gates plus the
+`certificates.k8s.io/v1beta1` runtime config the controller needs:
+
+| Target                 | What it does                                                          |
+| ---------------------- | --------------------------------------------------------------------- |
+| `make kind-start`      | Create the local dev cluster (`pcs-dev`)                               |
+| `make kind-load-image` | Build the image and load it into the dev cluster                       |
+| `make helm-deploy`     | Load the image and install the chart with the example CA secret and values |
+| `make helm-uninstall`  | Remove the Helm release                                                |
+| `make kind-stop`       | Tear the dev cluster down                                              |
+
+## Pull requests
+
+- Target the `main` branch.
+- Keep PRs focused; smaller PRs are reviewed faster.
+- Make sure `make test` and `make lint` pass.
+- Update the README / chart docs when you change user-facing behavior.
+
+### Release labels (required)
+
+Releases are fully label-driven. **Every PR must carry exactly one
+`release/*` label** — a required CI check
+(`.github/workflows/pr-labels.yml`) fails otherwise:
+
+| Label           | Effect on merge                                                 |
+| --------------- | ---------------------------------------------------------------- |
+| `release/major` | Next release bumps the **major** version (breaking change)       |
+| `release/minor` | Next release bumps the **minor** version (feature)               |
+| `release/patch` | Next release bumps the **patch** version (fix)                   |
+| `release/skip`  | No release; the change is collected into the next release draft  |
+
+Your PR title ends up in the generated release notes, so make it descriptive.
+
+## Reporting issues
+
+Use the issue forms in this repository for bugs and feature requests. For
+security vulnerabilities, please **do not** open a public issue — report them
+privately via [GitHub security advisories](https://github.com/RafPe/pod-certificate-signer/security/advisories/new).
+
+## Code of conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold it.


### PR DESCRIPTION
Part of #52 (harden epic), tier 2. Adds CONTRIBUTING.md (real Go/kind prereqs, make targets, release-label rule), CODE_OF_CONDUCT.md (Contributor Covenant 2.1, RafPe contact), PULL_REQUEST_TEMPLATE.md (release-label check first), and issue forms with a config-source dropdown + `config.yml` (`blank_issues_enabled:false`). MAINTAINING.md/CHANGELOG.py intentionally skipped.
