### PR TITLE
fix(#49): emit events after status write; retry status conflicts

### DIFF
--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -37,6 +37,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -386,13 +387,60 @@ func (r *PodCertificateRequestReconciler) setCertificateOnPodCertificateRequest(
 
 // ------------------------------------------------ GENERIC FUNCTIONS  ------------------------------------------------
 
-// recordOutcome sets the terminal condition on the PodCertificateRequest,
-// emits the corresponding event and persists the status.
+// recordOutcome sets the condition on the PodCertificateRequest, persists the
+// status and only then emits the corresponding event. The order matters: the
+// event announces an outcome, so it must not be emitted until the write that
+// makes the outcome real has succeeded. Emitting first would advertise a result
+// that a failed or conflicting write never persisted, and re-advertise it on
+// every requeue.
 func (r *PodCertificateRequestReconciler) recordOutcome(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest, conditionType string, reason Reason, message, eventType string) error {
 	r.setPodCertificateRequestStatusCondition(pcr, conditionType, string(reason), message)
-	r.EventRecorder.Eventf(pcr, nil, eventType, string(reason), "SignPodCertificateRequest", message)
 
-	return r.Status().Update(ctx, pcr)
+	if err := r.updateStatusWithRetry(ctx, pcr); err != nil {
+		return err
+	}
+
+	r.EventRecorder.Eventf(pcr, nil, eventType, string(reason), "SignPodCertificateRequest", message)
+	return nil
+}
+
+// updateStatusWithRetry writes the PodCertificateRequest status, retrying on a
+// version conflict within this single reconcile. A 409 means another writer
+// advanced the object between the read and the write; letting it propagate out
+// of Reconcile would re-run the whole signing pipeline next pass, minting a
+// fresh certificate and serial number for a status that was ultimately
+// discarded. Instead re-read the live object, re-apply the outcome and try
+// again, so the signer runs once regardless of a lost race on the write.
+func (r *PodCertificateRequestReconciler) updateStatusWithRetry(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest) error {
+	desired := pcr.Status.DeepCopy()
+	key := client.ObjectKeyFromObject(pcr)
+
+	// PodCertificateRequests are served from the manager cache, which lags the
+	// write that caused the conflict; re-read through the API reader so the
+	// retry carries the current resourceVersion, not the stale cached one.
+	reader := r.statusRetryReader()
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Status().Update(ctx, pcr)
+		if err == nil || !apierrors.IsConflict(err) {
+			return err
+		}
+		if gerr := reader.Get(ctx, key, pcr); gerr != nil {
+			return gerr
+		}
+		desired.DeepCopyInto(&pcr.Status)
+		return err
+	})
+}
+
+// statusRetryReader returns the reader used to re-read a PodCertificateRequest
+// before retrying a conflicted status write: the cache-bypassing APIReader in
+// production, falling back to the cached client when none is wired (unit tests).
+func (r *PodCertificateRequestReconciler) statusRetryReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
 }
 
 func (r *PodCertificateRequestReconciler) setPodCertificateRequestStatusCondition(pcr *capiv1beta1.PodCertificateRequest, conditionType, reason, message string) {

--- a/internal/controller/podcertificaterequest_controller.go
+++ b/internal/controller/podcertificaterequest_controller.go
@@ -396,8 +396,15 @@ func (r *PodCertificateRequestReconciler) setCertificateOnPodCertificateRequest(
 func (r *PodCertificateRequestReconciler) recordOutcome(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest, conditionType string, reason Reason, message, eventType string) error {
 	r.setPodCertificateRequestStatusCondition(pcr, conditionType, string(reason), message)
 
-	if err := r.updateStatusWithRetry(ctx, pcr); err != nil {
+	persisted, err := r.updateStatusWithRetry(ctx, pcr)
+	if err != nil {
 		return err
+	}
+	if !persisted {
+		// Another writer recorded a terminal outcome first and won the race;
+		// this reconcile's outcome was discarded, so there is nothing to
+		// announce. updateStatusWithRetry has already logged the loss.
+		return nil
 	}
 
 	r.EventRecorder.Eventf(pcr, nil, eventType, string(reason), "SignPodCertificateRequest", message)
@@ -405,13 +412,18 @@ func (r *PodCertificateRequestReconciler) recordOutcome(ctx context.Context, pcr
 }
 
 // updateStatusWithRetry writes the PodCertificateRequest status, retrying on a
-// version conflict within this single reconcile. A 409 means another writer
-// advanced the object between the read and the write; letting it propagate out
-// of Reconcile would re-run the whole signing pipeline next pass, minting a
-// fresh certificate and serial number for a status that was ultimately
-// discarded. Instead re-read the live object, re-apply the outcome and try
-// again, so the signer runs once regardless of a lost race on the write.
-func (r *PodCertificateRequestReconciler) updateStatusWithRetry(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest) error {
+// version conflict within this single reconcile, and reports whether the write
+// was persisted. A 409 means another writer advanced the object between the
+// read and the write; letting it propagate out of Reconcile would re-run the
+// whole signing pipeline next pass, minting a fresh certificate and serial
+// number for a status that was ultimately discarded. Instead re-read the live
+// object, re-apply the outcome and try again, so the signer runs once
+// regardless of a lost race on the write.
+//
+// If the re-read shows a terminal condition another writer already recorded,
+// this reconcile lost the race: the request is now immutable, so its outcome is
+// left in place (persisted is false) rather than overwritten.
+func (r *PodCertificateRequestReconciler) updateStatusWithRetry(ctx context.Context, pcr *capiv1beta1.PodCertificateRequest) (bool, error) {
 	desired := pcr.Status.DeepCopy()
 	key := client.ObjectKeyFromObject(pcr)
 
@@ -420,17 +432,35 @@ func (r *PodCertificateRequestReconciler) updateStatusWithRetry(ctx context.Cont
 	// retry carries the current resourceVersion, not the stale cached one.
 	reader := r.statusRetryReader()
 
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	persisted := false
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		err := r.Status().Update(ctx, pcr)
-		if err == nil || !apierrors.IsConflict(err) {
+		if err == nil {
+			persisted = true
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
 			return err
 		}
 		if gerr := reader.Get(ctx, key, pcr); gerr != nil {
 			return gerr
 		}
+		if api.IsPodCertificateRequestImmutable(pcr) {
+			// A terminal outcome already won; leave it in place. Stop retrying
+			// (return nil) with persisted still false so the caller announces
+			// nothing.
+			logf.FromContext(ctx).Info("another writer recorded a terminal outcome first; discarding this reconcile's outcome",
+				"winningCondition", api.GetPodCertificateRequestConditionType(&pcr.Status))
+			return nil
+		}
+		// Not terminal, so nothing on the fresh object needs preserving: a
+		// non-terminal request carries no conditions and no certificate block.
+		// Re-apply this reconcile's intended status (onto the fresh
+		// resourceVersion) and retry.
 		desired.DeepCopyInto(&pcr.Status)
 		return err
 	})
+	return persisted, err
 }
 
 // statusRetryReader returns the reader used to re-read a PodCertificateRequest

--- a/internal/controller/podcertificaterequest_controller_test.go
+++ b/internal/controller/podcertificaterequest_controller_test.go
@@ -78,6 +78,24 @@ var _ = Describe("PodCertificateRequest Controller", func() {
 			Expect(got.Status.NotAfter.Sub(got.Status.NotBefore.Time)).
 				To(BeNumerically("<=", time.Duration(testMaxExpirationSeconds)*time.Second))
 		})
+
+		It("emits a single Issued event only once the status is persisted", func() {
+			pcr := createPodAndRequest("issued-event", testSignerName, nil)
+
+			By("waiting for the Issued condition, so the status write has landed")
+			waitForCondition(pcr, capiv1beta1.PodCertificateRequestConditionTypeIssued)
+
+			By("observing exactly one CertificateIssued event for the request")
+			// The event recorder is asynchronous, so the event may lag the
+			// condition; poll until it appears, then hold to prove the reconcile
+			// does not re-emit it on subsequent passes.
+			Eventually(func(g Gomega) {
+				g.Expect(issuedEventsFor(g, pcr)).To(HaveLen(1))
+			}, 30*time.Second, 200*time.Millisecond).Should(Succeed())
+			Consistently(func(g Gomega) {
+				g.Expect(issuedEventsFor(g, pcr)).To(HaveLen(1))
+			}, 3*time.Second, 250*time.Millisecond).Should(Succeed())
+		})
 	})
 
 	Context("When the request carries an invalid configuration", func() {
@@ -197,6 +215,22 @@ func newStubPKCS10Request() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	return csr
+}
+
+// issuedEventsFor returns the CertificateIssued events the API server holds for
+// the given request. Events are listed as core/v1 and filtered in Go, which
+// sidesteps field-selector support questions and keeps the assertion explicit.
+func issuedEventsFor(g Gomega, pcr *capiv1beta1.PodCertificateRequest) []corev1.Event {
+	var list corev1.EventList
+	g.Expect(k8sClient.List(ctx, &list, client.InNamespace(pcr.Namespace))).To(Succeed())
+
+	var out []corev1.Event
+	for _, e := range list.Items {
+		if e.InvolvedObject.Name == pcr.Name && e.Reason == string(ReasonCertificateIssued) {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // waitForCondition polls the request until the controller records the given

--- a/internal/controller/podsigner_seam_test.go
+++ b/internal/controller/podsigner_seam_test.go
@@ -26,11 +26,13 @@ type stubSigner struct {
 	cert      *podcertificate.PodCertificate
 	err       error
 	called    bool
+	signings  int
 	gotConfig *podcertificate.PodCertificateConfig
 }
 
 func (s *stubSigner) SignPodCertificate(cfg *podcertificate.PodCertificateConfig) (*podcertificate.PodCertificate, error) {
 	s.called = true
+	s.signings++
 	s.gotConfig = cfg
 	return s.cert, s.err
 }

--- a/internal/controller/status_write_safety_test.go
+++ b/internal/controller/status_write_safety_test.go
@@ -60,7 +60,7 @@ func TestRecordOutcomeNoEventWhenStatusWriteFails(t *testing.T) {
 // status is persisted once, and the signer runs exactly once.
 func TestReconcileRetriesStatusConflict(t *testing.T) {
 	const signerName = "example.org/signer"
-	pcr, pod := livePCR(t, "uid-1", "uid-1")
+	pcr, pod := livePCR(t, "conflict-uid", "conflict-uid")
 	pcr.Spec.SignerName = signerName // otherwise Reconcile returns early and nothing is written
 
 	var updateAttempts, successfulWrites int

--- a/internal/controller/status_write_safety_test.go
+++ b/internal/controller/status_write_safety_test.go
@@ -118,3 +118,74 @@ func TestReconcileRetriesStatusConflict(t *testing.T) {
 		t.Error("no Issued event recorded after the successful write")
 	}
 }
+
+// 49.2 (concurrency): when the conflict is caused by another writer that
+// recorded a terminal outcome first, the retry must not overwrite that outcome
+// with this reconcile's stale result. A PodCertificateRequest is immutable once
+// terminal, so this reconcile lost the race: it must leave the winning outcome
+// in place and announce nothing.
+func TestReconcileConflictPreservesConcurrentTerminalOutcome(t *testing.T) {
+	const signerName = "example.org/signer"
+	pcr, pod := livePCR(t, "race-uid", "race-uid")
+	pcr.Spec.SignerName = signerName
+
+	key := client.ObjectKeyFromObject(pcr)
+	var updateAttempts int
+	cl := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(pcr, pod).
+		WithStatusSubresource(&capiv1beta1.PodCertificateRequest{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, _ string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				updateAttempts++
+				if updateAttempts == 1 {
+					// A concurrent writer denies the request, then this
+					// reconcile's write loses the race with a conflict.
+					concurrent := &capiv1beta1.PodCertificateRequest{}
+					if err := c.Get(ctx, key, concurrent); err != nil {
+						return err
+					}
+					concurrent.Status.Conditions = []metav1.Condition{{
+						Type:               capiv1beta1.PodCertificateRequestConditionTypeDenied,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+						Reason:             string(ReasonInvalidUserAnnotations),
+						Message:            "denied by a concurrent writer",
+					}}
+					if err := c.Status().Update(ctx, concurrent); err != nil {
+						return err
+					}
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "certificates.k8s.io", Resource: "podcertificaterequests"},
+						obj.GetName(), errors.New("resourceVersion mismatch"))
+				}
+				return c.Status().Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	stub := &stubSigner{name: signerName, cert: stubCert()}
+	rec := events.NewFakeRecorder(10)
+	r := &PodCertificateRequestReconciler{
+		Client: cl, APIReader: cl, Log: logr.Discard(), Signer: stub, EventRecorder: rec,
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile() error = %v, want nil (losing the race to a terminal outcome is not a failure)", err)
+	}
+
+	got := &capiv1beta1.PodCertificateRequest{}
+	if err := cl.Get(context.Background(), key, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Status.Conditions) != 1 ||
+		got.Status.Conditions[0].Type != capiv1beta1.PodCertificateRequestConditionTypeDenied {
+		t.Fatalf("persisted conditions = %+v, want the concurrent Denied outcome preserved, not overwritten by this reconcile's Issued",
+			got.Status.Conditions)
+	}
+	select {
+	case e := <-rec.Events:
+		t.Errorf("recorded event %q, want none: a reconcile that lost the race must announce nothing", e)
+	default:
+	}
+}

--- a/internal/controller/status_write_safety_test.go
+++ b/internal/controller/status_write_safety_test.go
@@ -1,0 +1,120 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// 49.1: the outcome event must announce a result that was actually persisted.
+// When the status write fails, recordOutcome must surface the error and record
+// no event, so a failed write is not advertised (and re-advertised on every
+// requeue) as a done deal.
+func TestRecordOutcomeNoEventWhenStatusWriteFails(t *testing.T) {
+	pcr := &capiv1beta1.PodCertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "pcr", Namespace: "ns"},
+	}
+	// A non-conflict error: rejected outright, never retried.
+	writeErr := apierrors.NewBadRequest("status rejected")
+	cl := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(pcr).
+		WithStatusSubresource(&capiv1beta1.PodCertificateRequest{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return writeErr
+			},
+		}).
+		Build()
+	rec := events.NewFakeRecorder(10)
+	r := &PodCertificateRequestReconciler{Client: cl, APIReader: cl, Log: logr.Discard(), EventRecorder: rec}
+
+	err := r.recordOutcome(context.Background(), pcr,
+		capiv1beta1.PodCertificateRequestConditionTypeIssued, ReasonCertificateIssued, "issued", corev1.EventTypeNormal)
+	if err == nil {
+		t.Fatal("recordOutcome() error = nil, want the status write error to propagate")
+	}
+	select {
+	case e := <-rec.Events:
+		t.Fatalf("recorded event %q, want none: the event must follow a successful status write", e)
+	default:
+	}
+}
+
+// 49.2: a single status-write conflict must be resolved inside one reconcile.
+// A 409 propagating out of Reconcile re-runs the signer next pass, minting a
+// second certificate and serial for a status that was discarded. recordOutcome
+// must re-read and retry the write instead, so the reconcile succeeds, the
+// status is persisted once, and the signer runs exactly once.
+func TestReconcileRetriesStatusConflict(t *testing.T) {
+	const signerName = "example.org/signer"
+	pcr, pod := livePCR(t, "uid-1", "uid-1")
+	pcr.Spec.SignerName = signerName // otherwise Reconcile returns early and nothing is written
+
+	var updateAttempts, successfulWrites int
+	cl := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(pcr, pod).
+		WithStatusSubresource(&capiv1beta1.PodCertificateRequest{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, _ string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				updateAttempts++
+				if updateAttempts == 1 {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "certificates.k8s.io", Resource: "podcertificaterequests"},
+						obj.GetName(), errors.New("resourceVersion mismatch"))
+				}
+				if err := c.Status().Update(ctx, obj, opts...); err != nil {
+					return err
+				}
+				successfulWrites++
+				return nil
+			},
+		}).
+		Build()
+
+	stub := &stubSigner{name: signerName, cert: stubCert()}
+	rec := events.NewFakeRecorder(10)
+	r := &PodCertificateRequestReconciler{
+		Client: cl, APIReader: cl, Log: logr.Discard(), Signer: stub, EventRecorder: rec,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pcr)})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v, want nil (a one-time status conflict must be retried, not propagated)", err)
+	}
+	if res != (ctrl.Result{}) {
+		t.Errorf("Reconcile() result = %+v, want empty (no requeue)", res)
+	}
+	if stub.signings != 1 {
+		t.Errorf("signer ran %d times, want 1 (a retried conflict must not re-sign)", stub.signings)
+	}
+	if successfulWrites != 1 {
+		t.Errorf("successful status writes = %d, want exactly 1", successfulWrites)
+	}
+
+	got := &capiv1beta1.PodCertificateRequest{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(pcr), got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Status.Conditions) != 1 || got.Status.Conditions[0].Type != capiv1beta1.PodCertificateRequestConditionTypeIssued {
+		t.Fatalf("conditions = %+v, want a single Issued condition persisted", got.Status.Conditions)
+	}
+	select {
+	case <-rec.Events:
+	default:
+		t.Error("no Issued event recorded after the successful write")
+	}
+}


