### PR TITLE
ci(H2): enable gosec + bodyclose linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,13 @@ run:
 linters:
   default: none
   enable:
+    - bodyclose
     - copyloopvar
     - dupl
     - errcheck
     - ginkgolinter
     - gocyclo
+    - gosec
     - govet
     - ineffassign
     - lll
@@ -31,12 +33,15 @@ linters:
     generated: lax
     rules:
       - linters:
-          - lll
-        path: api/*
-      - linters:
           - dupl
           - lll
         path: internal/*
+      # Tests legitimately shell out to helm/git/kubectl and read fixture
+      # files by path; G204/G304 on that test-only code is noise, not risk.
+      - linters:
+          - gosec
+        text: "G204|G304"
+        path: _test\.go
     paths:
       - third_party$
       - builtin$

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -62,6 +62,7 @@ func Run(cmd *exec.Cmd) (string, error) {
 // UninstallCertManager uninstalls the cert manager
 func UninstallCertManager() {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
+	//nolint:gosec // G204: url is built from constant templates, not user input; e2e test helper only.
 	cmd := exec.Command("kubectl", "delete", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
@@ -73,6 +74,7 @@ func UninstallCertManager() {
 		"cert-manager-controller",
 	}
 	for _, lease := range kubeSystemLeases {
+		//nolint:gosec // G204: lease names are hard-coded constants; e2e test helper only.
 		cmd = exec.Command("kubectl", "delete", "lease", lease,
 			"-n", "kube-system", "--ignore-not-found", "--force", "--grace-period=0")
 		if _, err := Run(cmd); err != nil {
@@ -84,6 +86,7 @@ func UninstallCertManager() {
 // InstallCertManager installs the cert manager bundle.
 func InstallCertManager() error {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
+	//nolint:gosec // G204: url is built from constant templates, not user input; e2e test helper only.
 	cmd := exec.Command("kubectl", "apply", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		return err
@@ -144,6 +147,7 @@ func LoadImageToKindClusterWithName(name string) error {
 	if v, ok := os.LookupEnv("KIND"); ok {
 		kindBinary = v
 	}
+	//nolint:gosec // G204: kind binary/args come from env-configured constants; e2e test helper only.
 	cmd := exec.Command(kindBinary, kindOptions...)
 	_, err := Run(cmd)
 	return err


### PR DESCRIPTION
Part of #52 (H2 · golangci: enable gosec + bodyclose).

## Summary
- Enable the `gosec` and `bodyclose` linters in `.golangci.yml`.
- Remove the dead `api/*` lll exclusion — there is no `api/` directory in this repo (the existing `internal/*` rule already covers `internal/api/helper.go`).
- Scope a `G204`/`G304` gosec exclusion to `_test.go` files (tests shell out to helm/git/kubectl and read fixtures by path).
- Annotate the four `exec.Command` sites in the e2e helper `test/utils/utils.go` (not a `_test.go` file) with `//nolint:gosec` plus a specific reason.

## Findings: before vs after
Measured with the repo-pinned golangci-lint **v2.12.2** (`go tool -modfile internal/tools/go.mod golangci-lint`, i.e. what `make lint` runs), uncapped (`--max-same-issues 0 --max-issues-per-linter 0`):

- **Before:** 8 gosec findings, 0 bodyclose. All in test-only code — `G204` (subprocess: helm/git/kubectl/kind) and `G304` (fixture file read). No production code flagged; bodyclose found nothing (the codebase has no HTTP clients).
- **After:** **0 issues.**

## `only-new-issues` decision
Fully-clean baseline (0 remaining), so no `only-new-issues` gate is needed. Note also that this repo runs `make lint` (`golangci-lint run`) directly rather than via `golangci-lint-action`, so `only-new-issues` isn't available without restructuring CI — and it's moot at 0.

## Validation
- `golangci-lint run ./...` (pinned v2.12.2) → **0 issues**; `golangci-lint config verify` → ok.
- `go build ./...` → ok.
- `go test ./...` → all unit packages pass. The `internal/controller` envtest suite is skipped locally (apiserver/etcd binaries absent: `/usr/local/kubebuilder/bin/etcd`); it runs in CI.
