### PR TITLE
fix(H8): digest-pin image + -trimpath, chart PDB + resource defaults (closes #50)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+# Digest-pinned for reproducible builds; refresh the digest when bumping the tag.
+FROM golang:1.26@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -20,11 +21,15 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/podcertificate-signer/main.go
+# -trimpath strips local filesystem paths for reproducible builds;
+# -ldflags="-s -w" drops the symbol table and DWARF debug info for a smaller binary.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -a -trimpath -ldflags="-s -w" -o manager cmd/podcertificate-signer/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Digest-pinned for reproducible builds; refresh the digest when bumping the tag.
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 LABEL org.opencontainers.image.source=https://github.com/rafpe/pod-certificate-signer
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/charts/podcertificate-signer/README.md
+++ b/charts/podcertificate-signer/README.md
@@ -93,7 +93,10 @@ The signing CA is configured under `signer.ca` with an explicit `source`:
 | **`signer.allow_unverified_identities`** | **Security escape hatch.** When `false`, annotation `cn`/`san`/`ip-san`/`uris` values must resolve to the pod's verified identity, and IP SANs are denied. See [Identity constraints](#identity-constraints-security). | `false` |
 | `manager.max_concurrent_reconciles` | Concurrent reconciles. | `5` |
 | `manager.reconcile_timeout` | Per-reconcile timeout. | `"5m"` |
-| `resources` | Container resource requests/limits (unset by default — set them in production). | `{}` |
+| `resources` | Container resource requests/limits. Conservative defaults for a lightweight controller; set `{}` to leave it unconstrained. | requests `100m`/`128Mi`, limits `500m`/`256Mi` |
+| `podDisruptionBudget.enabled` | Create a PodDisruptionBudget for the controller. | `true` |
+| `podDisruptionBudget.minAvailable` / `.maxUnavailable` | Disruption budget (mutually exclusive; `minAvailable` wins when both set). With 2 replicas `minAvailable: 1` drains one at a time; switch to `maxUnavailable: 1` if you scale to a single replica. | `1` / `""` |
+| `podDisruptionBudget.unhealthyPodEvictionPolicy` | Eviction policy so a not-yet-Ready pod can't wedge a node drain. | `AlwaysAllow` |
 | `serviceAccount.create` / `serviceAccount.automount` | ServiceAccount management. | `true` / `true` |
 | `volumes` / `volumeMounts` | Extra volumes/mounts. Only needed to mount the CA yourself when `signer.ca.source=file`; `secretRef` mode wires the CA volume for you. | `[]` |
 | `podSecurityContext` / `securityContext` | PSS-restricted defaults (non-root, seccomp `RuntimeDefault`, read-only rootfs, drop `ALL`). | see `values.yaml` |

--- a/charts/podcertificate-signer/templates/poddisruptionbudget.yaml
+++ b/charts/podcertificate-signer/templates/poddisruptionbudget.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- $pdb := .Values.podDisruptionBudget }}
+{{- if and (not $pdb.minAvailable) (not $pdb.maxUnavailable) }}
+{{- fail "podDisruptionBudget requires either minAvailable or maxUnavailable to be set" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "podcertificate-signer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "podcertificate-signer.labels" . | nindent 4 }}
+spec:
+  {{- if $pdb.minAvailable }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- end }}
+  {{- with $pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "podcertificate-signer.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/podcertificate-signer/values.yaml
+++ b/charts/podcertificate-signer/values.yaml
@@ -146,17 +146,18 @@ service:
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 80
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# Container resource requests/limits. Conservative production defaults for a
+# lightweight, mostly-idle controller: requests reserve a small baseline so the
+# pod schedules and keeps its Guaranteed share, while the limits cap bursts
+# during reconcile storms and the memory limit guards against a runaway. Tune
+# for your cluster size; set to {} to leave the container unconstrained.
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
@@ -167,6 +168,21 @@ readinessProbe:
   httpGet:
     path: /readyz
     port: http
+
+# PodDisruptionBudget for the controller. With the default replicaCount of 2
+# (leader-elected: one active, one warm standby), minAvailable: 1 lets a node be
+# drained one replica at a time while always keeping a pod that can hold the lease.
+# unhealthyPodEvictionPolicy: AlwaysAllow lets the node drain evict a pod that is
+# already unhealthy (e.g. not yet Ready) so a bad replica can never wedge a drain.
+# NOTE: if you enable the HPA and it scales the Deployment down to 1, minAvailable: 1
+# blocks node drains for the sole pod — switch to maxUnavailable: 1 in that case.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  # Set maxUnavailable instead of minAvailable (mutually exclusive; minAvailable
+  # wins when both are set).
+  maxUnavailable: ""
+  unhealthyPodEvictionPolicy: AlwaysAllow
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:


### PR DESCRIPTION
Part of #52. Closes #50.

## Summary

Production-readiness defaults for the image and the Helm chart. Nothing changes the base images' identity; the chart stays values-driven and backward compatible.

**Dockerfile**
- Digest-pin both stages: `golang:1.26@sha256:2005724…` (builder) and `gcr.io/distroless/static:nonroot@sha256:f7f8f72…` (runtime). Human-readable tags kept in comments. Both digests are current multi-arch manifest lists carrying the release platforms (linux/amd64, linux/arm64).
- Add `-trimpath` and `-ldflags="-s -w"` for reproducibility and a smaller binary. No version stamping exists in the Makefile/workflows to clobber.

**Chart**
- New `PodDisruptionBudget` template, guarded by `podDisruptionBudget.enabled` (default `true`), with `minAvailable: 1` and `unhealthyPodEvictionPolicy: AlwaysAllow`. Sized for the 2-replica leader-elected controller (one active, one warm standby): one replica can be drained at a time while a lease-holder stays up. `minAvailable`/`maxUnavailable` are configurable and mutually exclusive; a `fail` guard catches the both-unset misconfiguration.
- Default resource requests/limits in `values.yaml` (requests `100m`/`128Mi`, limits `500m`/`256Mi`) — conservative for a lightweight, mostly-idle controller. The deployment already consumes `.Values.resources`.
- Chart README values table updated for the new keys and the changed `resources` default.

## Behavior change on upgrade

Existing installs previously had `resources: {}` (BestEffort QoS). This populates requests/limits, so an upgrade triggers a rollout and moves the pod to Burstable QoS — the intended point of the change. A PDB is also created by default; set `podDisruptionBudget.enabled=false` to opt out. `Chart.yaml` `version`/`appVersion` are left untouched (the release workflow rewrites them).

## Validation

- `helm lint charts/podcertificate-signer` — passes.
- `helm template --set signer.ca.secretRef.name=test-ca` — renders the PDB (`minAvailable: 1`, `unhealthyPodEvictionPolicy: AlwaysAllow`) and container `resources`.
- `--set podDisruptionBudget.enabled=false` — omits the PDB.
- `--set podDisruptionBudget.minAvailable=null --set podDisruptionBudget.maxUnavailable=1` — renders `maxUnavailable`; both-unset fails with a clear message.
- `docker buildx build --platform linux/amd64,linux/arm64 --output=type=cacheonly .` — builds green on both arches with the pinned digests.

> [!NOTE]
> Held at v1.2.1 — no version bump. Labeled `release/skip`.