### PR DESCRIPTION
## Plan

Two write-safety defects in `recordOutcome` (`internal/controller/podcertificaterequest_controller.go`) let the controller announce or discard work that was never durably recorded. Both are stated below as guarantees with the test that pins them.

**User journeys**

- An operator watches PodCertificateRequest events to know whether a certificate was issued or a request denied. The event must reflect what the API server actually persisted, not an outcome a rejected or conflicting write threw away.
- Under concurrent writers (or a stale cache), a single reconcile that loses the race on its status write must not cause the CA to sign a second certificate — a fresh serial for a cert that is immediately discarded — on the next pass.

**Guarantee 49.1 — outcome events follow the write.** An event that accompanies a status write is emitted only after that write succeeds. If the write fails, `recordOutcome` returns the error and records no event. (The event-only drop path in `recordPodGone`, which deliberately writes no status per #29, is unchanged.)

- Test `TestRecordOutcomeNoEventWhenStatusWriteFails`: a fake-client interceptor fails the status write; assert `recordOutcome` returns the error and the recorder saw no event.
- **RED:** `recorded event "Normal CertificateIssued issued", want none` — the event was emitted before the write.
- **GREEN:** passes.

**Guarantee 49.2 — status conflicts are retried in-band.** A one-time `409` on the status write is resolved within the same reconcile: re-read the live object, re-apply the outcome, write again. The reconcile succeeds, the status is persisted by a single successful write, and the signer runs exactly once. The re-read goes through the API reader, because the manager cache lags the write that caused the conflict.

- Test `TestReconcileRetriesStatusConflict`: a fake-client interceptor injects one `409` on the first status write; assert `Reconcile` returns nil, the signer ran once, exactly one write succeeded, and the Issued condition is persisted.
- **RED:** `Reconcile() error = Operation cannot be fulfilled on podcertificaterequests ... resourceVersion mismatch, want nil` — the conflict propagated out of `Reconcile`.
- **GREEN:** passes.

**Guarantee 49.2b — a concurrent terminal outcome is never erased.** If the conflict was caused by another writer that recorded a terminal condition first, the retry must not overwrite it with this reconcile's stale result. A PodCertificateRequest is immutable once terminal, so when the re-read shows a terminal condition already present, this reconcile recognizes it lost the race: it leaves the winning outcome in place, logs the discarded outcome, and emits no event. (A non-terminal request carries no conditions and no certificate block, so re-applying this reconcile's status on the non-terminal path erases nothing.)

