### PR TITLE
docs(H12+H13): README restructure, docs/ with C4 diagrams, Artifact Hub prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,614 +1,87 @@
-🔐 **PodCertificateSigner**: A Kubernetes controller that issues x509 certificates from a custom provided CA for your pods.
+<p align="center">
+  <img src="./assets/social-card.png" alt="pod-certificate-signer — issues short-lived x509 certificates for pods from your own CA via the native PodCertificateRequest API" width="820">
+</p>
 
-- [pod-certificate-signer (PCS): Custom signer for x509 pod certificates](#pod-certificate-signer-pcs-custom-signer-for-x509-pod-certificates)
-  - [📋 Overview](#-overview)
-    - [What PodCertificateSigner Does](#what-podcertificatesigner-does)
-    - [Why Do You Need PodCertificateSigner](#why-do-you-need-podcertificatesigner)
-    - [Key Benefits](#key-benefits)
-  - [Features](#features)
-  - [🔄 How It Works](#-how-it-works)
-  - [📋 Prerequisites](#-prerequisites)
-  - [📦 Deployment](#-deployment)
-    - [1. 🔐 Create the CA secret](#1--create-the-ca-secret)
-    - [2. 🚀 Install the chart](#2--install-the-chart)
-    - [3. 🧑‍💻 Deploying from a local checkout](#3--deploying-from-a-local-checkout)
-  - [📝 Usage](#-usage)
-    - [🏷️ Configuration via `unverifiedUserAnnotations`](#️-configuration-via-unverifieduserannotations)
-    - [🧩 Interpolating pod identity into certificate values](#-interpolating-pod-identity-into-certificate-values)
-    - [🔮 CSR-requested SANs (forward compatibility)](#-csr-requested-sans-forward-compatibility)
-    - [🏷️ Configuration via Pod Annotations (deprecated)](#️-configuration-via-pod-annotations-deprecated)
-      - [🔗 Example configuration](#-example-configuration)
-    - [Requesting PodCertificates for your workload](#requesting-podcertificates-for-your-workload)
-      - [🔗 Example workload manifest](#-example-workload-manifest)
-  - [✅ Default PodCertificateSigner validation rules](#-default-podcertificatesigner-validation-rules)
-  - [⌘ Controller commandline options](#-controller-commandline-options)
-  - [🔧 Troubleshooting](#-troubleshooting)
-    - [Common Issues](#common-issues)
-    - [📊 Logs](#-logs)
-  - [🛡️ Security Considerations](#️-security-considerations)
-  - [📦 Release process](#-release-process)
-  - [🤝 Contributing](#-contributing)
-# pod-certificate-signer (PCS): Custom signer for x509 pod certificates
+[![Tests](https://github.com/RafPe/pod-certificate-signer/actions/workflows/test.yml/badge.svg)](https://github.com/RafPe/pod-certificate-signer/actions/workflows/test.yml)
+[![Lint](https://github.com/RafPe/pod-certificate-signer/actions/workflows/lint.yml/badge.svg)](https://github.com/RafPe/pod-certificate-signer/actions/workflows/lint.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
+[![Release](https://img.shields.io/github/v/release/rafpe/pod-certificate-signer?logo=github)](https://github.com/rafpe/pod-certificate-signer/releases)
+[![Go](https://img.shields.io/github/go-mod/go-version/rafpe/pod-certificate-signer)](./go.mod)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/podcertificate-signer)](https://artifacthub.io/packages/search?repo=podcertificate-signer)
+<!-- Scorecard badge: add after publish_results flip post-CA-rotation -->
 
-## 📋 Overview
+# pod-certificate-signer
 
-PodCertificateSigner is a simple controller built on the **native** [PodCertificateRequest](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#pod-certificate-requests) feature: when a pod requests a certificate from a custom x509 signer via a projected volume, the kube-apiserver creates a `PodCertificateRequest`, and this controller issues (or denies) a short-lived x509 certificate from your CA - ready for your workloads to use for TLS or mTLS.
+A Kubernetes controller that signs the native `PodCertificateRequest` API, issuing short-lived x509 certificates to your pods from your own CA and publishing that CA as a `ClusterTrustBundle`.
 
-The controller also publishes its CA - including previously used CAs during rotation - as a [ClusterTrustBundle](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#cluster-trust-bundles), so workloads can mount the matching trust anchors next to their certificates. Combined with MutatingAdmissionPolicy / ValidatingAdmissionPolicy this gives the cluster operator an extremely strong, fully native security framework for workload identity.
+## Why
 
+- **The problem:** giving every pod its own short-lived x509 identity used to mean a sidecar mesh or a bespoke CSR pipeline — extra moving parts to run and secure.
+- **The fix:** Kubernetes 1.35 added the built-in [`PodCertificateRequest`](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#pod-certificate-requests) API. A pod asks for a certificate through a projected volume, the apiserver creates a request, and this controller issues (or denies) it from your CA — no sidecars, no external tooling.
+- **What's different:** the controller also publishes its CA — current and previous, across rotations — as a [`ClusterTrustBundle`](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#cluster-trust-bundles), so workloads mount the matching trust anchors next to their certificate. Combined with a `ValidatingAdmissionPolicy`, this is a fully native workload-identity and mTLS foundation.
 
+> [!NOTE]
+> This signs the upstream `PodCertificateRequest` API. It is **not** a
+> `CertificateSigningRequest` (CSR) signer and **not** an authentication proxy —
+> the only requests it acts on are ones the apiserver creates and whose identity
+> fields it has already verified.
 
-### What PodCertificateSigner Does
-- **Handles PodCertificateRequests**: responds to and validates all requests for new pod certificates
-- **Validates the x509 certificate configuration**: making sure the dynamic configuration is correct, against the same constraints the kube-apiserver enforces
-- **Signs pod x509 certificates** or denies issuing a certificate based on the configuration and cluster information
-- **Publishes and maintains the ClusterTrustBundle** for the signer, retaining previous CAs across rotations
+## Quickstart
 
-###  Why Do You Need PodCertificateSigner
-- **Secures your workloads east/west traffic** by issuing short-lived x509 certificates to your pods
-- **Declarative security** by providing the configuration to your workloads
-- **Enabling mTLS** by allowing you to implement strict client/server auth from the x509 certs
-- **Enhancing your cluster security** without any external tools - you can use native cluster features to strengthen your security.
+Prerequisites: Kubernetes 1.35+ with the `PodCertificateRequest` feature gates, Helm 3+, and a signing CA (see [prerequisites](./docs/getting-started.md#prerequisites)).
 
-### Key Benefits
-- **Zero false positives** - only kube-api creates the PodCertificateRequests
-- **Easy integration** - works with existing Kubernetes clusters
-- **Comprehensive logging** - full audit trail of decisions
-- **Flexible configuration** - per-workload certificate configuration via `unverifiedUserAnnotations`
-
-## Features
-
-- **Support for TLS/mTLS certificates**: You can decide how to use the certificates
-- **Per-workload configuration**: certificate CN, SANs, URIs, duration and refresh hint via `unverifiedUserAnnotations` on the projected volume
-- **CA hot-reload**: the CA certificate and key are reloaded from disk when they change - no restart needed to rotate
-- **Trust distribution**: the current and previously used CAs are published as a ClusterTrustBundle for workloads to mount
-
-
-
-## 🔄 How It Works
-
-1. **Pod Creation**: When a pod is created in Kubernetes with the `podCertificate` projected volume, the kube-apiserver creates a `PodCertificateRequest`
-2. **Configuration**: PodCertificateSigner reads the `unverifiedUserAnnotations` of the request (falling back to deprecated pod annotations) to customize the certificate
-3. **Validation**: It validates the certificate configuration against the constraints the kube-apiserver enforces
-4. **Decision**: The certificate for the pod is either issued or denied based on validation results
-5. **Trust distribution**: In parallel, the controller keeps the signer's ClusterTrustBundle in sync with the CA, so workloads can mount the trust anchors needed to verify the issued certificates
-
-```mermaid
----
-config:
-  theme: neo
----
-sequenceDiagram
-    participant Pod
-    participant KubeAPI
-    participant Controller
-    participant CA
-    Pod->>KubeAPI: Create with projected volume
-    KubeAPI->>Controller: PodCertificateRequest event
-    Controller->>Controller: Validate pod & config
-    critical Handle request
-    alt Success
-        Controller->>CA: Sign certificate
-        CA->>Controller: Return certificate
-        Controller->>KubeAPI: Update status: Issued
-        KubeAPI->>Pod: Pod starts
-    else Failure/Deny
-        Controller->>KubeAPI: Update status: Failed/Denied
-        KubeAPI->>Pod: Pod blocked
-    end
-    end
-
-```
-
-
-## 📋 Prerequisites
-> To test this setup with kind you can use prepared [kind-config](https://github.com/RafPe/pod-certificate-signer/blob/main/kind/kind-config.yaml)
-
-- Kubernetes cluster version **1.35+** (the controller uses the `certificates.k8s.io/v1beta1` API, available since 1.35), with:
-  - feature gates: `PodCertificateRequest`, `ClusterTrustBundle`, `ClusterTrustBundleProjection`
-  - runtime config: `certificates.k8s.io/v1beta1=true`
-- CA certificate ( can be self-signed )
-
-
-
-## 📦 Deployment
-
-PodCertificateSigner is deployed via its Helm chart. On every release the chart is published to GHCR as an OCI artifact, alongside the controller image.
-
-### 1. 🔐 Create the CA secret
-
-You will need a valid CA which will be used by the controller to sign the pod certificate requests. There are many ways of approaching this - either via a tool like [cfssl](https://github.com/cloudflare/cfssl), leveraging [`cert-manager`](https://cert-manager.io/), or if you live in terminal you can use the `openssl` cli. If you have an existing CA you would like to use, simply skip the creation and use that as the source for the secret.
-
-Create a `kubernetes.io/tls` secret from the CA in the namespace you will deploy into:
+Create a Secret from your CA, then install the published OCI chart — `signer.name` and a CA source are required:
 
 ```sh
 kubectl create namespace pcs-system
 kubectl create secret tls podcertificate-signer-ca \
-  --namespace pcs-system \
-  --cert=ca.pem \
-  --key=ca-key.pem
-```
+  --namespace pcs-system --cert=ca.pem --key=ca-key.pem
 
-> [!WARNING]
-> Use a CA you generated yourself. A sample CA (`examples/ca_tls_secret.yaml`) once shipped with this repository; it is removed from `HEAD` by [#37](https://github.com/rafpe/pod-certificate-signer/pull/37), but its private key remains readable in git history and must never be used anywhere real. See [Rotating the signing CA](#-rotating-the-signing-ca).
-
-### 2. 🚀 Install the chart
-
-Install directly from GHCR (replace the version with the [latest release](https://github.com/rafpe/pod-certificate-signer/releases)):
-
-```sh
 helm install podcertificate-signer oci://ghcr.io/rafpe/charts/podcertificate-signer \
-  --version <X.Y.Z> \
   --namespace pcs-system \
   --set signer.name=coolcert.example.com/foo \
-  --values my-values.yaml
+  --set signer.ca.secretRef.name=podcertificate-signer-ca
 ```
 
-Mount the CA secret into the controller via your values file (see [examples/helm-values.yaml](./examples/helm-values.yaml)):
+Add `--version <x.y.z>` to pin a specific [release](https://github.com/rafpe/pod-certificate-signer/releases); omit it for the latest. Full flow — CA options, a workload requesting a certificate, and verification: [docs/getting-started.md](./docs/getting-started.md).
 
-```yaml
-volumes:
-  - name: podcertificate-signer-ca
-    secret:
-      secretName: podcertificate-signer-ca
-      optional: false
+## How it works
 
-volumeMounts:
-  - name: podcertificate-signer-ca
-    mountPath: /app/signer/ca
-    readOnly: true
-```
+When a pod declares a `podCertificate` projected volume naming this signer, kubelet generates the key pair and CSR and the kube-apiserver creates a `PodCertificateRequest` carrying the pod's verified identity. The controller validates the request and its annotation configuration, then signs a short-lived certificate from your CA or denies the request. In parallel it keeps the signer's `ClusterTrustBundle` in sync so workloads can verify their peers.
 
-All configuration options are documented in the chart [values.yaml](./charts/podcertificate-signer/values.yaml).
+See [docs/architecture.md](./docs/architecture.md) for the full C4 model (system context, containers, components) and the request-flow sequence.
 
-### 3. 🧑‍💻 Deploying from a local checkout
+## Features
 
-For development, `make helm-deploy` builds the image, loads it into a local Kind cluster and installs the chart with the example values. `make helm-uninstall`, `make helm-status` and `make helm-rollback` manage the release.
+- **Native API, no sidecars** — signs the built-in `PodCertificateRequest`; nothing to inject into workloads.
+- **Per-workload certificates** — CN, SANs, IP SANs, URIs, EKU, duration and refresh via `unverifiedUserAnnotations` on the projected volume.
+- **Default-secure identity** — by default a pod can only obtain a certificate for its own apiserver-verified identity; `${...}` interpolation fills in per-pod values.
+- **CA hot-reload** — the CA cert/key are reloaded from disk on change; rotate without a restart.
+- **Trust distribution** — the current and previous CAs are published as a `ClusterTrustBundle` for workloads to mount.
+- **Hardened by default** — distroless non-root image, static CGO-disabled binary, restricted Pod Security Standard, least-privilege RBAC.
 
-## 📝 Usage
+## Documentation
 
-### 🏷️ Configuration via `unverifiedUserAnnotations`
-In order to not use controller defaults for certificates being generated - the cluster operator is able to customize them via the `userAnnotations` field of the `podCertificate` projected volume source. This is the standard Kubernetes mechanism for passing additional context to a signer: kubelet copies these keys verbatim into the `spec.unverifiedUserAnnotations` field of the resulting `PodCertificateRequest`, which is what the signer reads.
+| Topic | Where |
+| --- | --- |
+| Install, prerequisites, a working example | [docs/getting-started.md](./docs/getting-started.md) |
+| Annotation contract, CLI flags, Helm values, identity model, production posture | [docs/configuration.md](./docs/configuration.md) |
+| CA rotation, leader election, readiness, upgrades, troubleshooting | [docs/operations.md](./docs/operations.md) |
+| C4 diagrams, component overview, security posture | [docs/architecture.md](./docs/architecture.md) |
+| Threat model, reporting policy, supported versions | [SECURITY.md](./SECURITY.md) |
+| All chart values | [charts/podcertificate-signer/README.md](./charts/podcertificate-signer/README.md) |
+| Publishing the chart on Artifact Hub | [docs/artifact-hub.md](./docs/artifact-hub.md) |
 
-The scheme for configuration keys is `signer-domain/name-<configuration-item>: <value>` — the same keys as in the table below:
+## Release process
 
-```yaml
-  # ..... content not relevant for the example
+Releases are label-driven: every PR targeting `main` carries exactly one
+`release/*` label (`major`/`minor`/`patch`/`skip`), enforced by a required
+check. Publishing a release tags `vX.Y.Z`, pushes the multi-arch image to
+`ghcr.io/rafpe/pod-certificate-signer`, and packages the Helm chart to
+`oci://ghcr.io/rafpe/charts/podcertificate-signer`.
 
-      volumes:
-      - name: x509-cert
-        projected:
-          sources:
-          - podCertificate:
-              signerName: coolcert.example.com/foo
-              keyType: ED25519
-              credentialBundlePath: credentialbundle.pem
-              userAnnotations:
-                coolcert.example.com/foo-cn: "some-epic-name.com"
-                coolcert.example.com/foo-duration: "2h"
+## Contributing
 
-  # ..... rest of the manifest
-```
-
-> [!NOTE]
-> Keys the signer does not recognize, as well as malformed values (e.g. an invalid duration), result in the request being **Denied** with reason `InvalidUnverifiedUserAnnotations`, as recommended by the Kubernetes API contract for signers.
-
-### 🔒 Identity constraints (default-secure)
-
-> [!IMPORTANT]
-> By default the signer only issues certificates for the **requesting pod's own verified identity**. A `cn`, `san` or `uris` value is accepted only when it resolves to an identity the signer derives from the apiserver-verified `PodCertificateRequest` fields — the pod's name, its canonical Kubernetes DNS forms (`<pod>.<ns>.pod[.<fqdn>]`, `<pod>.<ns>.svc[.<fqdn>]`), its SPIFFE ID, or its service account (`<sa>.<ns>` and the SA SPIFFE ID). Any other value is **Denied**, so a pod author cannot obtain a certificate for an identity it does not own (e.g. `kubernetes.default.svc` or another team's service).
-
-Because a value authored on a pod template is identical for every replica, the intended way to set per-pod identities is `${...}` interpolation of verified fields (see below); a literal `cn: "some-name.com"` that does not match the pod's verified identity is denied. `node.name` and `pod.uid` are available for interpolation but are **not** claimable as a certificate subject (a node identity belongs to the kubelet; a UID is opaque). `ip-san` values have no verified derivation and are denied.
-
-**Escape hatch (not recommended).** To lift these constraints — allowing arbitrary literal `cn`/`san`/`ip-san`/`uris` values — start the controller with `--allow-unverified-identities` (Helm: `signer.allow_unverified_identities: true`). Only do this if a `ValidatingAdmissionPolicy` (or equivalent) already restricts which annotations workloads may set — see below.
-
-#### 🚧 Restricting annotations with a ValidatingAdmissionPolicy
-
-[examples/validating-admission-policy.yaml](./examples/validating-admission-policy.yaml) is a ready-to-apply `ValidatingAdmissionPolicy` and binding that decides, at admission time, which pods may set signer-prefixed `userAnnotations` on a `podCertificate` projected volume:
-
-- `cn`, `san`, `ip-san` and `uris` claim an identity, so they are rejected unless the pod's namespace carries an allowlist label — on the deprecated pod `annotations` path too, which no flag disables and which would otherwise be an open bypass
-- `eku`, `duration` and `refresh` only shape a certificate the pod is already entitled to, so any namespace may set them
-- any other key using the signer's prefix is rejected as a typo
-
-Substitute your own signer name, annotation prefix and label key before applying.
-
-[examples/validating-admission-policy-eku.yaml](./examples/validating-admission-policy-eku.yaml) is a second, standalone example focused on `eku`: it restricts which extended key usages a workload may request — `server`, `client`, or both — based on a `pcs.example.org/eku-profile` namespace label, so client-auth certificates can be confined to specific namespaces rather than available cluster-wide.
-
-**When to use it.** If you enable `--allow-unverified-identities`, this policy is what replaces the protection you just switched off — it is the "or equivalent" the escape hatch above refers to, and without it any pod author can request a certificate for any name. Under the default constraints it is still worth applying as defense in depth: a pod rejected at admission gives its author an immediate error, instead of a volume that never mounts and a `Denied` `PodCertificateRequest` they have to go and read.
-
-> [!WARNING]
-> **Breaking change.** Earlier releases issued certificates for arbitrary literal `cn`/`san`/`ip-san`/`uris` values and included `clientAuth` in the default extended key usage. Both defaults have changed: unverified identities are now denied, and the default EKU is `serverAuth` only. To restore the previous behaviour set `signer.allow_unverified_identities: true` **and** add `eku: server,client`; the recommended migration is to switch literal values to `${...}` interpolation and request client auth explicitly with the `eku` annotation.
-
-### 🧩 Interpolating pod identity into certificate values
-
-> [!IMPORTANT]
-> This is a feature flag, **disabled by default**. Enable it by starting the controller with `--enable-annotation-interpolation` (Helm: `signer.enable_annotation_interpolation: true`). While disabled, configuration values containing `${...}` are denied rather than issued verbatim.
-
-Values authored on a pod template are identical for every replica - so a static `cn` can never contain the pod's own name. With interpolation enabled, the `cn`, `san` and `uris` values may contain `${...}` placeholders which the signer resolves per request:
-
-```yaml
-          - podCertificate:
-              # ...
-              userAnnotations:
-                coolcert.example.com/foo-cn: "${pod.name}.${pod.namespace}.svc.${cluster.fqdn}"
-                coolcert.example.com/foo-san: "${pod.name}.${pod.namespace}.svc,${pod.serviceAccountName}.${pod.namespace}"
-                coolcert.example.com/foo-uris: "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}"
-```
-
-A complete runnable example - including the ClusterTrustBundle mount - is available in [examples/workload-pod.yaml](./examples/workload-pod.yaml) (it is also exercised by the e2e suite).
-
-Available variables - all resolved from fields of the `PodCertificateRequest` that kubelet populates and the kube-apiserver verifies (never from user-controlled input), so a workload can only interpolate its own verified identity:
-
-| Variable                    | Value                                        |
-| --------------------------- | -------------------------------------------- |
-| `${pod.name}`               | Name of the pod the certificate is issued to |
-| `${pod.namespace}`          | Namespace of the pod                         |
-| `${pod.uid}`                | UID of the pod                               |
-| `${pod.serviceAccountName}` | Service account the pod runs as              |
-| `${node.name}`              | Node the pod is scheduled on                 |
-| `${cluster.fqdn}`           | Cluster FQDN from the `-cluster-fqdn` flag   |
-
-Unknown variables and unterminated placeholders deny the request with reason `InvalidUnverifiedUserAnnotations`. Values are validated after expansion, including the 64 character common name limit from RFC 5280.
-
-### 🔮 CSR-requested SANs (forward compatibility)
-
-Upstream Kubernetes plans to let pod authors request DNS and IP SANs which kubelet embeds in the PKCS#10 CSR of the `PodCertificateRequest` (today kubelet generates completely empty CSRs). The controller is ready for this behind the `--honor-csr-sans` feature flag (Helm: `signer.honor_csr_sans`, disabled by default): when enabled, CSR-requested DNS and IP SANs are used unless a `san`/`ip-san` annotation overrides them. While disabled, CSR SANs are ignored, which the Kubernetes API contract explicitly allows for signers.
-
-Until then, IP SANs can be requested via the `ip-san` annotation — once kubelet gains native SAN support, the same values move into the pod spec and the annotation simply becomes the override.
-
-> [!NOTE]
-> An IP address has no verified derivation from the request fields, so the `ip-san` annotation is **denied by default** and requires `--allow-unverified-identities` (Helm: `signer.allow_unverified_identities: true`). See [Identity constraints](#-identity-constraints-default-secure).
-
-### 🏷️ Configuration via Pod Annotations (deprecated)
-
-> [!WARNING]
-> Configuration via pod annotations is deprecated and will be removed in a future release - use `unverifiedUserAnnotations` instead. When both are set, `unverifiedUserAnnotations` take precedence.
-
-Certificate configuration can also be provided via pod [`annotations`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
-
-Below is the table with the annotations and example values:
-
-| Annotation Prefix        | Required | Default Value                                                                       | Example                                                                                              |
-| ------------------------ | -------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `{signer-name}-cn`       | No       | `{pod-name}`                                                                        | `mysigner.example.com/foobar-cn: my-pod.default.pod.cluster.local`                                   |
-| `{signer-name}-san`      | No       | `{pod-name}.{namespace}.pod.cluster.local,{pod-name}.{namespace}.svc.cluster.local` | `mysigner.example.com/foobar-san: my-pod.default.pod.cluster.local,my-pod.default.svc.cluster.local` |
-| `{signer-name}-ip-san`   | No       | `(empty)`                                                                           | `mysigner.example.com/foobar-ip-san: 10.96.0.10,2001:db8::1`                                         |
-| `{signer-name}-eku`      | No       | `server` (serverAuth only; add `client` to opt in)                                  | `mysigner.example.com/foobar-eku: server,client`                                                     |
-| `{signer-name}-uris`     | No       | `(empty)`                                                                           | `mysigner.example.com/foobar-uris: spiffe://cluster.local/ns/default/sa/my-service`                  |
-| `{signer-name}-duration` | No       | `24h`                                                                               | `mysigner.example.com/foobar-duration: 12h`                                                          |
-| `{signer-name}-refresh`  | No       | `15m`                                                                               | `mysigner.example.com/foobar-refresh: 30m`                                                           |
-
-
-To customize certificates issued by PodCertificateSigner you can add one of the following annotations to your pod. This operation can be automated and delegated to your pipeline(s) or you can leverage native Kubernetes enhancment i.e `MutatingAdmissionPolicy`
-
-
-
-
-#### 🔗 Example configuration
-```yaml
-  # ..... content not relevant for the example
-
-  template:
-    metadata:
-      labels:
-        app: podcertificate-app
-      annotations:
-        coolcert.example.com/foo-cn: "some-epic-name.com"
-        coolcert.example.com/foo-san: "example.com, www.example.com, anotherexample.com.cy"
-        coolcert.example.com/foo-duration: "2h"
-        coolcert.example.com/foo-refresh: "30m"
-        coolcert.example.com/foo-uris: "https://example.com, https://www.example.com, https://anotherexample.com.cy"
-    spec:
-
-  # ..... rest of the manifest
-```
-
-
-### Requesting PodCertificates for your workload
-In order for the kube-apiserver to create new PodCertificateRequests your workload needs to use the `podCertificate` projected volume referencing a signer.
-The snippet below shows the crucial part of the configuration required - including mounting the signer's ClusterTrustBundle alongside the certificate, so the workload also has the trust anchors to verify its peers:
-```yaml
-  # ..... content not relevant for the example
-
-        volumeMounts:
-        - name: x509-cert
-          mountPath: /var/run/x509-cert
-      volumes:
-      - name: x509-cert
-        projected:
-          defaultMode: 420
-          sources:
-          - podCertificate:
-              keyType: RSA4096 # "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384", "ECDSAP521", "ED25519"
-              signerName: coolcert.example.com/foo # 👈 IMPORTANT! The signer name must match controller
-              credentialBundlePath: credentialbundle.pem
-          - clusterTrustBundle:
-              signerName: coolcert.example.com/foo # 👈 The CA bundle published by the controller
-              labelSelector: {} # required with signerName; {} selects all bundles for the signer
-              path: ca.crt
-
-  # ..... rest of the manifest
-```
-
-With this in place the container sees two files: `/var/run/x509-cert/credentialbundle.pem` (private key + issued certificate chain, kept fresh by kubelet) and `/var/run/x509-cert/ca.crt` (the signer's CA bundle, including previous CAs during rotation - use it to verify peer certificates for mTLS).
-
-#### 🔗 Example workload manifest
-The below provided deployment manifest is using GowebHTTPs server I wrote in Go in order to explore use of certificates in container environment. The certificate is customized via `userAnnotations` on the projected volume, and the signer's ClusterTrustBundle is mounted alongside it.
-
-
-```yaml
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: goweb
-  labels:
-    app: goweb-https
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: goweb-https
-  template:
-    metadata:
-      labels:
-        app: goweb-https
-    spec:
-      containers:
-      - name: server
-        image: ghcr.io/rafpe/goweb-https/server:d567d45
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        env:
-        - name: GOWEB_PORT
-          value: "8443"
-        - name: GOWEB_CERT_DIRECTORY_PATH
-          value: "/var/run/pcr-x509"
-        - name: TZ
-          value: "Europe/Amsterdam" # 👈 Update to match your timezone
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: CONTAINER_NAME
-          value: "server"
-        volumeMounts:
-        - name: pcr-x509
-          mountPath: /var/run/pcr-x509
-          readOnly: true
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          limits:
-            memory: "128Mi"
-            cpu: "100m"
-        securityContext:
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          runAsUser: 65532
-          runAsGroup: 65532
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
-      volumes:
-      - name: pcr-x509
-        projected:
-          defaultMode: 420
-          sources:
-          - podCertificate:
-              keyType: RSA4096
-              signerName: coolcert.example.com/foo
-              credentialBundlePath: credentialbundle.pem
-              userAnnotations:
-                coolcert.example.com/foo-cn: "some-epic-name.com"
-                coolcert.example.com/foo-san: "example.com,www.example.com,anotherexample.com.cy"
-                coolcert.example.com/foo-duration: "1h"
-                coolcert.example.com/foo-refresh: "45m"
-          - clusterTrustBundle:
-              signerName: coolcert.example.com/foo
-              labelSelector: {}
-              path: ca.crt
-      securityContext:
-        fsGroup: 65532
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 5
-```
-
-The pod ends up with `/var/run/pcr-x509/credentialbundle.pem` (key + issued certificate) and `/var/run/pcr-x509/ca.crt` (the signer's CA bundle for verifying peers).
-
-As a bonus point if using this workload demo you can check the certificate status via call to `/status` which provides detailed view of mounted certificate.
-```sh
-📜 Certificate Status:
-
-Domain: some-epic-name.com
-  File: /var/run/pcr-x509/credentialbundle.pem
-  CN: some-epic-name.com
-  Valid: 2025-09-24 11:33:54 UTC to 2025-09-24 12:33:54 UTC
-  Status: ⚠️  EXPIRES SOON (in 57m46s)
-```
-
-
-
-## ✅ Default PodCertificateSigner validation rules
-
-PodCertificateSigner performs the following `default` validations:
-
-1. **CA files provided**: Verifies the CA provided/mounted files exists and can be loaded
-2. **CA valid**: Ensures that the CA used to signing of certificates is a valid CA and not expired
-3. **PodCertificateRequest configuration**: Validates the configuration provided via `unverifiedUserAnnotations` (or deprecated pod annotations) against Kubernetes constraints
-
-The certificate configuration is validated against the constraints kube-apiserver enforces on the `PodCertificateRequest` status, so misconfigurations are denied immediately instead of failing on the API server:
-
-- The certificate duration must be at least `1h` (kube-apiserver minimum) and must not exceed the request's `spec.maxExpirationSeconds` (set by the pod author on the projected volume, defaulted to `24h` by kube-apiserver). The default duration is automatically clamped to `maxExpirationSeconds`.
-- The refresh hint must lie within the window kube-apiserver accepts for `beginRefreshAt`: `refresh` must be at least `10m` and at most the certificate duration minus `10m`.
-- The `eku` annotation accepts the tokens `client` and `server` (comma-separated); unknown tokens deny the request. **The default extended key usage is `serverAuth` only** — add `eku: server,client` (or `eku: client`) to request client authentication. Certificates for non-RSA keys carry only the `digitalSignature` key usage.
-
-## ⌘ Controller commandline options
-Controller is customizable and supports the following arguments along with their default values
-```
-  -allow-unverified-identities
-    	Allow annotation-provided cn/san/ip-san/uris values that do not resolve to the pod's verified identity. Off by default: unverified identities are denied and the default EKU is serverAuth only.
-  -ca-cert-path string
-    	CA certificate file.
-  -ca-key-path string
-    	CA private key file.
-  -cluster-fqdn string
-    	The FQDN of the cluster (default "cluster.local")
-  -enable-annotation-interpolation
-    	Allow ${...} placeholders (e.g. ${pod.name}, ${pod.serviceAccountName}) in certificate configuration annotations, resolved from the verified fields of the PodCertificateRequest.
-  -health-probe-bind-address string
-    	The address the probe endpoint binds to. (default ":8081")
-  -honor-csr-sans
-    	Honor DNS and IP SANs embedded in the kubelet-generated PKCS#10 CSR when no SAN annotation overrides them. Kubelet generates empty CSRs today; this prepares for upcoming Kubernetes support for requesting SANs.
-  -kubeconfig string
-    	Paths to a kubeconfig. Only required if out-of-cluster.
-  -leader-elect
-    	Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
-  -leader-election-id string
-    	The name of the configmap used to coordinate leader election between controller-managers. (default "pcs-leader-election")
-  -leader-election-namespace string
-    	Namespace for leader election (default: pod's namespace).
-  -max-concurrent-reconciles int
-    	maximum number of concurrent reconciles which can be run. (default 5)
-  -max-previous-ca-certs int
-    	maximum number of previous CA certificates to keep during CA rotation. (default 2)
-  -metrics-bind-address string
-    	The address on which to bind the metrics server. (default ":9090")
-  -reconcile-timeout duration
-    	maximum duration of a reconcile before it times out. (default 5m0s)
-  -signer-name string
-    	Only sign CSR with this .spec.signerName. (default "example.org/signer")
-  -zap-devel
-    	Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
-  -zap-encoder value
-    	Zap log encoding (one of 'json' or 'console')
-  -zap-log-level value
-    	Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
-  -zap-stacktrace-level value
-    	Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
-  -zap-time-encoding value
-    	Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
-```
-
-## 🔧 Troubleshooting
-Every system can experience issues. Below you may find the most commonly identified ones.
-
-### Common Issues
-
-1. **Signer name mismatch**
-   - Ensure signer name is correct in the controller
-   - Ensure signer name is correct in the projected volume of the pod(s)
-
-2. **CA failures**
-   - Verify CA is valid ( isCA )
-   - Verify private key is valid
-   - Ensure the CA is not expiring too soon
-
-3. **Configuration Errors**
-   - Check the `PodCertificateRequest` conditions: a `Denied` condition with reason `InvalidUnverifiedUserAnnotations` carries the exact configuration error in its message (`kubectl describe podcertificaterequest -n <namespace>`)
-   - Troubleshoot by incrementally changing the configuration to eliminate the source
-   - Keep checking the PodCertificateSigner logs
-
-### 📊 Logs
-
-PodCertificateSigner provides detailed logging for troubleshooting:
-
-```bash
-kubectl logs -n pcs-system deployment/podcertificate-signer
-```
-
-## 🛡️ Security Considerations
-
-- Use Kubernetes secrets to store certificates/keys
-- Monitor controller logs for suspicious activity
-- Use RBAC or ValidatingAdmissionPolicy to restrict access
-- Bonus: Use MutatingAdmissionPolicy/ValidatingAdmissionPolicy to control which `unverifiedUserAnnotations` workloads are allowed to request
-
-### Controller RBAC (least privilege)
-
-The chart grants the controller only the permissions it uses. Notably, `pods`
-is **`get` only** — the controller reads the associated pod directly (uncached)
-and does not `list`/`watch` pods, so it never caches every pod in the cluster.
-
-> [!IMPORTANT]
-> Because `pods` is `get`-only, roll the chart and image out **together**. The
-> previous binary relied on a cached pod informer (`list`/`watch`); upgrading the
-> chart ahead of the image would leave an old controller without the permissions
-> it needs. The chart `appVersion` pins the image tag so they ship as a unit.
-
-🔐 Remember: No security mechanism is effective without strong authentication and authorization. In Kubernetes, security begins with controlling who can access what — user identities , RBAC policies and MutatingAdmissionPolicies/ValidatingAdmissionPolicy to form the foundation of your cluster's defense.
-
-### 🔁 Rotating the signing CA
-
-> [!CAUTION]
-> **The sample CA that used to ship with this repository is not a secret.** `examples/ca_tls_secret.yaml` carried a CA private key in plain sight. It is removed from `HEAD` by [#37](https://github.com/rafpe/pod-certificate-signer/pull/37), which replaces it with an ephemeral CA generated at install time — but deleting a file does not unpublish a key, and it remains readable in git history. Anyone can recover it and mint certificates your workloads would trust. If that CA was ever loaded into a cluster that matters, treat it as compromised: rotate now, and treat every certificate issued under it as untrusted.
-
-Rotation is a secret update — there is nothing to restart:
-
-```sh
-kubectl create secret tls podcertificate-signer-ca \
-  --namespace pcs-system \
-  --cert=new-ca.pem \
-  --key=new-ca-key.pem \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
-
-What happens next:
-
-1. **The controller hot-reloads.** It watches the mounted CA files and reloads them in place, so new certificates are signed by the new CA without a rollout. Kubelet refreshes a mounted secret on its sync period (up to ~1 minute), so allow a short delay — and mount the secret as a plain volume, since a `subPath` mount is **never** updated after the pod starts.
-2. **The old CA stays trusted.** The controller republishes its `ClusterTrustBundle` with the new CA followed by the previous ones, keeping up to `--max-previous-ca-certs` (default `2`) of them. Workloads that mount the bundle (see [Requesting PodCertificates for your workload](#requesting-podcertificates-for-your-workload)) therefore keep verifying peers that are still holding a certificate from the old CA.
-3. **Certificates drain on their own.** Already-issued certificates remain valid until they expire — at most the request's `duration` (default `24h`, capped by `maxExpirationSeconds`) — and kubelet then requests a fresh one from the new CA.
-
-> [!IMPORTANT]
-> Leave **at least one full certificate lifetime** between rotations. Rotating more than `--max-previous-ca-certs` times inside that window drops the oldest CA out of the published bundle while certificates signed by it are still in use, and those workloads will fail peer verification. If you must rotate faster, raise `--max-previous-ca-certs` first.
-
-The retained history survives a restart: on startup the controller reseeds it from the `ClusterTrustBundle` it already published, so a rotation performed while the controller was down still keeps the previous CA trusted.
-
-## 📦 Release process
-
-Releases are fully label-driven. Every PR targeting `main` must carry exactly one of the following labels (enforced by a required PR check):
-
-| Label           | Effect on merge                                                        |
-| --------------- | ---------------------------------------------------------------------- |
-| `release/major` | Publishes a release with a **major** version bump (breaking changes)   |
-| `release/minor` | Publishes a release with a **minor** version bump (features)           |
-| `release/patch` | Publishes a release with a **patch** version bump (fixes)              |
-| `release/skip`  | No release; the change is collected into the next release draft        |
-
-Publishing the release creates the `v*` tag and chains directly into the release artifacts workflow (tags created by the workflow token never trigger workflows on their own; manually pushed `v*` tags and `workflow_dispatch` also work):
-
-- a multi-arch (`linux/amd64`, `linux/arm64`) image is built and pushed to `ghcr.io/rafpe/pod-certificate-signer` tagged `vX.Y.Z`, `vX.Y`, `vX` and `latest`
-- the Helm chart is packaged with `version: X.Y.Z` / `appVersion: vX.Y.Z` and pushed to `oci://ghcr.io/rafpe/charts/podcertificate-signer`
-
-One-time repository setup:
-
-```sh
-gh label create release/major --color B60205 --description "Breaking change: next release bumps the major version"
-gh label create release/minor --color 0E8A16 --description "Feature: next release bumps the minor version"
-gh label create release/patch --color 1D76DB --description "Fix: next release bumps the patch version"
-gh label create release/skip  --color C5DEF5 --description "No release: collect into the next release draft"
-
-# Seed the version baseline (the first automated release bumps from here)
-git tag v0.1.0 && git push origin v0.1.0
-```
-
-## 🤝 Contributing
-
-Contributions are welcome!
-
-For issues and questions:
-- 📝 Create an issue in the repository
-- 🔍 Check the troubleshooting section
-- 📊 Review the logs for error details
+Contributions are welcome — issues and pull requests both. Building requires Go
+1.26; see [CONTRIBUTING.md](./CONTRIBUTING.md) for the development workflow and
+the checks to run before opening a PR, and [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).

--- a/charts/podcertificate-signer/Chart.yaml
+++ b/charts/podcertificate-signer/Chart.yaml
@@ -26,3 +26,36 @@ appVersion: "latest"
 
 # Kubernetes version constraint
 kubeVersion: ">= 1.35.0"
+
+home: https://github.com/rafpe/pod-certificate-signer
+sources:
+  - https://github.com/rafpe/pod-certificate-signer
+maintainers:
+  - name: RafPe
+    url: https://github.com/RafPe
+
+annotations:
+  # Metadata consumed by Artifact Hub (https://artifacthub.io) to enrich the
+  # chart listing. Registration is a one-time manual step — see
+  # docs/artifact-hub.md.
+  artifacthub.io/category: security
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/links: |
+    - name: Source
+      url: https://github.com/RafPe/pod-certificate-signer
+    - name: Documentation
+      url: https://github.com/RafPe/pod-certificate-signer/tree/main/docs
+    - name: Security policy
+      url: https://github.com/RafPe/pod-certificate-signer/blob/main/SECURITY.md
+  # Image scanned/displayed by Artifact Hub. The release workflow overrides the
+  # chart version/appVersion from the git tag but does NOT currently rewrite this
+  # tag — bump it when it drifts from the released image (see docs/artifact-hub.md).
+  artifacthub.io/images: |
+    - name: pod-certificate-signer
+      image: ghcr.io/rafpe/pod-certificate-signer:v1.2.1
+  # Placeholder: cosign keyless signing arrives with hardening item H7. Once
+  # releases are signed, fill this in so Artifact Hub shows the signature.
+  # artifacthub.io/signKey: |
+  #   fingerprint: <cosign key fingerprint>
+  #   url: <public key URL>

--- a/charts/podcertificate-signer/README.md
+++ b/charts/podcertificate-signer/README.md
@@ -119,7 +119,7 @@ set. Enabling it renders `--allow-unverified-identities` on the controller.
 > EKU are no longer granted by default. To keep the old behaviour set
 > `signer.allow_unverified_identities: true` and add the `eku: server,client`
 > annotation; prefer migrating to `${...}` interpolation. See the
-> [repository README](../../README.md#-identity-constraints-default-secure).
+> [identity constraints documentation](../../docs/configuration.md#identity-constraints).
 
 > The `signer.allow_unverified_identities` value and this behaviour are
 > introduced together with the identity-constraint change (issue #26 / PR #38);

--- a/charts/podcertificate-signer/artifacthub-repo.yml
+++ b/charts/podcertificate-signer/artifacthub-repo.yml
@@ -1,0 +1,15 @@
+# Artifact Hub repository metadata.
+#
+# This file claims ownership of the OCI Helm repository on Artifact Hub and
+# marks it as a "Verified Publisher". It is pushed ONCE to the OCI registry
+# (not on every chart release) via `oras push ...:artifacthub.io` — see
+# docs/artifact-hub.md for the exact steps.
+#
+# TODO(maintainer): fill in `repositoryID` with the ID shown on the Artifact Hub
+# control panel after you add the repository, and set `owners[].email` to the
+# address on your Artifact Hub account (a mismatch fails ownership verification
+# silently). Then push this file to the registry.
+repositoryID: "" # TODO: paste the Repository ID from the Artifact Hub control panel
+owners:
+  - name: RafPe
+    email: "" # TODO: must match the email on your Artifact Hub account

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,193 @@
+# Architecture
+
+`pod-certificate-signer` is a Kubernetes controller for the built-in
+[`PodCertificateRequest`](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#pod-certificate-requests)
+API (`certificates.k8s.io/v1beta1`). When a pod declares a `podCertificate`
+projected volume that names this signer, the kube-apiserver creates a
+`PodCertificateRequest`; the controller validates it and either issues a
+short-lived x509 certificate from your CA or denies the request. In parallel it
+publishes the signer's CA — current and previously used, across rotations — as a
+[`ClusterTrustBundle`](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#cluster-trust-bundles)
+so workloads can mount the matching trust anchors next to their certificates.
+
+It is **not** a CSR (`CertificateSigningRequest`) signer and **not** an
+authentication proxy: the only requests it acts on are `PodCertificateRequest`
+objects that the apiserver itself creates and whose identity fields it has
+already verified.
+
+## Request flow
+
+1. A pod is created with a `podCertificate` projected volume that names this
+   signer. Kubelet generates the key pair and a PKCS#10 CSR, and the
+   kube-apiserver creates a `PodCertificateRequest` carrying the pod's
+   apiserver-verified identity fields.
+2. The controller's reconciler picks up the request for its signer name and
+   reads the requesting pod directly (an uncached `get`, never a cached
+   list/watch).
+3. It resolves the certificate configuration from the request's
+   `unverifiedUserAnnotations` (falling back to deprecated pod annotations),
+   enforces the identity constraints, and validates the result against the same
+   limits the apiserver applies to the request status.
+4. On success the signer builds and signs the leaf certificate from the current
+   CA and writes the credential bundle to the request status (`Issued`).
+   Otherwise the request is `Denied` or `Failed` with a reason.
+5. Kubelet delivers the issued credential bundle to the pod and keeps it fresh,
+   mounting the signer's `ClusterTrustBundle` alongside it for peer
+   verification.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Pod
+    participant Kubelet as kubelet
+    participant API as kube-apiserver
+    participant Ctrl as pod-certificate-signer
+    participant CA as Signing CA
+
+    Pod->>Kubelet: podCertificate projected volume
+    Kubelet->>API: Create PodCertificateRequest (+ PKCS#10 CSR)
+    API->>Ctrl: PodCertificateRequest event
+    Ctrl->>API: Get requesting pod (uncached)
+    Ctrl->>Ctrl: Validate identity & configuration
+    alt Valid
+        Ctrl->>CA: Sign leaf certificate
+        CA-->>Ctrl: Signed certificate
+        Ctrl->>API: Status Issued (credential bundle)
+        API->>Kubelet: Deliver bundle + ClusterTrustBundle
+        Kubelet->>Pod: Mount credential bundle + ca.crt
+    else Invalid
+        Ctrl->>API: Status Denied / Failed (reason)
+    end
+```
+
+## C4 model
+
+The following [C4 model](https://c4model.com/) views zoom in from the signer in
+its cluster environment down to the components inside the controller. They are
+generated from [`c4/workspace.dsl`](./c4/workspace.dsl) (Structurizr DSL) — edit
+the model there and keep the diagrams below in step. The Mermaid blocks render
+natively on GitHub.
+
+### System context (C4 level 1)
+
+Who the signer serves and what it depends on: a cluster operator provides the
+CA and configures the signer, workloads request certificates through the
+apiserver, and the signer watches `PodCertificateRequest`s and publishes the
+`ClusterTrustBundle`.
+
+```mermaid
+flowchart TB
+    operator["Cluster operator<br/><i>[Person]</i><br/>Provides the CA, sets the signer<br/>name, rotates the CA"]
+    workload["Workload author<br/><i>[Person]</i><br/>Ships pods that request a certificate"]
+
+    signer["pod-certificate-signer<br/><i>[Software System]</i><br/>Issues short-lived pod certificates<br/>and publishes the ClusterTrustBundle"]
+
+    api["kube-apiserver<br/><i>[External system]</i><br/>Creates &amp; verifies PodCertificateRequests,<br/>serves the ClusterTrustBundle"]
+    kubelet["kubelet<br/><i>[External system]</i><br/>Generates the CSR, mounts and<br/>refreshes the credential bundle"]
+    ca["Signing CA source<br/><i>[External system]</i><br/>CA cert + key, mounted read-only<br/>from a Secret"]
+
+    operator -->|Provisions &amp; rotates| ca
+    operator -->|Installs via Helm chart| signer
+    workload -->|Declares podCertificate volume| api
+    signer -->|Watches &amp; updates PodCertificateRequests,<br/>publishes ClusterTrustBundle| api
+    signer -->|Loads &amp; hot-reloads CA| ca
+    kubelet -->|Creates PodCertificateRequest| api
+    api -->|Delivers bundle + trust anchors| kubelet
+```
+
+### Containers (C4 level 2)
+
+The signer ships as a single deployable — one leader-elected controller
+Deployment — and integrates with the apiserver and the mounted CA.
+
+```mermaid
+flowchart TB
+    operator["Cluster operator<br/><i>[Person]</i>"]
+
+    subgraph signer["pod-certificate-signer [Software System]"]
+        controller["Controller<br/><i>[Container: Go, distroless/static:nonroot]</i><br/>controller-runtime manager running the<br/>reconciler, CA watcher and ClusterTrustBundle<br/>publisher; leader-elected"]
+    end
+
+    api["kube-apiserver<br/><i>[External system]</i>"]
+    ca["Signing CA source<br/><i>[External system]</i><br/>Secret-mounted CA cert + key"]
+
+    operator -->|Installs via Helm chart| controller
+    controller -->|Reconciles PodCertificateRequests<br/>and the ClusterTrustBundle, watch/patch HTTPS| api
+    controller -->|Reads &amp; watches the CA files<br/>read-only mount| ca
+```
+
+### Components (C4 level 3)
+
+Inside the controller, three concerns run in one process: reconciling requests,
+tracking the CA on disk, and publishing the trust bundle.
+
+```mermaid
+flowchart TB
+    api["kube-apiserver<br/><i>[External system]</i>"]
+    ca["Signing CA source<br/><i>[External system]</i>"]
+
+    subgraph controller["Controller [Container: Go]"]
+        reconciler["PodCertificateRequest reconciler<br/><i>[Component]</i><br/>Validates the request, then issues or denies"]
+        config["Certificate configuration<br/><i>[Component]</i><br/>Annotation contract, identity constraints,<br/>interpolation, status-contract validation"]
+        authority["Certificate authority<br/><i>[Component]</i><br/>In-memory CA, fsnotify hot-reload,<br/>retains previous CAs across rotation"]
+        signerCore["Signer<br/><i>[Component]</i><br/>Builds &amp; signs the leaf certificate;<br/>assembles the trust bundle"]
+        ctb["ClusterTrustBundle publisher<br/><i>[Component]</i><br/>Leader-gated; reconciles the bundle<br/>towards the current CA"]
+        probes["Health &amp; readiness<br/><i>[Component]</i><br/>healthz/readyz gated on CA and<br/>publisher health"]
+        metrics["Metrics<br/><i>[Component]</i><br/>Prometheus, incl. publish failures"]
+    end
+
+    api -->|PodCertificateRequest events| reconciler
+    reconciler -->|Reads requesting pod, updates status| api
+    reconciler -->|Resolves configuration| config
+    reconciler -->|Signs on success| signerCore
+    config -->|Fits lifetime to CA validity| authority
+    signerCore -->|Signs with current CA key| authority
+    authority -->|Watches &amp; reloads cert/key| ca
+    ctb -->|Reads current trust bundle PEM| authority
+    ctb -->|Creates/patches ClusterTrustBundle| api
+    probes -->|Polls watcher/reload health| authority
+    probes -->|Polls last publish outcome| ctb
+```
+
+## Component overview
+
+| Component | Responsibility | Leader-gated |
+| --- | --- | --- |
+| **PodCertificateRequest reconciler** | Watches `PodCertificateRequest`s for the configured signer name, reads the requesting pod (uncached `get`), drives validation and records the `Issued`/`Denied`/`Failed` outcome. | No — runs on every replica |
+| **Certificate configuration** | Parses the annotation contract, enforces identity constraints, resolves `${...}` interpolation, and validates duration/refresh/EKU against the apiserver status contract. | No |
+| **Certificate authority** | Holds the in-memory CA, hot-reloads the cert/key when the mounted files change (fsnotify), and retains up to `--max-previous-ca-certs` previous CAs across rotation. | No — every replica keeps its CA current |
+| **Signer** | Builds and signs the leaf certificate from the CSR and resolved configuration; assembles the trust bundle PEM. | No |
+| **ClusterTrustBundle publisher** | Reconciles the signer's `ClusterTrustBundle` towards the current CA on reload events and a 10-minute drift-repair tick, with single-flight retries. | **Yes** — only the elected leader writes the shared resource |
+| **Health & readiness** | Serves `healthz`/`readyz`; readiness is gated on CA watcher/reload health and the publisher's last outcome. | No |
+| **Metrics** | Exposes Prometheus metrics, including `ctb_publish_failures_total`. | No |
+
+The CA watcher runs on **every** replica so a standby never signs or publishes
+with stale material immediately after being promoted; only the publisher is
+leader-gated, so exactly one replica writes the shared `ClusterTrustBundle`. See
+[Operations](./operations.md) for how these behave during CA rotation, leader
+changes and restarts.
+
+## Security posture
+
+- **Distroless, non-root image.** The controller runs on
+  `gcr.io/distroless/static:nonroot` — no shell, no libc, no package manager —
+  as a non-root user (UID `65532`). There is nothing in the image to exec into
+  and almost no OS surface for a CVE to land on.
+- **Static, CGO-disabled binary.** The manager is built with `CGO_ENABLED=0` as
+  a fully static binary, so the image needs no dynamic libraries and the
+  attack surface is the Go binary alone.
+- **Restricted pod security by default.** The chart's defaults comply with the
+  `restricted` Pod Security Standard: `runAsNonRoot`, `seccompProfile:
+  RuntimeDefault`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`
+  and `capabilities: drop: [ALL]`.
+- **Least-privilege RBAC.** The controller reads pods with `get` only (uncached,
+  no cluster-wide pod informer) and touches only the `PodCertificateRequest` and
+  `ClusterTrustBundle` APIs it needs. Because `pods` is `get`-only, the chart and
+  image must roll out together — see [Operations: upgrades](./operations.md#upgrades).
+- **Default-secure identity model.** By default the signer issues certificates
+  only for the requesting pod's apiserver-verified identity, and the default
+  extended key usage is `serverAuth` only. See
+  [Configuration: identity constraints](./configuration.md#identity-constraints).
+- **CA private key handling.** The signing key is mounted read-only from a
+  Secret, held in memory, and hot-reloaded on rotation without a restart. See
+  [SECURITY.md](../SECURITY.md) for the full threat model and reporting policy.

--- a/docs/artifact-hub.md
+++ b/docs/artifact-hub.md
@@ -1,0 +1,66 @@
+# Publishing on Artifact Hub
+
+[Artifact Hub](https://artifacthub.io) is where most Helm users discover charts.
+Listing `podcertificate-signer` there makes it installable and searchable beyond
+GitHub.
+
+The chart is already prepared for it:
+
+- [`charts/podcertificate-signer/Chart.yaml`](../charts/podcertificate-signer/Chart.yaml)
+  carries `artifacthub.io/*` annotations (category, license, links, images) that
+  populate the listing.
+- [`charts/podcertificate-signer/artifacthub-repo.yml`](../charts/podcertificate-signer/artifacthub-repo.yml)
+  is the ownership file used to claim the repository and become a Verified
+  Publisher.
+
+Registration is a one-time manual step — it needs an Artifact Hub account.
+
+> [!NOTE]
+> Signed releases: cosign keyless signing is tracked separately (hardening item
+> H7). Once releases are signed, Artifact Hub detects and displays the signature
+> automatically, and the `artifacthub.io/signKey` annotation placeholder in
+> `Chart.yaml` should be filled in.
+
+## One-time setup
+
+1. **Sign in** at <https://artifacthub.io> (GitHub sign-in works).
+
+2. **Add the repository** under *Control Panel → Repositories → Add*:
+   - **Kind:** `Helm charts`
+   - **Name:** `podcertificate-signer` (this becomes the URL slug and **must**
+     match the Artifact Hub badge in the README)
+   - **URL:** `oci://ghcr.io/rafpe/charts/podcertificate-signer`
+
+3. **Copy the Repository ID** shown for the new repository and paste it into
+   `charts/podcertificate-signer/artifacthub-repo.yml` (replacing the
+   `repositoryID` placeholder). Also set `owners[].email` to the address on your
+   Artifact Hub account. Commit that change.
+
+4. **Publish the ownership metadata** to the OCI registry once, so Artifact Hub
+   can verify ownership (requires [`oras`](https://oras.land) and a GHCR login).
+   Artifact Hub reads this file **from the registry**, not from git:
+
+   ```bash
+   echo "$GITHUB_TOKEN" | oras login ghcr.io -u <your-github-user> --password-stdin
+
+   oras push ghcr.io/rafpe/charts/podcertificate-signer:artifacthub.io \
+     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+     charts/podcertificate-signer/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+   ```
+
+Artifact Hub re-indexes the repository within a few minutes and shows the chart,
+its annotations, and a "Verified Publisher" badge. The README's Artifact Hub
+badge stays a 404 until this registration completes.
+
+## Keeping the listing fresh
+
+Artifact Hub polls the OCI repository and picks up new chart versions
+automatically; the `artifacthub.io/*` annotations travel with each packaged
+chart.
+
+> [!NOTE]
+> The release workflow (`.github/workflows/release-image.yml`) overrides the
+> chart `version`/`appVersion` from the git tag, but does **not** currently
+> rewrite the `artifacthub.io/images` tag in `Chart.yaml`. Bump that annotation
+> when it drifts from the released image, or extend the workflow to rewrite it on
+> release.

--- a/docs/c4/workspace.dsl
+++ b/docs/c4/workspace.dsl
@@ -1,0 +1,99 @@
+workspace "pod-certificate-signer" "Signer for the built-in PodCertificateRequest API that issues short-lived pod certificates and publishes its CA as a ClusterTrustBundle" {
+
+    model {
+        operator = person "Cluster operator" "Installs the chart, provides the signing CA, sets the signer name and rotates the CA."
+        workload = person "Workload author" "Ships pods that request a certificate via a podCertificate projected volume."
+
+        apiServer = softwareSystem "kube-apiserver" "Creates PodCertificateRequests from projected volumes, verifies request fields, enforces the status contract and serves the ClusterTrustBundle." {
+            tags "External"
+        }
+
+        kubelet = softwareSystem "kubelet" "Generates the key pair and PKCS#10 CSR for the projected volume, mounts the issued credential bundle and the ClusterTrustBundle, and refreshes them." {
+            tags "External"
+        }
+
+        caSource = softwareSystem "Signing CA source" "The CA certificate and private key, mounted read-only from a Kubernetes Secret (recommended) or a bring-your-own volume." {
+            tags "External"
+        }
+
+        signer = softwareSystem "pod-certificate-signer" "Watches PodCertificateRequests for its signer name, issues or denies short-lived certificates from the CA, and keeps the signer's ClusterTrustBundle in sync." {
+            controller = container "Controller" "Kubernetes controller (controller-runtime manager) that runs the reconciler, the CA watcher and the ClusterTrustBundle publisher as a single leader-elected deployment." "Go, distroless/static:nonroot" {
+                reconciler = component "PodCertificateRequest reconciler" "Watches PodCertificateRequests for the configured signer name; validates the request and its annotation configuration, then issues or denies." "Go, controller-runtime"
+                config = component "Certificate configuration" "Parses the annotation contract (cn/san/ip-san/eku/duration/refresh/uris), enforces identity constraints, resolves ${...} interpolation and validates against the apiserver status contract." "Go"
+                authority = component "Certificate authority" "Holds the in-memory CA, hot-reloads the cert/key on disk change via an fsnotify watcher, and retains previous CAs across rotation." "Go, fsnotify + crypto/x509"
+                signerCore = component "Signer" "Builds and signs the leaf certificate from the CSR and resolved configuration; assembles the trust bundle for the signer." "Go, crypto/x509"
+                ctbPublisher = component "ClusterTrustBundle publisher" "Leader-gated runnable that reconciles the signer's ClusterTrustBundle towards the current CA on reload events and a drift-repair tick." "Go, controller-runtime"
+                probes = component "Health & readiness" "Serves healthz/readyz; readiness is gated on CA watcher/reload health and on the ClusterTrustBundle publisher outcome." "Go, healthz"
+                metrics = component "Metrics" "Exposes Prometheus metrics, including ClusterTrustBundle publish failures." "Go, Prometheus"
+            }
+        }
+
+        # People
+        operator -> caSource "Provisions the CA (Secret) and rotates it"
+        operator -> signer "Installs and configures via the Helm chart"
+        workload -> apiServer "Declares a podCertificate projected volume"
+
+        # System context
+        signer -> apiServer "Watches and updates PodCertificateRequests; publishes the ClusterTrustBundle" "watch/patch"
+        signer -> caSource "Loads and hot-reloads the CA cert/key" "read-only mount"
+        apiServer -> kubelet "Delivers the issued credential bundle and ClusterTrustBundle"
+        kubelet -> apiServer "Creates the PodCertificateRequest with a PKCS#10 CSR"
+
+        # Container level
+        controller -> apiServer "Reconciles PodCertificateRequests and the ClusterTrustBundle" "watch/patch, HTTPS"
+        controller -> caSource "Reads and watches the CA files" "read-only mount"
+
+        # Component level
+        reconciler -> config "Validates and resolves the requested configuration"
+        reconciler -> signerCore "Signs on success / records deny outcome"
+        config -> authority "Fits the certificate lifetime inside CA validity"
+        signerCore -> authority "Signs the leaf with the current CA key"
+        authority -> caSource "Watches and reloads the cert/key" "fsnotify"
+        ctbPublisher -> authority "Reads the current trust bundle PEM"
+        ctbPublisher -> apiServer "Creates/patches the ClusterTrustBundle" "HTTPS"
+        probes -> authority "Polls CA watcher/reload health"
+        probes -> ctbPublisher "Polls last publish outcome"
+        reconciler -> apiServer "Reads the requesting pod (uncached get) and updates request status" "HTTPS"
+    }
+
+    views {
+        systemContext signer "SystemContext" "Who the signer serves and what it depends on." {
+            include *
+            autoLayout
+        }
+
+        container signer "Containers" "The signer as a single deployable and the systems it integrates with." {
+            include *
+            autoLayout
+        }
+
+        component controller "Components" "The reconcile, CA and publication components inside the controller." {
+            include *
+            autoLayout
+        }
+
+        styles {
+            element "Person" {
+                shape Person
+                background #08427b
+                color #ffffff
+            }
+            element "Software System" {
+                background #1168bd
+                color #ffffff
+            }
+            element "Container" {
+                background #438dd5
+                color #ffffff
+            }
+            element "Component" {
+                background #85bbf0
+                color #000000
+            }
+            element "External" {
+                background #999999
+                color #ffffff
+            }
+        }
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,285 @@
+# Configuration
+
+This page documents everything you can tune: the per-request certificate
+annotation contract, the identity-constraint model, the controller CLI flags,
+and the Helm values including the recommended production posture. For a first
+install see [Getting started](./getting-started.md).
+
+## Certificate configuration annotations
+
+To override the controller defaults for an issued certificate, set keys on the
+`userAnnotations` field of the `podCertificate` projected volume source. This is
+the standard Kubernetes mechanism for passing context to a signer: kubelet
+copies these keys verbatim into `spec.unverifiedUserAnnotations` of the
+resulting `PodCertificateRequest`, which is what the signer reads.
+
+Keys follow the scheme `<signer-domain>/<name>-<item>: <value>` — the signer's
+own name as a prefix, then the configuration item:
+
+```yaml
+      volumes:
+        - name: x509-cert
+          projected:
+            sources:
+              - podCertificate:
+                  signerName: coolcert.example.com/foo
+                  keyType: ED25519
+                  credentialBundlePath: credentialbundle.pem
+                  userAnnotations:
+                    coolcert.example.com/foo-cn: "some-name.example.com"
+                    coolcert.example.com/foo-duration: "2h"
+```
+
+| Item | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `-cn` | No | pod name | Common name. Must resolve to the pod's verified identity unless `--allow-unverified-identities`. Max 64 chars (RFC 5280). |
+| `-san` | No | `<pod>.<ns>.pod.<fqdn>,<pod>.<ns>.svc.<fqdn>` | Comma-separated DNS SANs. Subject to identity constraints. |
+| `-ip-san` | No | *(empty)* | Comma-separated IP SANs. No verified derivation, so **denied by default** — requires `--allow-unverified-identities`. |
+| `-eku` | No | `server` | Extended key usage; tokens `server` and/or `client`. Add `client` to opt into client auth. |
+| `-uris` | No | *(empty)* | Comma-separated URI SANs (e.g. SPIFFE IDs). Subject to identity constraints. |
+| `-duration` | No | `24h` | Certificate lifetime. Clamped to the request's `maxExpirationSeconds`; minimum `1h`. |
+| `-refresh` | No | `15m` | Refresh hint (`beginRefreshAt`). At least `10m`, at most `duration − 10m`. |
+
+> [!NOTE]
+> Keys the signer does not recognise, and malformed values (e.g. an invalid
+> duration), deny the request with reason `InvalidUnverifiedUserAnnotations`, as
+> the Kubernetes API contract for signers recommends.
+
+### Interpolating pod identity into values
+
+> [!IMPORTANT]
+> This is a feature flag, **disabled by default**. Enable it with
+> `--enable-annotation-interpolation` (Helm:
+> `signer.enable_annotation_interpolation: true`). While disabled, values
+> containing `${...}` are denied rather than issued verbatim.
+
+A value authored on a pod template is identical for every replica, so a static
+`cn` can never carry the pod's own name. With interpolation enabled, the `cn`,
+`san` and `uris` values may contain `${...}` placeholders resolved per request:
+
+```yaml
+                  userAnnotations:
+                    coolcert.example.com/foo-cn: "${pod.name}.${pod.namespace}.svc.${cluster.fqdn}"
+                    coolcert.example.com/foo-san: "${pod.name}.${pod.namespace}.svc,${pod.serviceAccountName}.${pod.namespace}"
+                    coolcert.example.com/foo-uris: "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}"
+```
+
+Every variable resolves from fields of the `PodCertificateRequest` that kubelet
+populates and the apiserver verifies (never from user-controlled input), so a
+workload can only interpolate its **own** verified identity:
+
+| Variable | Value |
+| --- | --- |
+| `${pod.name}` | Name of the pod the certificate is issued to |
+| `${pod.namespace}` | Namespace of the pod |
+| `${pod.uid}` | UID of the pod |
+| `${pod.serviceAccountName}` | Service account the pod runs as |
+| `${node.name}` | Node the pod is scheduled on |
+| `${cluster.fqdn}` | Cluster FQDN from `--cluster-fqdn` |
+
+Unknown variables and unterminated placeholders deny the request with reason
+`InvalidUnverifiedUserAnnotations`. Values are validated **after** expansion,
+including the 64-character common-name limit.
+
+### CSR-requested SANs (forward compatibility)
+
+Upstream Kubernetes plans to let pod authors request DNS and IP SANs that
+kubelet embeds in the PKCS#10 CSR of the `PodCertificateRequest` (today kubelet
+generates empty CSRs). The controller is ready for this behind
+`--honor-csr-sans` (Helm: `signer.honor_csr_sans`, disabled by default): when
+enabled, CSR-requested DNS and IP SANs are used unless a `san`/`ip-san`
+annotation overrides them. While disabled, CSR SANs are ignored — which the API
+contract explicitly permits.
+
+Until then, IP SANs can be requested via the `ip-san` annotation; once kubelet
+gains native SAN support the same values move into the pod spec and the
+annotation becomes the override.
+
+### Configuration via pod annotations (deprecated)
+
+> [!WARNING]
+> Configuration via pod `annotations` is deprecated and will be removed in a
+> future release — use `unverifiedUserAnnotations` instead. When both are set,
+> `unverifiedUserAnnotations` take precedence.
+
+The same items (`cn`/`san`/`ip-san`/`eku`/`uris`/`duration`/`refresh`) can be
+set as pod [`annotations`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+with the same `<signer>/<name>-<item>` keys, e.g.
+`coolcert.example.com/foo-cn: some-name.example.com`. This path predates
+`userAnnotations` and is kept only for compatibility.
+
+## Identity constraints
+
+> [!IMPORTANT]
+> By default the signer issues certificates only for the **requesting pod's own
+> verified identity**. A `cn`, `san` or `uris` value is accepted only when it
+> resolves to an identity the signer derives from the apiserver-verified
+> `PodCertificateRequest` fields — the pod's name, its canonical Kubernetes DNS
+> forms (`<pod>.<ns>.pod[.<fqdn>]`, `<pod>.<ns>.svc[.<fqdn>]`), its SPIFFE ID, or
+> its service account (`<sa>.<ns>` and the SA SPIFFE ID). Any other value is
+> **Denied**, so a pod author cannot obtain a certificate for an identity it does
+> not own (e.g. `kubernetes.default.svc` or another team's service).
+
+Because a value authored on a pod template is identical for every replica, the
+intended way to set per-pod identities is `${...}` interpolation of verified
+fields (above); a literal `cn` that does not match the pod's verified identity is
+denied. `node.name` and `pod.uid` are available for interpolation but are **not**
+claimable as a certificate subject (a node identity belongs to the kubelet; a UID
+is opaque). `ip-san` values have no verified derivation and are denied.
+
+**Escape hatch (not recommended).** To lift these constraints — allowing
+arbitrary literal `cn`/`san`/`ip-san`/`uris` values — start the controller with
+`--allow-unverified-identities` (Helm: `signer.allow_unverified_identities:
+true`). Only do this if a `ValidatingAdmissionPolicy` (or equivalent) already
+restricts which annotations workloads may set.
+
+> [!WARNING]
+> **Breaking change.** Earlier releases issued certificates for arbitrary literal
+> `cn`/`san`/`ip-san`/`uris` values and included `clientAuth` in the default
+> extended key usage. Both defaults have changed: unverified identities are now
+> denied, and the default EKU is `serverAuth` only. To restore the previous
+> behaviour set `signer.allow_unverified_identities: true` **and** add
+> `eku: server,client`; the recommended migration is to switch literal values to
+> `${...}` interpolation and request client auth explicitly with `eku`.
+
+### Restricting annotations with a ValidatingAdmissionPolicy
+
+[`examples/validating-admission-policy.yaml`](https://github.com/rafpe/pod-certificate-signer/blob/main/examples/validating-admission-policy.yaml)
+is a ready-to-apply `ValidatingAdmissionPolicy` and binding that decides, at
+admission time, which pods may set signer-prefixed `userAnnotations`:
+
+- `cn`, `san`, `ip-san` and `uris` claim an identity, so they are rejected unless
+  the pod's namespace carries an allowlist label — on the deprecated pod
+  `annotations` path too, which no flag disables and which would otherwise be an
+  open bypass;
+- `eku`, `duration` and `refresh` only shape a certificate the pod is already
+  entitled to, so any namespace may set them;
+- any other key using the signer's prefix is rejected as a typo.
+
+[`examples/validating-admission-policy-eku.yaml`](https://github.com/rafpe/pod-certificate-signer/blob/main/examples/validating-admission-policy-eku.yaml)
+is a second, standalone example focused on `eku`: it restricts which extended key
+usages a workload may request (`server`, `client`, or both) based on a namespace
+label, so client-auth certificates can be confined to specific namespaces.
+
+**When to use it.** If you enable `--allow-unverified-identities`, this policy is
+what replaces the protection you switched off — without it any pod author can
+request a certificate for any name. Under the default constraints it is still
+worth applying as defense in depth: a pod rejected at admission gets an immediate
+error, instead of a volume that never mounts and a `Denied` request to go read.
+
+## Validation rules
+
+The controller performs these validations by default:
+
+1. **CA files present** — the mounted CA cert/key files exist and load.
+2. **CA valid** — the CA is a valid, non-expired CA.
+3. **Request configuration** — the `unverifiedUserAnnotations` (or deprecated
+   annotations) are validated against the constraints the apiserver enforces on
+   the request status, so misconfigurations are denied immediately:
+   - Duration is at least `1h` and no more than the request's
+     `spec.maxExpirationSeconds` (default `24h`); the default is clamped to it.
+   - The refresh hint lies within `beginRefreshAt`: at least `10m` and at most
+     the certificate duration minus `10m`.
+   - `eku` accepts `client` and/or `server`; unknown tokens deny. The default is
+     `serverAuth` only. Certificates for non-RSA keys carry only the
+     `digitalSignature` key usage.
+
+## Controller CLI flags
+
+The chart renders these from Helm values; you rarely set them directly.
+
+```
+  -allow-unverified-identities
+        Allow cn/san/ip-san/uris values that do not resolve to the pod's verified
+        identity. Off by default.
+  -ca-cert-path string        CA certificate file.
+  -ca-key-path string         CA private key file.
+  -cluster-fqdn string        FQDN of the cluster (default "cluster.local").
+  -enable-annotation-interpolation
+        Allow ${...} placeholders in certificate configuration annotations.
+  -health-probe-bind-address string   Probe endpoint address (default ":8081").
+  -honor-csr-sans             Honor DNS/IP SANs from the kubelet PKCS#10 CSR.
+  -kubeconfig string          Kubeconfig path; only for out-of-cluster runs.
+  -leader-elect               Enable leader election.
+  -leader-election-id string  Leader-election ConfigMap name (default "pcs-leader-election").
+  -leader-election-namespace string   Leader-election namespace (default: pod's namespace).
+  -max-concurrent-reconciles int      Max concurrent reconciles (default 5).
+  -max-previous-ca-certs int  Previous CAs retained across rotation (default 2).
+  -metrics-bind-address string        Metrics server address (default ":9090").
+  -reconcile-timeout duration Per-reconcile timeout (default 5m0s).
+  -signer-name string         Only sign requests with this .spec.signerName. Required.
+  -zap-* ...                  Standard zap logging flags (encoder, level, time encoding).
+```
+
+## Helm values
+
+The complete values reference — every key, default and the CA-source abstraction
+— lives in the [chart README](../charts/podcertificate-signer/README.md) and is
+documented inline in
+[`values.yaml`](../charts/podcertificate-signer/values.yaml). The essentials:
+
+### Providing the CA
+
+The signing CA is configured under `signer.ca` with an explicit `source`:
+
+- **`secretRef` (recommended, default)** — mount an existing Secret. The private
+  key stays in a Secret, the chart wires a read-only volume for you, and only the
+  CA cert + key are projected into the pod. `signer.ca.secretRef.name` is
+  **required**; an empty name fails `helm install`/`upgrade` at render time.
+- **`file` (advanced / BYO mount)** — you mount the cert/key yourself via
+  `.Values.volumes` / `.Values.volumeMounts` and point `signer.ca.file.certPath`
+  / `keyPath` at them.
+
+```yaml
+signer:
+  name: coolcert.example.com/foo
+  ca:
+    source: secretRef
+    secretRef:
+      name: podcertificate-signer-ca
+      certKey: tls.crt
+      keyKey: tls.key
+      mountPath: /app/signer/ca
+```
+
+### Recommended production posture
+
+The chart ships production-safe security defaults (restricted PSS, non-root,
+read-only rootfs) and `replicaCount: 2` with leader election. Two things are
+left as a conscious operator choice and should be set for production:
+
+- **Resource requests and limits.** `resources` is `{}` by default. Set modest
+  requests/limits — the controller is a lightweight point-reconciler:
+
+  ```yaml
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  ```
+
+- **A PodDisruptionBudget.** With two leader-elected replicas, a PDB keeps a
+  standby available during voluntary disruptions (node drains, upgrades):
+
+  ```yaml
+  apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    name: podcertificate-signer
+    namespace: pcs-system
+  spec:
+    minAvailable: 1
+    unhealthyPodEvictionPolicy: AlwaysAllow
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: podcertificate-signer
+  ```
+
+> [!NOTE]
+> Default `resources` values and a first-class `PodDisruptionBudget` chart
+> template are being finalised in the chart (hardening item H8). Until that lands,
+> set `resources` via values and apply the PDB above as a plain manifest — this
+> is the recommended production posture either way.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,127 @@
+# Getting started
+
+This guide takes you from an empty cluster to a workload holding a certificate
+issued by `pod-certificate-signer`. For the full configuration surface see
+[Configuration](./configuration.md); for day-2 tasks see
+[Operations](./operations.md).
+
+## Prerequisites
+
+- **Kubernetes 1.35+.** The controller uses the `certificates.k8s.io/v1beta1`
+  `PodCertificateRequest` API, available since 1.35. The cluster must have:
+  - feature gates `PodCertificateRequest`, `ClusterTrustBundle`,
+    `ClusterTrustBundleProjection`;
+  - runtime config `certificates.k8s.io/v1beta1=true`.
+- **Helm 3+** and **`kubectl`**.
+- **A signing CA** (certificate + private key). It can be self-signed. The chart
+  does **not** ship a CA — you provide your own.
+
+> [!TIP]
+> To try this on a laptop, [`kind/kind-config.yaml`](https://github.com/RafPe/pod-certificate-signer/blob/main/kind/kind-config.yaml)
+> enables the required feature gates and runtime config for a local Kind cluster.
+
+## 1. Create the CA Secret
+
+You need a CA the controller will use to sign requests. Generate one with
+[cfssl](https://github.com/cloudflare/cfssl), [cert-manager](https://cert-manager.io/),
+or `openssl`; if you already have a CA, skip creation and use it as the source.
+
+Create a `kubernetes.io/tls` Secret from the CA in the namespace you deploy into:
+
+```sh
+kubectl create namespace pcs-system
+kubectl create secret tls podcertificate-signer-ca \
+  --namespace pcs-system \
+  --cert=ca.pem \
+  --key=ca-key.pem
+```
+
+> [!WARNING]
+> Use a CA you generated yourself. A sample CA (`examples/ca_tls_secret.yaml`)
+> once shipped with this repository; it is removed from `HEAD` by
+> [#37](https://github.com/rafpe/pod-certificate-signer/pull/37), but its private
+> key remains readable in git history and must never be used anywhere real. See
+> [Operations: rotating the signing CA](./operations.md#rotating-the-signing-ca).
+
+## 2. Install the chart
+
+The chart is published to GHCR as an OCI artifact on every release, alongside
+the controller image. `signer.name` and a CA source are **required**:
+
+```sh
+helm install podcertificate-signer oci://ghcr.io/rafpe/charts/podcertificate-signer \
+  --version <X.Y.Z> \
+  --namespace pcs-system \
+  --set signer.name=coolcert.example.com/foo \
+  --set signer.ca.secretRef.name=podcertificate-signer-ca
+```
+
+Replace `<X.Y.Z>` with the [latest release](https://github.com/rafpe/pod-certificate-signer/releases);
+omit `--version` for the latest. With `signer.ca.source=secretRef` (the default)
+the chart wires a read-only volume for the Secret automatically — there is no
+`volumes`/`volumeMounts` to plumb. See
+[Configuration: providing the CA](./configuration.md#providing-the-ca) for the
+`file` (bring-your-own-mount) alternative and the full values reference.
+
+Confirm the controller is running and has published its trust bundle:
+
+```sh
+kubectl -n pcs-system rollout status deploy/podcertificate-signer
+kubectl get clustertrustbundle
+```
+
+### Deploying from a local checkout
+
+For development, `make helm-deploy` builds the image, loads it into a local Kind
+cluster and installs the chart with the example values. `make helm-uninstall`,
+`make helm-status` and `make helm-rollback` manage the release.
+
+## 3. Request a certificate from a workload
+
+A workload opts in by declaring a `podCertificate` projected volume that names
+the signer, and (recommended) mounting the signer's `ClusterTrustBundle`
+alongside it so it also has the trust anchors to verify peers:
+
+```yaml
+      volumeMounts:
+        - name: x509-cert
+          mountPath: /var/run/x509-cert
+      volumes:
+        - name: x509-cert
+          projected:
+            defaultMode: 420
+            sources:
+              - podCertificate:
+                  keyType: RSA4096   # RSA3072, RSA4096, ECDSAP256/384/521, ED25519
+                  signerName: coolcert.example.com/foo   # must match the controller
+                  credentialBundlePath: credentialbundle.pem
+              - clusterTrustBundle:
+                  signerName: coolcert.example.com/foo   # the CA bundle the controller publishes
+                  labelSelector: {}                      # required with signerName; {} selects all
+                  path: ca.crt
+```
+
+The container then sees two files:
+
+- `/var/run/x509-cert/credentialbundle.pem` — the private key plus the issued
+  certificate chain, kept fresh by kubelet;
+- `/var/run/x509-cert/ca.crt` — the signer's CA bundle (including previous CAs
+  during rotation), used to verify peer certificates for mTLS.
+
+A complete, runnable manifest — including per-pod identity via annotations — is
+in [`examples/workload-pod.yaml`](https://github.com/rafpe/pod-certificate-signer/blob/main/examples/workload-pod.yaml)
+(it is also exercised by the e2e suite).
+
+> [!NOTE]
+> With controller defaults the certificate is issued for the pod's own verified
+> identity. To set a custom common name, SANs, duration, EKU or SPIFFE URIs, use
+> the annotation contract in [Configuration](./configuration.md#certificate-configuration-annotations).
+
+## Next steps
+
+- [Configuration](./configuration.md) — the annotation contract, CLI flags, Helm
+  values, the identity-constraint model and production-recommended settings.
+- [Operations](./operations.md) — CA rotation, leader election, readiness,
+  upgrades and troubleshooting.
+- [Architecture](./architecture.md) — C4 diagrams, component overview and
+  security posture.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,142 @@
+# Operations
+
+Day-2 tasks: rotating the CA, understanding leader election and readiness, how
+the `ClusterTrustBundle` is published, upgrades and troubleshooting. For the
+component model behind these behaviours see [Architecture](./architecture.md).
+
+## Rotating the signing CA
+
+> [!CAUTION]
+> **The sample CA that used to ship with this repository is not a secret.**
+> `examples/ca_tls_secret.yaml` carried a CA private key in plain sight. It is
+> removed from `HEAD` by [#37](https://github.com/rafpe/pod-certificate-signer/pull/37),
+> which replaces it with an ephemeral CA generated at install time — but deleting
+> a file does not unpublish a key, and it remains readable in git history. Anyone
+> can recover it and mint certificates your workloads would trust. If that CA was
+> ever loaded into a cluster that matters, treat it as compromised: rotate now,
+> and treat every certificate issued under it as untrusted.
+
+Rotation is a Secret update — there is nothing to restart:
+
+```sh
+kubectl create secret tls podcertificate-signer-ca \
+  --namespace pcs-system \
+  --cert=new-ca.pem \
+  --key=new-ca-key.pem \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+What happens next:
+
+1. **The controller hot-reloads.** Every replica watches the mounted CA files
+   (fsnotify) and reloads them in place, so new certificates are signed by the
+   new CA without a rollout. Kubelet refreshes a mounted Secret on its sync
+   period (up to ~1 minute), so allow a short delay — and mount the Secret as a
+   plain volume, since a `subPath` mount is **never** updated after the pod
+   starts.
+2. **The old CA stays trusted.** The elected leader republishes the
+   `ClusterTrustBundle` with the new CA followed by the previous ones, keeping up
+   to `--max-previous-ca-certs` (default `2`). Workloads that mount the bundle
+   keep verifying peers still holding a certificate from the old CA.
+3. **Certificates drain on their own.** Already-issued certificates stay valid
+   until they expire — at most the request's `duration` (default `24h`, capped by
+   `maxExpirationSeconds`) — and kubelet then requests a fresh one from the new
+   CA.
+
+> [!IMPORTANT]
+> Leave **at least one full certificate lifetime** between rotations. Rotating
+> more than `--max-previous-ca-certs` times inside that window drops the oldest CA
+> out of the published bundle while certificates signed by it are still in use,
+> and those workloads will fail peer verification. If you must rotate faster,
+> raise `--max-previous-ca-certs` first.
+
+The retained history survives a restart: on startup the controller reseeds it
+from the `ClusterTrustBundle` it already published, so a rotation performed while
+the controller was down still keeps the previous CA trusted. If that history
+cannot be read on startup, the controller **fails closed** (refuses to start)
+rather than publish an empty bundle and drop previously-trusted CAs.
+
+## Leader election and replicas
+
+The chart runs `replicaCount: 2` with `leader_election.enabled: true`. Work is
+split deliberately between every-replica and leader-only duties:
+
+- **CA watching and signing run on every replica.** A standby keeps its
+  in-memory CA current, so it never signs with stale material immediately after
+  being promoted.
+- **`ClusterTrustBundle` publication is leader-gated.** Only the elected leader
+  writes the shared resource, so replicas cannot fight over it.
+
+Autoscaling (`autoscaling.enabled`) is of limited use for a leader-elected
+controller — extra replicas are warm standbys, not additional throughput.
+
+## Readiness and health
+
+The controller serves two endpoints (default port `:8081`):
+
+- **`/healthz`** — liveness; a simple ping.
+- **`/readyz`** — readiness, gated on two signals:
+  - **CA health** — a replica whose CA watcher has died, or whose reloads have
+    been failing persistently, is pulled from readiness so it is not relied upon
+    to sign or publish with stale material. A *transient* reload failure keeps the
+    replica ready, because the last-good CA is retained and signing still works.
+  - **ClusterTrustBundle publisher** — a leader whose publishes keep failing after
+    retries is pulled from readiness, so the failure is visible and leadership can
+    move elsewhere.
+
+## ClusterTrustBundle publication
+
+The publisher reconciles the signer's `ClusterTrustBundle` towards the current
+CA. It publishes on startup (so a newly-elected leader publishes from the current
+in-memory CA), on every CA reload event, and on a periodic **drift-repair tick**
+(every 10 minutes) that re-publishes even without a reload — repairing a manual
+edit or a lost event. Publishes are single-flight and retried with exponential
+backoff; failures after the retry budget increment the
+`ctb_publish_failures_total` metric and fail the leader's readiness.
+
+Inspect the published bundle:
+
+```sh
+kubectl get clustertrustbundle
+kubectl get clustertrustbundle <name> -o jsonpath='{.spec.trustBundle}' \
+  | openssl crl2pkcs7 -nocrl -certfile /dev/stdin | openssl pkcs7 -print_certs -noout
+```
+
+## Upgrades
+
+> [!IMPORTANT]
+> **Roll the chart and image out together.** The controller's RBAC grants `pods`
+> as **`get` only** — it reads the associated pod directly (uncached) and does not
+> `list`/`watch` pods. A previous binary relied on a cached pod informer
+> (`list`/`watch`), so upgrading the chart ahead of the image would leave an old
+> controller without the permissions it needs. The chart `appVersion` pins the
+> image tag so they ship as a unit; a normal `helm upgrade` to a released chart
+> version keeps them aligned.
+
+## Troubleshooting
+
+**Signer name mismatch** — the most common issue. Ensure the `--signer-name`
+(Helm `signer.name`) matches the `signerName` in every workload's projected
+volume exactly.
+
+**CA failures** — verify the CA is a valid CA (`isCA`), the private key matches,
+and it is not expiring too soon.
+
+**Configuration errors** — a `Denied` condition with reason
+`InvalidUnverifiedUserAnnotations` carries the exact error in its message:
+
+```sh
+kubectl describe podcertificaterequest -n <namespace>
+```
+
+Narrow it down by changing the configuration incrementally, and watch the
+controller logs alongside.
+
+### Logs
+
+```sh
+kubectl logs -n pcs-system deployment/podcertificate-signer
+```
+
+Adjust verbosity with `log.level` (`info`, `error`, `debug`, `panic`) and
+`log.encoder` (`console` or `json`) in the chart values.


### PR DESCRIPTION
Part of #52 (hardening epic items H12 + H13, plus Artifact Hub prep).

## Summary

Restructures the 542-line README into a compact hero + badge row + Why +
quickstart + documentation table, and extracts the deep content into a new
`docs/` tree modelled on the reference project's layout and quality bar.

**README (H12)**
- Hero: social card, one-line description, a short "Why".
- Relevant badge row only: Tests, Lint, License (Apache-2.0), Release, Go
  version, Artifact Hub. No Go Report Card (sunset); Scorecard left behind a
  `<!-- ... -->` comment pending the `publish_results` flip after CA rotation.
- Replaced the 28-line inline TOC with a Documentation table linking into
  `docs/`. De-emoji headings, GitHub `> [!NOTE]`/`> [!WARNING]` callouts.
- No `untitled.md` was present to delete.

**docs/ tree (H13)**
- `getting-started.md` — prerequisites (K8s 1.35+, feature gates), Helm install,
  a working workload example.
- `configuration.md` — annotation contract (`cn/san/ip-san/eku/duration/refresh/uris`),
  interpolation, CSR SANs, identity-constraint model + `--allow-unverified-identities`,
  VAP examples, CLI flags, Helm values / CA-source abstraction, and the
  recommended production posture (resource requests/limits + a PodDisruptionBudget).
- `operations.md` — CA rotation runbook, leader election, readiness/health,
  ClusterTrustBundle publication, upgrades, troubleshooting.
- `architecture.md` — C4 System Context / Container / Component diagrams
  (Mermaid), component overview, and the security posture (distroless/static:nonroot,
  non-root UID, static CGO-disabled binary).
- `c4/workspace.dsl` — Structurizr source of truth for the C4 model.
- `artifact-hub.md` — one-time repository registration steps.

**Artifact Hub prep (item 4)**
- `artifacthub.io/*` annotations in `charts/podcertificate-signer/Chart.yaml`
  (category, license, links, images, `signKey` placeholder for H7).
- `charts/podcertificate-signer/artifacthub-repo.yml` ownership file
  (`repositoryID` and `owners[].email` left as maintainer TODOs).
- Repointed the chart README cross-link to the moved docs content.

## Validation

- `helm lint charts/podcertificate-signer` passes; `helm template ... --set
  signer.ca.secretRef.name=test-ca` renders (11 resources, with
  `--kube-version 1.35.0`).
- All 4 Mermaid blocks validated with `@mermaid-js/mermaid-cli` (render clean).
- Every relative link and intra/cross-doc anchor across README + docs + chart
  README resolves (scripted check, 7 files).
- `Chart.yaml` and `artifacthub-repo.yml` parse as YAML.
- Release/Go/Artifact Hub shields badges return 200. The Actions badges
  (`test.yml`, `lint.yml`) point at workflows that exist on `main`; unauthenticated
  curls return 422 exactly as the reference repo's badges do (a GitHub artifact,
  not a broken ref).

## Manual steps for the maintainer (Artifact Hub)

- [ ] Sign in at https://artifacthub.io and add the repository: Kind **Helm
      charts**, Name **`podcertificate-signer`** (must match the README badge
      slug), URL `oci://ghcr.io/rafpe/charts/podcertificate-signer`.
- [ ] Paste the Repository ID into `charts/podcertificate-signer/artifacthub-repo.yml`
      (`repositoryID`) and set `owners[].email` to your Artifact Hub account email.
- [ ] Push the ownership file to the registry once with `oras push
      ghcr.io/rafpe/charts/podcertificate-signer:artifacthub.io ...` (full command
      in `docs/artifact-hub.md`).
- [ ] Upload the social preview under the repo's GitHub settings if not already set.

> The Artifact Hub badge 404s until this registration completes — expected, not a
> broken-badge regression.

## Decisions to confirm

- **Security row → root `SECURITY.md`** (already present, 13KB) rather than a new
  `docs/security.md`.
- **Omitted `artifacthub.io/operator`** — this signs an upstream built-in API and
  ships no CRDs, so the operator flag is not appropriate. Easy to add if you disagree.
- **`artifacthub.io/images` pinned to `v1.2.1`** and `prerelease: "false"`: the
  release workflow overrides chart `version`/`appVersion` from the tag but does
  **not** rewrite the images tag, so it will drift on future releases. Bump it
  when it drifts, or extend `release-image.yml` to rewrite it (noted in
  `docs/artifact-hub.md`). `Chart.yaml` `version`/`appVersion` left untouched.
- **PDB documented as a plain manifest** pending the chart template in H8, not a
  new values key.
- **C4 rendered as Mermaid `flowchart` with C4-typed labels** (renders natively on
  GitHub) rather than Structurizr-exported PNGs; `docs/c4/workspace.dsl` is kept
  as the C4 source of truth.
