### PR TITLE
ci(H1): harden workflows — pin actions, least-privilege permissions, concurrency, build/gofmt gates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,16 +6,19 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -44,18 +44,18 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE_REPO }}
           tags: |
@@ -72,7 +72,7 @@ jobs:
             type=semver,pattern=v{{major}},value=${{ env.RELEASE_TAG }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -95,7 +95,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       # v* tag.
       - name: Draft or publish the release
         id: drafter
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         with:
           publish: ${{ !contains(github.event.pull_request.labels.*.name, 'release/skip') }}
         env:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so gitleaks can scan past commits, not just the tip.
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Use the repo config, which allowlists the historical (now removed

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -5,6 +5,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-e2e:
     permissions:
@@ -13,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -3,16 +3,23 @@ name: E2E Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-e2e:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,18 +6,33 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Check formatting
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "${unformatted}" ]; then
+            echo "::error::The following files are not gofmt-formatted. Run 'make fmt' and commit the result:"
+            echo "${unformatted}"
+            exit 1
+          fi
 
       - name: Running Tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ vet: ## Run go vet against code.
 	$(GOCMD) vet ./...
 
 .PHONY: test
-test: generate fmt vet  ## Run tests.
+test: generate vet  ## Run tests. Formatting is enforced separately (make fmt / CI gofmt gate), not auto-applied here.
 	@KUBEBUILDER_ASSETS="$$( $(GO_TOOL) setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path )" \
 		$(GOCMD) test \
 			-v \


### PR DESCRIPTION
Part of #52.

Hardens every existing GitHub Actions workflow ahead of the Scorecard rollout
(H5), which scores Pinned-Dependencies and Token-Permissions.

## Changes

- **SHA-pin every third-party `uses:`** to a full 40-char commit SHA with a
  trailing `# vX.Y.Z` comment (18 pins across the workflows). SHAs were
  resolved to the commit each release tag currently points at:
  - `actions/checkout` v7.0.1, `actions/setup-go` v7.0.0
  - `docker/setup-qemu-action` v4.2.0, `docker/setup-buildx-action` v4.2.0,
    `docker/login-action` v4.6.0, `docker/metadata-action` v6.2.0,
    `docker/build-push-action` v7.3.0
  - `release-drafter/release-drafter` v7.7.0, `gitleaks/gitleaks-action` v3.0.0
  - The local reusable workflow `./.github/workflows/release-image.yml` is a
    same-repo call and is intentionally left unpinned.
- **Least-privilege permissions**: added top-level `permissions: { contents: read }`
  to `lint.yml`, `test.yml`, and `test-e2e.yml` (the three that lacked a block).
  The workflows already set to `permissions: {}` (`pr-labels`, `release`,
  `release-image`, `test-chart`) keep it; the release workflows retain their
  genuinely-needed job-level `packages: write` / `contents: write` escalations.
- **Concurrency** groups keyed by `workflow + ref` with `cancel-in-progress`
  for PR runs on the kind-cluster workflows (`test-e2e.yml`, `test-chart.yml`).
- **`test.yml`**: added a `go build ./...` step and a failing `gofmt` gate
  (fails if `gofmt -l .` prints anything). Dropped `fmt` from the Makefile
  `test` target so CI enforces formatting instead of silently auto-fixing it;
  the standalone `fmt` target is unchanged.

> [!NOTE]
> `secret-scan.yml` was added to the repo after the original H1 task list was
> written, so it is included here beyond that list — it also carries a
> third-party action (`gitleaks-action`) that needed pinning. Its existing
> `permissions: contents: read` was left as-is.

## Validation

- `actionlint` on `.github/workflows/` — clean (exit 0).
- Confirmed all 18 pins are 40 hex chars and each `# vX.Y.Z` comment matches
  the tag the SHA resolves to (verified via `gh api .../commits/<tag>` and
  `.../releases/latest`).
- `go build ./...` and `gofmt -l .` both clean.
- `make generate` then `gofmt -l .` clean (no unformatted generated output),
  and `make test` passes after the `fmt` prereq removal.
