### PR TITLE
fix(#48): enforce identity allowlist on CSR SANs; bound default DNS label

### DIFF
--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -104,7 +104,9 @@ func main() {
 			"resolved from the verified fields of the PodCertificateRequest.")
 	flag.BoolVar(&honorCSRSANs, "honor-csr-sans", false,
 		"Honor DNS and IP SANs embedded in the kubelet-generated PKCS#10 CSR when no SAN annotation overrides them. "+
-			"Kubelet generates empty CSRs today; this prepares for upcoming Kubernetes support for requesting SANs.")
+			"CSR SANs stay subject to the identity constraints unless --allow-unverified-identities is set (CSR DNS SANs "+
+			"must be a verified identity; CSR IP SANs are denied). Kubelet generates empty CSRs today; this prepares for "+
+			"upcoming Kubernetes support for requesting SANs.")
 	flag.BoolVar(&allowUnverifiedIdentities, "allow-unverified-identities", false,
 		"Allow cn/san/ip-san/uris annotation values that are not derived from the verified PodCertificateRequest fields "+
 			"(pod name/namespace/serviceAccountName/uid + cluster FQDN). Off by default: leaving it off prevents a pod from "+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,8 +88,11 @@ kubelet embeds in the PKCS#10 CSR of the `PodCertificateRequest` (today kubelet
 generates empty CSRs). The controller is ready for this behind
 `--honor-csr-sans` (Helm: `signer.honor_csr_sans`, disabled by default): when
 enabled, CSR-requested DNS and IP SANs are used unless a `san`/`ip-san`
