### PR TITLE
fix(ci): drop gha layer cache from the release image build

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -82,8 +82,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No GitHub Actions layer cache: releases are infrequent, and the gha
+          # cache backend fails hard ("failed to reserve cache") under this
+          # reusable-workflow context, which would take the whole build down.
           # Generate a per-platform SPDX SBOM and attach it to the image index as
           # an in-toto attestation. buildx fails the build if generation fails, so
           # a missing SBOM never slips through silently on a signer release.


### PR DESCRIPTION
The `type=gha` build cache fails hard (`failed to reserve cache` / `cache write denied`) under the reusable-workflow (`workflow_call`) context, which failed the entire multi-arch build — so v2.0.0's image and chart never published (release + tag are live). Releases are infrequent, so the cache is removed rather than made conditional. cosign signing, SBOM, and the chart push are unchanged.

After merge: re-run `release-image.yml` (workflow_dispatch, tag `v2.0.0`) to build + push the missing v2.0.0 artifacts.

Part of #52.