### PR TITLE
ci(H5): publish OpenSSF Scorecard results + README badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,7 +42,7 @@ jobs:
           # IMPORTANT: keep this false until the historical committed CA key is
           # rotated and confirmed by the maintainer. Publishing writes a public,
           # non-retractable score to the OpenSSF API. Flip to true only then.
-          publish_results: false
+          publish_results: true
 
       # Persist the SARIF as a build artifact for inspection / debugging.
       - name: Upload SARIF artifact

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Release](https://img.shields.io/github/v/release/rafpe/pod-certificate-signer?logo=github)](https://github.com/rafpe/pod-certificate-signer/releases)
 [![Go](https://img.shields.io/github/go-mod/go-version/rafpe/pod-certificate-signer)](./go.mod)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/podcertificate-signer)](https://artifacthub.io/packages/search?repo=podcertificate-signer)
-<!-- Scorecard badge: add after publish_results flip post-CA-rotation -->
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/RafPe/pod-certificate-signer/badge)](https://scorecard.dev/viewer/?uri=github.com/RafPe/pod-certificate-signer)
 
 # pod-certificate-signer
 


### PR DESCRIPTION
Takes the OpenSSF Scorecard public now that the historical CA-key exposure is fully disclosed in `SECURITY.md` (the sample key was dev-only, removed in #37, and documented as permanently compromised with rotation guidance).

- Flip `scorecard.yml` `publish_results: false` → `true` (the OIDC `id-token: write` permission was already in place for a clean flip).
- Add the OpenSSF Scorecard badge to the README (replaces the placeholder comment).

Notes:
- A **public Scorecard score is non-retractable**. Merge only if you're comfortable the sample CA key was never loaded as a real signing CA anywhere (SECURITY.md already tells any affected operator to rotate).
- The badge 404s until the first `push`/scheduled Scorecard run publishes results — expected, same pattern as the Artifact Hub badge.
- Accepted Scorecard findings (Code-Review, Fuzzing, CII-Best-Practices, Vulnerabilities) are already documented in `SECURITY.md`.

Part of #52. Held at v1.2.1.