-annotation overrides them. While disabled, CSR SANs are ignored — which the API
-contract explicitly permits.
+annotation overrides them. CSR SANs stay subject to the [identity
+constraints](#identity-constraints): unless `--allow-unverified-identities` is
+set, a CSR-requested DNS SAN must resolve to a verified pod identity and
+CSR-requested IP SANs are denied (an IP has no verified derivation). While
+disabled, CSR SANs are ignored — which the API contract explicitly permits.
 
 Until then, IP SANs can be requested via the `ip-san` annotation; once kubelet
 gains native SAN support the same values move into the pod spec and the

--- a/internal/controller/default_san_warning_test.go
+++ b/internal/controller/default_san_warning_test.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// A pod name whose DNS label exceeds the 63-character limit gets no default pod
+// DNS SANs, because truncating would let two pods sharing a prefix impersonate
+// each other. The drop is not fatal - at 64 characters the common name still
+// carries the identity, so the certificate issues - but the operator must be
+// told, so process() emits a Warning event explaining why the default SAN was
+// dropped.
+func TestProcessLongPodNameEmitsDefaultSANWarning(t *testing.T) {
+	pcr, pod := livePCR(t, "uid-1", "uid-1")
+	longName := strings.Repeat("a", 64)
+	pcr.Spec.PodName = longName
+	pod.Name = longName
+
+	cache := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(pod).Build()
+	stub := &stubSigner{name: "example.org/signer", cert: stubCert()}
+	rec := events.NewFakeRecorder(10)
+	r := &PodCertificateRequestReconciler{
+		Client: cache, APIReader: cache, Log: logr.Discard(), Signer: stub, EventRecorder: rec,
+	}
+	ctx := logr.NewContext(context.Background(), logr.Discard())
+
+	cert, err := r.process(ctx, pcr)
+	if err != nil {
+		t.Fatalf("process() error = %v, want nil (the CN carries the identity)", err)
+	}
+	if cert == nil {
+		t.Fatal("process() cert = nil, want the signed certificate")
+	}
+
+	select {
+	case e := <-rec.Events:
+		if !strings.Contains(e, corev1.EventTypeWarning) {
+			t.Errorf("event = %q, want a %s event", e, corev1.EventTypeWarning)
+		}
+		if !strings.Contains(e, string(ReasonDefaultSANSkipped)) {
+			t.Errorf("event = %q, want reason %s", e, ReasonDefaultSANSkipped)
+		}
+		if !strings.Contains(e, "DNS label limit") {
+			t.Errorf("event = %q, want it to explain the DNS label limit", e)
+		}
+	default:
+		t.Fatal("no event recorded, want one warning event for the skipped default SAN")
+	}
+}

--- a/internal/controller/default_san_warning_test.go
+++ b/internal/controller/default_san_warning_test.go
@@ -18,7 +18,7 @@ import (
 // told, so process() emits a Warning event explaining why the default SAN was
 // dropped.
 func TestProcessLongPodNameEmitsDefaultSANWarning(t *testing.T) {
-	pcr, pod := livePCR(t, "uid-1", "uid-1")
+	pcr, pod := livePCR(t, "uid-long", "uid-long")
 	longName := strings.Repeat("a", 64)
 	pcr.Spec.PodName = longName
 	pod.Name = longName

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -61,6 +61,11 @@ const (
 	// which of the two it was.
 	ReasonAssociatedPodGone Reason = "AssociatedPodGone"
 
+	// ReasonDefaultSANSkipped is event-only: the certificate still issues, but a
+	// default that could not be applied (e.g. the pod DNS SANs for an over-long
+	// pod name) is surfaced as a Warning event so the operator can see why.
+	ReasonDefaultSANSkipped Reason = "DefaultSANSkipped"
+
 	// Well-known condition reasons defined by the certificates v1beta1 API.
 	ReasonUnsupportedKeyType     Reason = Reason(capiv1beta1.PodCertificateRequestConditionUnsupportedKeyType)
 	ReasonInvalidUserAnnotations Reason = Reason(capiv1beta1.PodCertificateRequestConditionInvalidUserConfig)

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -125,7 +125,9 @@ type PodCertificateRequestReconciler struct {
 	// certificate configuration annotations (feature flag, off by default).
 	EnableAnnotationInterpolation bool
 	// HonorCSRSANs uses DNS/IP SANs embedded in the kubelet-generated CSR
-	// (feature flag, off by default; kubelet generates empty CSRs today).
+	// (feature flag, off by default; kubelet generates empty CSRs today). CSR
+	// SANs remain subject to the identity constraints unless
+	// AllowUnverifiedIdentities is set.
 	HonorCSRSANs bool
 	// AllowUnverifiedIdentities lifts the requirement that annotation-provided
 	// certificate identities derive from the verified request fields (feature

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -296,6 +296,13 @@ func (r *PodCertificateRequestReconciler) process(ctx context.Context, pcr *capi
 	if err != nil {
 		return nil, denied(ReasonInvalidUserAnnotations, err)
 	}
+	// Non-fatal notices (e.g. default pod DNS SANs dropped for an over-long pod
+	// name): the certificate still issues, but the operator must see why a
+	// default was omitted, so surface each as a Warning event and a log line.
+	for _, warning := range pcConfig.Warnings {
+		log.Info(warning)
+		r.EventRecorder.Eventf(pcr, nil, corev1.EventTypeWarning, string(ReasonDefaultSANSkipped), "SignPodCertificateRequest", "%s", warning)
+	}
 	pcConfig.LogConfiguration(ctx)
 
 	if err := pcConfig.Validate(); err != nil {

--- a/internal/kubernetes/podcertificate/csr_sans_test.go
+++ b/internal/kubernetes/podcertificate/csr_sans_test.go
@@ -6,12 +6,16 @@ import (
 )
 
 // CSR-requested SANs are used when the feature is enabled and no annotation
-// overrides them.
+// overrides them. The CSR values here (csr.example.org, 10.1.2.3) are not
+// derived from a verified pod identity, so honoring them requires the
+// AllowUnverifiedIdentities opt-in; under the default constraints these same
+// values are denied (see TestCSRSANsIdentityConstraint).
 func TestCSRSANsHonoredWhenEnabled(t *testing.T) {
 	opts := Options{
-		HonorCSRSANs:   true,
-		CSRDNSNames:    []string{"csr.example.org"},
-		CSRIPAddresses: []net.IP{net.ParseIP("10.1.2.3")},
+		HonorCSRSANs:              true,
+		CSRDNSNames:               []string{"csr.example.org"},
+		CSRIPAddresses:            []net.IP{net.ParseIP("10.1.2.3")},
+		AllowUnverifiedIdentities: true,
 	}
 
 	config, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), opts, nil, 0)
@@ -24,6 +28,53 @@ func TestCSRSANsHonoredWhenEnabled(t *testing.T) {
 	if len(config.IPAddresses) != 1 || !config.IPAddresses[0].Equal(net.ParseIP("10.1.2.3")) {
 		t.Errorf("IPAddresses = %v, want the CSR-requested IP", config.IPAddresses)
 	}
+}
+
+// When identity constraints are enforced (the default), CSR-requested SANs must
+// pass the same verified-identity allowlist that annotation cn/san/uris values
+// pass: a CSR SAN the pod does not own is denied, one it does own is honored,
+// and IP SANs (which have no verified derivation) are denied outright. The
+// blanket denial and honoring are both lifted by AllowUnverifiedIdentities.
+func TestCSRSANsIdentityConstraint(t *testing.T) {
+	// Emitted by the signer itself for testPod, so it is a verified identity.
+	const verifiedDNS = "mypod.myns.pod.cluster.local"
+
+	t.Run("unverified CSR DNS name denied", func(t *testing.T) {
+		opts := Options{HonorCSRSANs: true, CSRDNSNames: []string{"csr.attacker.example"}}
+		if _, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), opts, nil, 0); err == nil {
+			t.Fatal("want denial for an unverified CSR DNS name, got nil")
+		}
+	})
+
+	t.Run("verified CSR DNS name honored", func(t *testing.T) {
+		opts := Options{HonorCSRSANs: true, CSRDNSNames: []string{verifiedDNS}}
+		config, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), opts, nil, 0)
+		if err != nil {
+			t.Fatalf("want the verified CSR DNS name honored, got error: %v", err)
+		}
+		if len(config.DNSNames) != 1 || config.DNSNames[0] != verifiedDNS {
+			t.Errorf("DNSNames = %v, want [%s]", config.DNSNames, verifiedDNS)
+		}
+	})
+
+	t.Run("CSR IP SAN denied", func(t *testing.T) {
+		opts := Options{HonorCSRSANs: true, CSRIPAddresses: []net.IP{net.ParseIP("10.1.2.3")}}
+		if _, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), opts, nil, 0); err == nil {
+			t.Fatal("want denial for a CSR IP SAN under identity constraints, got nil")
+		}
+	})
+
+	t.Run("unverified CSR SANs allowed with opt-in", func(t *testing.T) {
+		opts := Options{
+			HonorCSRSANs:              true,
+			CSRDNSNames:               []string{"csr.attacker.example"},
+			CSRIPAddresses:            []net.IP{net.ParseIP("10.1.2.3")},
+			AllowUnverifiedIdentities: true,
+		}
+		if _, err := NewPodCertificateConfig(testPCR(nil), testPod(nil), opts, nil, 0); err != nil {
+			t.Fatalf("want CSR SANs honored with --allow-unverified-identities, got error: %v", err)
+		}
+	})
 }
 
 // The san annotation takes precedence over CSR-requested DNS names.

