### PR TITLE
chore(chart): set Artifact Hub repositoryID + owner

### DIFF
--- a/charts/pod-certificate-signer/artifacthub-repo.yml
+++ b/charts/pod-certificate-signer/artifacthub-repo.yml
@@ -4,12 +4,7 @@
 # marks it as a "Verified Publisher". It is pushed ONCE to the OCI registry
 # (not on every chart release) via `oras push ...:artifacthub.io` — see
 # docs/artifact-hub.md for the exact steps.
-#
-# TODO(maintainer): fill in `repositoryID` with the ID shown on the Artifact Hub
-# control panel after you add the repository, and set `owners[].email` to the
-# address on your Artifact Hub account (a mismatch fails ownership verification
-# silently). Then push this file to the registry.
-repositoryID: "" # TODO: paste the Repository ID from the Artifact Hub control panel
+repositoryID: "4216c507-7d05-47e6-b109-3649859aef16"
 owners:
   - name: RafPe
-    email: "" # TODO: must match the email on your Artifact Hub account
+    email: "rafal@pieniazek.nl"


### PR DESCRIPTION
Fills `charts/pod-certificate-signer/artifacthub-repo.yml` with the Repository ID from the Artifact Hub control panel and the owner email, so ownership verification passes and the repo shows as a Verified Publisher.

The operative step is pushing this file to the OCI registry (`oras push …:artifacthub.io`) — Artifact Hub reads it from the registry, not from git; this commit keeps it in source for the record.

Part of #52.