### PR TITLE
ci(H4): add CodeQL SAST workflow for Go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly full scan so newly published queries catch issues in unchanged code.
+    - cron: "27 4 * * 1"
+
+# Minimal token scope: read the source, upload SARIF results, and read the
+# Actions API for run metadata. No package or write access is required.
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: go
+          # No compilation needed: CodeQL's Go analysis extracts source directly.
+          # This also avoids autobuild tripping over the separate tool module at
+          # internal/tools/go.mod (helm, golangci-lint and friends).
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,10 +33,14 @@ jobs:
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: go
-          # No compilation needed: CodeQL's Go analysis extracts source directly.
-          # This also avoids autobuild tripping over the separate tool module at
-          # internal/tools/go.mod (helm, golangci-lint and friends).
-          build-mode: none
+          # Deterministic build for the extractor. `go build ./...` from the repo
+          # root compiles the main module only; the separate tool module at
+          # internal/tools/go.mod (helm, golangci-lint and friends) is a distinct
+          # module and is not built, so autobuild never has to reason about it.
+          build-mode: manual
+
+      - name: Build
+        run: go build ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6


### PR DESCRIPTION
Part of #52

## Summary

Adds `.github/workflows/codeql.yml` — a CodeQL SAST workflow for the Go
codebase. Triggers on `pull_request`, `push` to `main`, and a weekly
`schedule` cron (`27 4 * * 1`) so newly published queries reach unchanged
code.

## Build-mode decision: `build-mode: manual`

This repo has a second module at `internal/tools/go.mod` pulling in a large
build-tooling dependency tree (helm, golangci-lint, controller-gen, kind,
setup-envtest), which `autobuild` can trip over in a multi-module layout.

The workflow uses `build-mode: manual` with an explicit `go build ./...` step
run from the repo root. That compiles the main module only — the tool module
is a separate module and is not built by `go build ./...`, so this sidesteps
the autobuild concern while remaining fully deterministic. `actions/setup-go`
is pinned with `go-version-file: go.mod` so the extractor sees a toolchain
matching the module.

(`build-mode: none` was the original choice, but the CodeQL runner shipped
with the GitHub-hosted CLI bundle at v2.26.2 does not yet support `none` for
Go — it requires `autobuild` or `manual`.)

## Hardening

- All action references pinned to full 40-char commit SHAs with `# vX.Y.Z`
  comments: `actions/checkout` v7.0.1, `actions/setup-go` v7.0.0,
  `github/codeql-action/{init,analyze}` v4.37.6 (identical SHA on both).
- Minimal token scope: `contents: read`, `security-events: write`,
  `actions: read`. No `packages: read` (all dependencies are public).

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` parses clean.
- `actionlint .github/workflows/codeql.yml` exits 0.
- Every pinned SHA is 40 hex chars with a matching version comment;
  `init` and `analyze` share the same commit.
- Go toolchain sourced from `go.mod` via `go-version-file`.
- Code-scanning **default setup** is `not-configured` on the repo, so this
  advanced workflow will not conflict with it.