--- a/internal/kubernetes/podcertificate/identity_constraints_test.go
+++ b/internal/kubernetes/podcertificate/identity_constraints_test.go
@@ -107,41 +107,71 @@ func TestDefaultEKUServerAuthOnly(t *testing.T) {
 	}
 }
 
-// (5): A pod name longer than the 64-character RFC 5280 common name limit must
-// still yield a configuration whose default CN passes validation (SAN-only or
-// truncated), rather than an un-issuable request.
-func TestLongPodNameYieldsValidDefaultCN(t *testing.T) {
-	pod := testPod(nil)
-	pod.Name = strings.Repeat("a", 65)
-	pcr := testPCR(nil)
-	pcr.Spec.PodName = pod.Name
+// (5): A pod name over the 63-character DNS label limit must not receive a
+// truncated, collision-prone default SAN. At 64 characters the common name still
+// carries the identity, so the certificate issues with no default DNS SANs. Past
+// the 64-character CN limit as well, with no annotation to supply an identity,
+// the configuration is denied at validation rather than issued without a
+// verifiable subject.
+func TestLongPodNameIdentityFallback(t *testing.T) {
+	t.Run("64 chars: CN carries identity, config validates", func(t *testing.T) {
+		name := strings.Repeat("a", 64)
+		pod := testPod(nil)
+		pod.Name = name
+		pcr := testPCR(nil)
+		pcr.Spec.PodName = name
 
-	config, err := NewPodCertificateConfig(pcr, pod, Options{}, nil, 0)
-	if err != nil {
-		t.Fatalf("NewPodCertificateConfig: %v", err)
-	}
-	if len(config.CommonName) > 64 {
-		t.Errorf("CommonName length = %d, want <= 64 for a long pod name", len(config.CommonName))
-	}
-	if err := config.Validate(); err != nil {
-		t.Errorf("Validate() = %v, want nil for a long pod name default CN", err)
-	}
+		config, err := NewPodCertificateConfig(pcr, pod, Options{}, nil, 0)
+		if err != nil {
+			t.Fatalf("NewPodCertificateConfig: %v", err)
+		}
+		if config.CommonName != name {
+			t.Errorf("CommonName = %q, want the 64-char pod name", config.CommonName)
+		}
+		if len(config.DNSNames) != 0 {
+			t.Errorf("DNSNames = %v, want none for an over-long label", config.DNSNames)
+		}
+		if err := config.Validate(); err != nil {
+			t.Errorf("Validate() = %v, want nil (the CN carries the identity)", err)
+		}
+	})
+
+	t.Run("65 chars, no annotation: denied at validation", func(t *testing.T) {
+		name := strings.Repeat("a", 65)
+		pod := testPod(nil)
+		pod.Name = name
+		pcr := testPCR(nil)
+		pcr.Spec.PodName = name
+
+		config, err := NewPodCertificateConfig(pcr, pod, Options{}, nil, 0)
+		if err != nil {
+			t.Fatalf("NewPodCertificateConfig: %v", err)
+		}
+		if config.CommonName != "" {
+			t.Errorf("CommonName = %q, want empty for a pod name over the CN limit", config.CommonName)
+		}
+		if err := config.Validate(); err == nil {
+			t.Error("Validate() = nil, want denial when there is neither a CN nor a SAN")
+		}
+	})
 }
 
-// A pod name longer than the 63-character DNS label limit (RFC 1035) must not
-// produce an invalid label in the default SANs <pod>.<ns>.pod|svc.<fqdn>. The
-// first label is truncated to stay valid. Boundaries: 63 chars is kept verbatim,
-// 64+ is truncated, and a truncation that would land on a dot or hyphen must not
-// leave an empty or otherwise malformed label.
-func TestLongPodNameDefaultDNSLabels(t *testing.T) {
+// A pod name whose DNS label(s) exceed the 63-character RFC 1035 limit must not
+// receive a truncated default SAN: truncation would give two pods sharing a
+// 63-character prefix identical pod/svc SANs, so one could impersonate the
+// other. Instead the default pod DNS SANs are omitted entirely and a warning is
+// surfaced. Boundary: a 63-character label is kept; 64+ yields no default SANs.
+func TestLongPodNameOmitsDefaultDNSSANs(t *testing.T) {
 	cases := []struct {
-		name    string
-		podName string
+		name        string
+		podName     string
+		wantSANs    bool
+		wantWarning bool
 	}{
-		{"exactly 63 chars kept", strings.Repeat("a", 63)},
-		{"64 chars truncated", strings.Repeat("a", 64)},
-		{"65 chars truncated", strings.Repeat("a", 65)},
-		{"truncation cut lands on a dot", strings.Repeat("a", 62) + "." + strings.Repeat("b", 10)},
+		{"exactly 63 chars kept", strings.Repeat("a", 63), true, false},
+		{"64 chars omitted", strings.Repeat("a", 64), false, true},
+		{"65 chars omitted", strings.Repeat("a", 65), false, true},
+		{"multi-label within limit kept", strings.Repeat("a", 40) + "." + strings.Repeat("b", 40), true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -154,6 +184,7 @@ func TestLongPodNameDefaultDNSLabels(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewPodCertificateConfig: %v", err)
 			}
+			// Whatever survives must be a valid label - no empty or >63 label.
 			for _, dns := range config.DNSNames {
 				for _, label := range strings.Split(dns, ".") {
 					if len(label) == 0 || len(label) > 63 {
@@ -161,6 +192,42 @@ func TestLongPodNameDefaultDNSLabels(t *testing.T) {
 					}
 				}
 			}
+			if gotSANs := len(config.DNSNames) > 0; gotSANs != tc.wantSANs {
+				t.Errorf("has default DNS SANs = %v (%v), want %v", gotSANs, config.DNSNames, tc.wantSANs)
+			}
+			gotWarning := false
+			for _, w := range config.Warnings {
+				if strings.Contains(w, "DNS label limit") {
+					gotWarning = true
+				}
+			}
+			if gotWarning != tc.wantWarning {
+				t.Errorf("DNS-label warning surfaced = %v (%v), want %v", gotWarning, config.Warnings, tc.wantWarning)
+			}
 		})
+	}
+}
+
+// Two distinct pods whose names share a 63-character prefix must not receive
+// identical default SANs - the collision truncation would introduce, letting one
+// pod's certificate impersonate the other. Each simply gets no default DNS SANs.
+func TestLongPodNameNoDefaultSANCollision(t *testing.T) {
+	prefix := strings.Repeat("a", 63)
+	build := func(podName string) *PodCertificateConfig {
+		pod := testPod(nil)
+		pod.Name = podName
+		pcr := testPCR(nil)
+		pcr.Spec.PodName = podName
+		config, err := NewPodCertificateConfig(pcr, pod, Options{}, nil, 0)
+		if err != nil {
+			t.Fatalf("NewPodCertificateConfig(%q): %v", podName, err)
+		}
+		return config
+	}
+
+	a := build(prefix + "x")
+	b := build(prefix + "y")
+	if len(a.DNSNames) != 0 || len(b.DNSNames) != 0 {
+		t.Fatalf("want no default DNS SANs for over-long names, got a=%v b=%v", a.DNSNames, b.DNSNames)
 	}
 }

--- a/internal/kubernetes/podcertificate/identity_constraints_test.go
+++ b/internal/kubernetes/podcertificate/identity_constraints_test.go
@@ -127,3 +127,40 @@ func TestLongPodNameYieldsValidDefaultCN(t *testing.T) {
 		t.Errorf("Validate() = %v, want nil for a long pod name default CN", err)
 	}
 }
+
+// A pod name longer than the 63-character DNS label limit (RFC 1035) must not
+// produce an invalid label in the default SANs <pod>.<ns>.pod|svc.<fqdn>. The
+// first label is truncated to stay valid. Boundaries: 63 chars is kept verbatim,
+// 64+ is truncated, and a truncation that would land on a dot or hyphen must not
+// leave an empty or otherwise malformed label.
+func TestLongPodNameDefaultDNSLabels(t *testing.T) {
+	cases := []struct {
+		name    string
+		podName string
+	}{
+		{"exactly 63 chars kept", strings.Repeat("a", 63)},
+		{"64 chars truncated", strings.Repeat("a", 64)},
+		{"65 chars truncated", strings.Repeat("a", 65)},
+		{"truncation cut lands on a dot", strings.Repeat("a", 62) + "." + strings.Repeat("b", 10)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := testPod(nil)
+			pod.Name = tc.podName
+			pcr := testPCR(nil)
+			pcr.Spec.PodName = tc.podName
+
+			config, err := NewPodCertificateConfig(pcr, pod, Options{}, nil, 0)
+			if err != nil {
+				t.Fatalf("NewPodCertificateConfig: %v", err)
+			}
+			for _, dns := range config.DNSNames {
+				for _, label := range strings.Split(dns, ".") {
+					if len(label) == 0 || len(label) > 63 {
+						t.Errorf("DNS name %q has invalid label %q (len %d)", dns, label, len(label))
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -163,19 +163,23 @@ type Options struct {
 	EnableInterpolation bool
 	// HonorCSRSANs uses the DNS and IP SANs embedded in the
 	// kubelet-generated PKCS#10 CSR (CSRDNSNames/CSRIPAddresses) when no
-	// san/ip-san annotation overrides them. Kubelet generates empty CSRs today,
-	// so this is inert until Kubernetes starts embedding requested SANs;
-	// when disabled, CSR SANs are ignored, which the API contract
-	// explicitly allows for signers.
+	// san/ip-san annotation overrides them. CSR SANs are still subject to the
+	// identity constraints below: unless AllowUnverifiedIdentities is set, CSR
+	// DNS SANs must clear the same verified-identity allowlist as annotation
+	// values, and CSR IP SANs (which have no verified derivation) are denied.
+	// Kubelet generates empty CSRs today, so this is inert until Kubernetes
+	// starts embedding requested SANs; when disabled, CSR SANs are ignored,
+	// which the API contract explicitly allows for signers.
 	HonorCSRSANs bool
-	// AllowUnverifiedIdentities lifts the requirement that annotation-provided
-	// cn/san/ip-san/uris values resolve to an identity derived from the
-	// apiserver-verified PodCertificateRequest fields (pod name/namespace/
-	// serviceAccountName/uid + cluster FQDN). It is off by default: without it,
-	// values that do not derive from a verified identity are denied, so a pod
-	// cannot request a certificate for an identity it does not own. IP SANs and
-	// arbitrary literals have no verified derivation and are always denied when
-	// this is false.
+	// AllowUnverifiedIdentities lifts the requirement that certificate identities
+	// resolve to one derived from the apiserver-verified PodCertificateRequest
+	// fields (pod name/namespace/serviceAccountName/uid + cluster FQDN). It
+	// governs both annotation-provided cn/san/ip-san/uris values and, when
+	// HonorCSRSANs is set, the SANs requested via the CSR. It is off by default:
+	// without it, values that do not derive from a verified identity are denied,
+	// so a pod cannot request a certificate for an identity it does not own. IP
+	// SANs and arbitrary literals have no verified derivation and are always
+	// denied when this is false.
 	AllowUnverifiedIdentities bool
 	// CSRDNSNames are the DNS SANs requested via the PKCS#10 CSR.
 	CSRDNSNames []string
@@ -254,11 +258,8 @@ func NewPodCertificateConfig(
 	}
 
 	config := &PodCertificateConfig{
-		CommonName: defaultCommonName(pod.Name),
-		DNSNames: []string{
-			fmt.Sprintf("%s.%s.pod.%s", pod.Name, pod.Namespace, clusterFQDN),
-			fmt.Sprintf("%s.%s.svc.%s", pod.Name, pod.Namespace, clusterFQDN),
-		},
+		CommonName:         defaultCommonName(pod.Name),
+		DNSNames:           defaultPodDNSNames(pod.Name, pod.Namespace, clusterFQDN),
 		Duration:           duration,
 		RefreshBefore:      DefaultRefreshBefore,
 		MaxExpiration:      maxExpiration,
@@ -453,6 +454,37 @@ func defaultCommonName(podName string) string {
 	return podName
 }
 
+// dnsLabelMaxLen is the maximum length of a single DNS label (RFC 1035 §2.3.4).
+const dnsLabelMaxLen = 63
+
+// defaultPodDNSNames returns the canonical pod DNS SANs
+// <pod>.<ns>.pod|svc.<fqdn>. The pod name forms the first DNS label, which
+// RFC 1035 caps at 63 characters, so a longer pod name is truncated to keep the
+// label valid; the certificate stays identifiable by its SANs (and long pod
+// names already fall back to a SAN-only common name, see defaultCommonName).
+// Truncation means two pods whose names share their first 63 characters receive
+// the same default SANs - an accepted trade-off for keeping the label valid.
+func defaultPodDNSNames(podName, namespace, clusterFQDN string) []string {
+	label := truncateDNSLabel(podName)
+	if label == "" {
+		return nil
+	}
+	return []string{
+		fmt.Sprintf("%s.%s.pod.%s", label, namespace, clusterFQDN),
+		fmt.Sprintf("%s.%s.svc.%s", label, namespace, clusterFQDN),
+	}
+}
+
+// truncateDNSLabel bounds s to a valid DNS label length, trimming any trailing
+// "-" or "." a naive cut could expose so the result stays a well-formed label
+// (a trailing hyphen or an empty label would be invalid).
+func truncateDNSLabel(s string) string {
+	if len(s) <= dnsLabelMaxLen {
+		return s
+	}
+	return strings.TrimRight(s[:dnsLabelMaxLen], "-.")
+}
+
 // verifiedIdentities returns the set of identity strings (common names, DNS
 // names and URIs) the signer is willing to emit for a request, computed solely
 // from its apiserver-verified fields. Resolved annotation values are accepted
@@ -574,6 +606,15 @@ func resolveDNSNames(
 	san, ok := lookup(AnnotationSuffixSAN)
 	if !ok {
 		if honorCSR && len(csrDNSNames) > 0 {
+			// CSR-requested SANs are attacker-influenced just like annotation
+			// values, so they must clear the same verified-identity allowlist.
+			if !allowUnverified {
+				for _, name := range csrDNSNames {
+					if err := assertVerifiedIdentity("CSR DNS name", name, verified); err != nil {
+						return nil, err
+					}
+				}
+			}
 			return csrDNSNames, nil
 		}
 		return defaults, nil
@@ -609,6 +650,12 @@ func resolveIPAddresses(
 	ipSAN, ok := lookup(AnnotationSuffixIPSAN)
 	if !ok {
 		if honorCSR && len(csrIPAddresses) > 0 {
+			// An IP has no verified derivation from the request fields, so
+			// CSR-requested IP SANs are denied under the same rule as the
+			// ip-san annotation unless unverified identities are allowed.
+			if !allowUnverified {
+				return nil, errors.New("CSR IP SANs are not derived from a verified pod identity and are denied; start the controller with --allow-unverified-identities to allow them")
+			}
 			return csrIPAddresses, nil
 		}
 		return nil, nil

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -44,6 +44,11 @@ type PodCertificateConfig struct {
 	ExtKeyUsage        []x509.ExtKeyUsage // TODO: Customizable Ext Key Usage via Policies or other aliases i.e. client-server-auth , ssl ,
 	PublicKey          crypto.PublicKey
 	PublicKeyAlgorithm x509.PublicKeyAlgorithm
+	// Warnings are non-fatal notices about how the configuration was resolved
+	// (e.g. default pod DNS SANs omitted for an over-long pod name). The
+	// certificate still issues; the reconciler surfaces each as a Warning event
+	// and a log line so the operator can see why a default was dropped.
+	Warnings []string
 }
 
 // Well-known configuration annotation suffixes understood by the signer.

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -262,9 +262,11 @@ func NewPodCertificateConfig(
 		verified = verifiedIdentities(pcr, clusterFQDN)
 	}
 
+	defaultDNSNames, dnsLabelTooLong := defaultPodDNSNames(pod.Name, pod.Namespace, clusterFQDN)
+
 	config := &PodCertificateConfig{
 		CommonName:         defaultCommonName(pod.Name),
-		DNSNames:           defaultPodDNSNames(pod.Name, pod.Namespace, clusterFQDN),
+		DNSNames:           defaultDNSNames,
 		Duration:           duration,
 		RefreshBefore:      DefaultRefreshBefore,
 		MaxExpiration:      maxExpiration,
@@ -292,6 +294,16 @@ func NewPodCertificateConfig(
 		return nil, err
 	}
 	config.DNSNames = dnsNames
+
+	// If the default pod DNS SANs were dropped for an over-long label and no
+	// annotation/CSR SAN took their place, the certificate loses its canonical
+	// DNS identity. Surface it so the operator can add an explicit SAN; the
+	// reconciler turns this into a Warning event and a log line.
+	if dnsLabelTooLong && len(config.DNSNames) == 0 {
+		config.Warnings = append(config.Warnings, fmt.Sprintf(
+			"default pod DNS SANs omitted: pod name %q exceeds the %d-character DNS label limit; request an explicit SAN via the san annotation if one is needed",
+			pod.Name, dnsLabelMaxLen))
+	}
 
 	ipAddresses, err := resolveIPAddresses(lookup, expand, signerName, opts.AllowUnverifiedIdentities, opts.HonorCSRSANs, opts.CSRIPAddresses)
 	if err != nil {
@@ -463,31 +475,23 @@ func defaultCommonName(podName string) string {
 const dnsLabelMaxLen = 63
 
 // defaultPodDNSNames returns the canonical pod DNS SANs
-// <pod>.<ns>.pod|svc.<fqdn>. The pod name forms the first DNS label, which
-// RFC 1035 caps at 63 characters, so a longer pod name is truncated to keep the
-// label valid; the certificate stays identifiable by its SANs (and long pod
-// names already fall back to a SAN-only common name, see defaultCommonName).
-// Truncation means two pods whose names share their first 63 characters receive
-// the same default SANs - an accepted trade-off for keeping the label valid.
-func defaultPodDNSNames(podName, namespace, clusterFQDN string) []string {
-	label := truncateDNSLabel(podName)
-	if label == "" {
-		return nil
+// <pod>.<ns>.pod|svc.<fqdn>. The pod name forms the leading DNS label(s), which
+// RFC 1035 caps at 63 characters each. When a label would exceed that limit the
+// SANs are omitted entirely (skipped=true) rather than truncated: truncation
+// would give two pods whose names share their first 63 characters identical
+// pod/svc SANs, letting one impersonate the other. The pod stays identifiable by
+// its common name (see defaultCommonName) or an explicit san annotation; callers
+// surface skipped so the operator can act.
+func defaultPodDNSNames(podName, namespace, clusterFQDN string) (names []string, skipped bool) {
+	for _, label := range strings.Split(podName, ".") {
+		if len(label) > dnsLabelMaxLen {
+			return nil, true
+		}
 	}
 	return []string{
-		fmt.Sprintf("%s.%s.pod.%s", label, namespace, clusterFQDN),
-		fmt.Sprintf("%s.%s.svc.%s", label, namespace, clusterFQDN),
-	}
-}
-
-// truncateDNSLabel bounds s to a valid DNS label length, trimming any trailing
-// "-" or "." a naive cut could expose so the result stays a well-formed label
-// (a trailing hyphen or an empty label would be invalid).
-func truncateDNSLabel(s string) string {
-	if len(s) <= dnsLabelMaxLen {
-		return s
-	}
-	return strings.TrimRight(s[:dnsLabelMaxLen], "-.")
+		fmt.Sprintf("%s.%s.pod.%s", podName, namespace, clusterFQDN),
+		fmt.Sprintf("%s.%s.svc.%s", podName, namespace, clusterFQDN),
+	}, false
 }
 
 // verifiedIdentities returns the set of identity strings (common names, DNS


### PR DESCRIPTION
## Plan

Two identity-constraint follow-ups, both in the default (identity-constrained) issuance path in `internal/kubernetes/podcertificate/podcertificate.go`. Restated as testable guarantees:

**48.1 — CSR SANs must clear the verified-identity allowlist.** When `HonorCSRSANs` is enabled *and* identity constraints are enforced (`allow_unverified_identities: false`), DNS/IP SANs taken from the kubelet PKCS#10 CSR must be subject to the same `verifiedIdentities` allowlist as annotation `cn`/`san`/`uris` values. A CSR-requested DNS SAN the pod does not own is denied; a CSR IP SAN is denied outright (an IP has no verified derivation, mirroring the existing `ip-san` annotation rule). Both are lifted by `--allow-unverified-identities`.

Test cases:
- CSR DNS name outside the verified identities, constraints enforced → denied
- CSR DNS name that *is* a verified identity, constraints enforced → honored
- CSR IP SAN, constraints enforced → denied
- Unverified CSR DNS + IP SANs with `AllowUnverifiedIdentities` → honored
- Existing `TestCSRSANsHonoredWhenEnabled` amended: it asserted an unverified CSR SAN is honored under default constraints — that acceptance *was* the bug, so it now carries the explicit opt-in.

**48.2 — the default DNS label must stay valid, without introducing a collision.** The default SAN `<pod>.<ns>.pod|svc.<fqdn>` uses the pod name as its leading DNS label(s), which RFC 1035 caps at 63 characters. When a label would exceed that limit the default pod/svc SANs are **omitted entirely** — *not* truncated. Truncation would give two pods whose names share a 63-character prefix identical `pod`/`svc` SANs, letting either certificate impersonate the other, which defeats the isolation this change exists to enforce. The omission is surfaced as a non-fatal warning so the operator can add an explicit SAN.

Test cases (boundaries):
- 63-char label → default SANs kept
- 64-char label → default SANs omitted, warning surfaced; CN (64 chars, still valid) carries the identity and the config validates
- 65-char label, no annotation → default SANs omitted, CN empty → denied at validation (no verifiable subject) rather than issued blind
- multi-label pod name within the per-label limit → kept
- **collision guard:** two names sharing a 63-char prefix → neither gets default SANs (no identical SANs)
- reconciler emits a Warning event (`ReasonDefaultSANSkipped`) and logs it when the default SANs are dropped

### Approach

TDD, RED first (compiled + failing for the intended reason), then the fix.

## Changes

- `resolveDNSNames`: CSR DNS SANs are checked against `verifiedIdentities` when constraints are enforced.
- `resolveIPAddresses`: CSR IP SANs are denied when constraints are enforced (consistent with the `ip-san` annotation).
- `defaultPodDNSNames` returns no pod/svc SANs (and `skipped=true`) when any label of the pod name exceeds 63 characters, instead of a truncated label. `NewPodCertificateConfig` records a non-fatal notice on the new `PodCertificateConfig.Warnings` field when the default SANs are dropped and nothing replaces them.
- Reconciler (`process`): surfaces each config warning as a Warning event (`ReasonDefaultSANSkipped`, event-only) and a log line.
- Table tests: `TestCSRSANsIdentityConstraint`, `TestLongPodNameOmitsDefaultDNSSANs`, `TestLongPodNameNoDefaultSANCollision`, `TestLongPodNameIdentityFallback`, and `TestProcessLongPodNameEmitsDefaultSANWarning` (controller); `TestCSRSANsHonoredWhenEnabled` amended to carry the opt-in.

### Reviewer fix

The first revision of this PR truncated an over-long pod name to a 63-character label. A reviewer flagged this as an identity **collision**: two distinct pods sharing a 63-character prefix would receive identical default SANs, so one could impersonate the other. This revision omits the default SANs instead (and warns), and adds an explicit collision test proving the two configs share no SANs.

### Known follow-up (out of scope)

`verifiedIdentities` derives `<pod>.<ns>.pod.<fqdn>` from the *full* pod name, so with interpolation enabled an annotation like `san: ${pod.name}.${pod.namespace}.pod.${cluster.fqdn}` on a 64-char pod still expands to an allowlisted name with an invalid label. This PR scopes 48.2 to the default SAN only; the interpolated-SAN case is a separate follow-up. Deliberately *not* adding DNS-label validation to `Validate()`, which would deny configurations that work today.

### Testing

- `make test` — all green.
- `make lint` — 0 issues.
- `gofmt -l ./internal ./cmd` — clean; `go build ./...` — ok.
- RED→GREEN captured. Before the fix: `TestCSRSANsIdentityConstraint/{unverified_CSR_DNS_name_denied,CSR_IP_SAN_denied}` fail (CSR SAN accepted); `TestLongPodNameOmitsDefaultDNSSANs/{64,65}_chars_omitted` and `TestLongPodNameNoDefaultSANCollision` fail (truncated SANs present, and the two configs share identical SANs); `TestLongPodNameIdentityFallback` and `TestProcessLongPodNameEmitsDefaultSANWarning` fail (no omission, no warning event). After the fix all pass.

### e2e

No e2e assertion added. 48.1 is inert today (kubelet emits empty CSRs, so there is no real CSR-SAN behavior to exercise end-to-end). 48.2 is deterministic config handling fully covered by unit + controller tests (the warning-event path is asserted against a real reconcile via a fake recorder); a Kind-based e2e would add cost without exercising logic the existing tests miss.

Closes #48
Part of #79
