### PR TITLE
ci(H7): cosign keyless signing + SBOM for released image; fix Artifact Hub images drift

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -40,6 +40,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Mint an OIDC token so cosign can sign the image keyless (Fulcio/Rekor).
+      id-token: write
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
@@ -72,6 +74,7 @@ jobs:
             type=semver,pattern=v{{major}},value=${{ env.RELEASE_TAG }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -81,6 +84,29 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Generate a per-platform SPDX SBOM and attach it to the image index as
+          # an in-toto attestation. buildx fails the build if generation fails, so
+          # a missing SBOM never slips through silently on a signer release.
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.3
+
+      - name: Sign the image (keyless)
+        env:
+          # Pushed image index digest from the build step; sign BY DIGEST so the
+          # signature is bound to the exact content, never a mutable tag.
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::build step produced no image digest; refusing to sign" >&2
+            exit 1
+          fi
+          # Sign the multi-arch image index by digest. Tags resolve to this index
+          # digest, so this is what consumers verify.
+          cosign sign --yes "${IMAGE_REPO}@${DIGEST}"
 
   push-chart:
     name: Package and push Helm chart
@@ -103,6 +129,18 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
             helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Pin the Artifact Hub image annotation to the released tag
+        run: |
+          # yq reads IMAGES via strenv so the multi-line value stays a literal
+          # block scalar instead of collapsing to a quoted one-liner.
+          IMAGES="- name: pod-certificate-signer
+            image: ${IMAGE_REPO}:${RELEASE_TAG}"
+          export IMAGES
+          yq -i '
+            .annotations."artifacthub.io/images" = strenv(IMAGES)
+            | .annotations."artifacthub.io/images" style="literal"
+          ' charts/podcertificate-signer/Chart.yaml
 
       - name: Package the chart
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # A called workflow's jobs are capped by the caller's grant, so the OIDC
+      # token cosign needs for keyless signing must be granted here too.
+      id-token: write
     uses: ./.github/workflows/release-image.yml
     with:
       tag: ${{ needs.release.outputs.tag_name }}

--- a/charts/podcertificate-signer/Chart.yaml
+++ b/charts/podcertificate-signer/Chart.yaml
@@ -48,14 +48,12 @@ annotations:
       url: https://github.com/RafPe/pod-certificate-signer/tree/main/docs
     - name: Security policy
       url: https://github.com/RafPe/pod-certificate-signer/blob/main/SECURITY.md
-  # Image scanned/displayed by Artifact Hub. The release workflow overrides the
-  # chart version/appVersion from the git tag but does NOT currently rewrite this
-  # tag — bump it when it drifts from the released image (see docs/artifact-hub.md).
+  # Image scanned/displayed by Artifact Hub. The release workflow rewrites this
+  # tag to the released version when it packages the chart (see
+  # docs/artifact-hub.md), so the value below only applies to source checkouts.
   artifacthub.io/images: |
     - name: pod-certificate-signer
       image: ghcr.io/rafpe/pod-certificate-signer:v1.2.1
-  # Placeholder: cosign keyless signing arrives with hardening item H7. Once
-  # releases are signed, fill this in so Artifact Hub shows the signature.
-  # artifacthub.io/signKey: |
-  #   fingerprint: <cosign key fingerprint>
-  #   url: <public key URL>
+  # No artifacthub.io/signKey: release images are signed with cosign keyless
+  # (Fulcio/Rekor, no static public key), which Artifact Hub detects on its own.
+  # The verification recipe lives in docs/artifact-hub.md.

--- a/docs/artifact-hub.md
+++ b/docs/artifact-hub.md
@@ -16,10 +16,11 @@ The chart is already prepared for it:
 Registration is a one-time manual step — it needs an Artifact Hub account.
 
 > [!NOTE]
-> Signed releases: cosign keyless signing is tracked separately (hardening item
-> H7). Once releases are signed, Artifact Hub detects and displays the signature
-> automatically, and the `artifacthub.io/signKey` annotation placeholder in
-> `Chart.yaml` should be filled in.
+> Signed releases: the release image is signed with **cosign keyless** signing
+> (Fulcio/Rekor, no static public key), so there is no `artifacthub.io/signKey`
+> annotation to fill in — Artifact Hub detects the signature on its own. See
+> [Verifying the image signature](#verifying-the-image-signature) for how a
+> consumer verifies it.
 
 ## One-time setup
 
@@ -58,9 +59,54 @@ Artifact Hub polls the OCI repository and picks up new chart versions
 automatically; the `artifacthub.io/*` annotations travel with each packaged
 chart.
 
+The release workflow (`.github/workflows/release-image.yml`) overrides the chart
+`version`/`appVersion` from the git tag **and** rewrites the
+`artifacthub.io/images` tag to the released version when it packages the chart,
+so the annotation never drifts from the published image. The value committed in
+`Chart.yaml` only applies to installs from a source checkout.
+
+## Verifying the image signature
+
+Release images are signed keyless with [cosign](https://github.com/sigstore/cosign):
+the signing identity is the GitHub Actions release workflow, certified by Fulcio
+and logged in Rekor — there is no long-lived public key to distribute.
+
 > [!NOTE]
-> The release workflow (`.github/workflows/release-image.yml`) overrides the
-> chart `version`/`appVersion` from the git tag, but does **not** currently
-> rewrite the `artifacthub.io/images` tag in `Chart.yaml`. Bump that annotation
-> when it drifts from the released image, or extend the workflow to rewrite it on
-> release.
+> Signatures and SBOM attestations exist only for releases cut **after** cosign
+> signing landed (hardening item H7). Tags published before that are unsigned;
+> `cosign verify` against them fails as expected.
+
+Verify a released image **by digest** so you verify the exact content a tag
+points at. Resolve the tag to a digest first (with
+[`crane`](https://github.com/google/go-containerregistry), or
+`docker buildx imagetools inspect <image> --format '{{.Manifest.Digest}}'`):
+
+```bash
+IMAGE=ghcr.io/rafpe/pod-certificate-signer:vX.Y.Z
+DIGEST="${IMAGE%:*}@$(crane digest "$IMAGE")"
+
+cosign verify \
+  --certificate-identity-regexp '(?i)^https://github\.com/RafPe/pod-certificate-signer/\.github/workflows/release-image\.yml@.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  "$DIGEST"
+```
+
+The identity regexp anchors on this repository and its release workflow but stays
+permissive on the git ref, because the release runs through a reusable-workflow
+call and the ref recorded in the certificate is not always the tag. To inspect
+the exact identity that was recorded rather than trusting the pattern:
+
+```bash
+cosign verify --certificate-identity-regexp '.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  "$DIGEST" -o text
+```
+
+The image also carries a per-platform SPDX SBOM attached at build time as an
+in-toto attestation. Inspect it with:
+
+```bash
+cosign download sbom "$DIGEST"
+# or
+docker buildx imagetools inspect "$IMAGE" --format '{{ json .SBOM }}'
+```


### PR DESCRIPTION
Part of #52 (hardening item H7).

## Summary
Release images are now signed and carry an SBOM, and the Artifact Hub image annotation stays accurate across releases.

- **Keyless signing** — `build-and-push` gets `id-token: write`; the build step gets an `id`; cosign (pinned to a full SHA, `cosign-release` explicitly pinned) signs the pushed image **by digest** (`cosign sign --yes <repo>@<digest>`), never by tag. A guard fails the job if the digest output is empty.
- **Caller permission** — `release.yml`'s `publish-artifacts` job also gets `id-token: write`; a called workflow's jobs are capped by the caller's grant, so without this the OIDC token would never be minted on the real release path (PR merge → publish). This is invisible to actionlint, so it's called out explicitly.
- **SBOM** — `docker/build-push-action` runs with `sbom: true`, generating a **per-platform SPDX** SBOM attached to the image index as an in-toto attestation. No `continue-on-error`: buildx fails the build if SBOM generation fails, which is the right posture for a signer. Per-platform (not a single-platform syft scan of the manifest list) is why this path was chosen for the multi-arch build.
- **Signing scope** — signs the **index digest** only (no `--recursive`). Tags resolve to the index digest, so that's what consumers verify; `--recursive` would only add arch-specific verification at the cost of also signing the attestation manifests.
- **Artifact Hub images drift** — `push-chart` now rewrites the `artifacthub.io/images` annotation to the released tag (via `yq` with `strenv` + `style="literal"` so the block scalar and comments survive) before `helm package`, so it no longer drifts from the published image. Stale "does not currently rewrite" notes in `Chart.yaml` and `docs/artifact-hub.md` are updated.
- **signKey** — the `artifacthub.io/signKey` placeholder from #70 is **removed**, not filled in: keyless signing has no static public key, so a key annotation would be bogus. Artifact Hub detects keyless signatures on its own. The verification recipe now lives in `docs/artifact-hub.md`.

## How a consumer verifies a (post-H7) release
```bash
IMAGE=ghcr.io/rafpe/pod-certificate-signer:vX.Y.Z
DIGEST="${IMAGE%:*}@$(crane digest "$IMAGE")"

cosign verify \
  --certificate-identity-regexp '(?i)^https://github\.com/RafPe/pod-certificate-signer/\.github/workflows/release-image\.yml@.*$' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  "$DIGEST"

cosign download sbom "$DIGEST"   # or: docker buildx imagetools inspect "$IMAGE" --format '{{ json .SBOM }}'
```
The identity regexp anchors on this repo + the release-image workflow but stays permissive on the git ref, because the release runs through a `workflow_call` and the ref recorded in the Fulcio cert isn't always the tag. Signatures/SBOMs exist only for releases cut after this change; the currently-held `v1.2.1` is unsigned.

## Validation
- `actionlint` clean on `release-image.yml` and `release.yml`.
- YAML parses (both workflows + `Chart.yaml`).
- `helm lint` passes; `helm template --set signer.name=... --set signer.ca.secretRef.name=test-ca` renders (with `--kube-version 1.35.0`; the chart's `kubeVersion >= 1.35.0` is pre-existing).
- Simulated the `yq` rewrite with a fake tag: the annotation round-trips as valid nested YAML, comments preserved.
- Every touched/added `uses:` is a 40-hex SHA with a matching `# vX.Y.Z` (cosign-installer `6f9f177…` = v4.1.2, verified against the GitHub API).
- Digest traced: `id: build` → `steps.build.outputs.digest` → `DIGEST` env → guard → `cosign sign`.

No version bump — held at v1.2.1. Labeled `release/skip`.