- Test `TestReconcileConflictPreservesConcurrentTerminalOutcome`: the interceptor's first write records a `Denied` condition from a concurrent writer, then rejects this reconcile's `Issued` write with a `409`; assert the persisted condition stays `Denied` and no event is emitted.
- **RED:** `persisted conditions = [{Type:Issued ...}], want the concurrent Denied outcome preserved` — the retry re-applied and overwrote it.
- **GREEN:** passes.

`Status().Patch(client.MergeFrom(orig))` was considered as the reviewer suggested. It does not help here: both writers mutate `status.conditions`, and a JSON merge patch replaces arrays wholesale (RFC 7386), so Patch would overwrite a concurrent terminal condition exactly as `Update` does. The immutability guard, not the write verb, is what preserves the concurrent outcome; the guard also correctly re-applies the certificate block on the Issued retry path, which re-applying "just the condition" would drop.

**envtest (real API-server round-trip).** New spec `emits a single Issued event only once the status is persisted`: after the Issued condition lands, list `core/v1` events and assert exactly one `CertificateIssued` event for the request, then hold it with `Consistently` to prove it is not re-emitted. Existing specs already prove the status persists. The e2e suite is not extended: asserting "exactly one Issued event / no duplicate signing" there needs a second concurrent writer and event-count polling against a shared cluster, which is racy machinery the envtest round-trip already covers deterministically.

## Changes

- `recordOutcome` now persists the status before emitting the event, and emits the event only when this reconcile's outcome was actually persisted.
- New `updateStatusWithRetry` wraps `Status().Update` in `retry.RetryOnConflict`, re-reading through `APIReader` (falling back to the cached client when none is wired) and re-applying the captured desired status on each attempt. It reports whether the write was persisted, and on a lost race to an already-recorded terminal outcome it stops and preserves that outcome.
- Tests: `status_write_safety_test.go` (three unit tests), a new envtest event spec, and a signing counter on the shared `stubSigner`.

Validated: `make test` (envtest suite, 5/5 specs), `make lint` (0 issues), `go build ./...`.

Part of #49 (the metrics-auth item ships separately). Part of #79.
