### PR TITLE
feat(#48): validate DNS SANs and add preventive admission policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,41 @@ See [docs/architecture.md](./docs/architecture.md) for the full C4 model (system
 - **Native API, no sidecars** — signs the built-in `PodCertificateRequest`; nothing to inject into workloads.
 - **Per-workload certificates** — CN, SANs, IP SANs, URIs, EKU, duration and refresh via `unverifiedUserAnnotations` on the projected volume.
 - **Default-secure identity** — by default a pod can only obtain a certificate for its own apiserver-verified identity; `${...}` interpolation fills in per-pod values.
+- **Preventive admission checks** — independently selectable Helm-managed `ValidatingAdmissionPolicy` resources can reject malformed explicit DNS SANs before a pod is stored.
 - **CA hot-reload** — the CA cert/key are reloaded from disk on change; rotate without a restart.
 - **Trust distribution** — the current and previous CAs are published as a `ClusterTrustBundle` for workloads to mount.
 - **Hardened by default** — distroless non-root image, static CGO-disabled binary, restricted Pod Security Standard, least-privilege RBAC.
+
+### DNS SAN validation behavior
+
+The signer always validates the final DNS SAN list after annotation selection,
+interpolation, or CSR/default fallback. The optional admission policy provides
+earlier feedback for explicit `podCertificate.userAnnotations` while preserving
+the signer as the authoritative boundary.
+
+| Request case | Preventive admission policy | Authoritative signer |
+| --- | --- | --- |
+| Valid explicit or interpolated DNS SAN | Admits | Issues if identity authorization also succeeds |
+| DNS label longer than 63 characters, name longer than 253 characters, or malformed DNS syntax | Denies the Pod when enabled with `Deny` | Denies the certificate request in every mode |
+| Unsupported or unterminated `${...}` in an explicit SAN | Denies the Pod | Denies the certificate request |
+| CSR-provided DNS SAN | Out of scope | Validates before identity authorization |
+| Generated default for a pod name longer than 63 characters | Out of scope | Omits the default SAN and emits `ReasonDefaultSANSkipped` |
+
+Enable the first policy independently and stage it with `Warn`/`Audit` before
+switching to `Deny`:
+
+```yaml
+admissionPolicies:
+  dnsSANValidation:
+    enabled: true
+    validationActions:
+      - Deny
+    namespaceSelector: {}
+    objectSelector: {}
+```
+
+See [configuration](./docs/configuration.md#preventive-dns-san-admission-policy)
+for rollout and scope details.
 
 ## Documentation
 

--- a/charts/pod-certificate-signer/README.md
+++ b/charts/pod-certificate-signer/README.md
@@ -95,6 +95,9 @@ The signing CA is configured under `signer.ca` with an explicit `source`:
 | `signer.enable_annotation_interpolation` | Allow `${...}` placeholders in `cn`/`san`/`uris`, resolved from verified request fields. | `false` |
 | `signer.honor_csr_sans` | Honor SANs from the kubelet PKCS#10 CSR (forward-compat; kubelet emits empty CSRs today). | `false` |
 | **`signer.allow_unverified_identities`** | **Security escape hatch.** When `false`, annotation `cn`/`san`/`ip-san`/`uris` values must resolve to the pod's verified identity, and IP SANs are denied. See [Identity constraints](#identity-constraints-security). | `false` |
+| `admissionPolicies.dnsSANValidation.enabled` | Create a signer-specific policy and binding that validate explicit Pod certificate DNS SANs before admission. | `false` |
+| `admissionPolicies.dnsSANValidation.validationActions` | Binding actions. Use `Warn`/`Audit` to stage, then `Deny`; `Deny` and `Warn` cannot be combined. | `[Deny]` |
+| `admissionPolicies.dnsSANValidation.namespaceSelector` / `.objectSelector` | Optional selectors limiting where the DNS SAN binding applies. | `{}` / `{}` |
 | `manager.max_concurrent_reconciles` | Concurrent reconciles. | `5` |
 | `manager.reconcile_timeout` | Per-reconcile timeout. | `"5m"` |
 | `resources` | Container resource requests/limits. Conservative defaults for a lightweight controller; set `{}` to leave it unconstrained. | requests `100m`/`128Mi`, limits `500m`/`256Mi` |
@@ -157,6 +160,31 @@ Set `metrics.insecure: true` **only** to restore the legacy unauthenticated
 plaintext endpoint, and only when the port is protected by other means. An
 optional `metrics.networkPolicy` (off by default) restricts ingress to the
 metrics port to selected namespaces/pods.
+
+## Preventive admission policies
+
+`admissionPolicies` is a map of independently enabled safeguards. The initial
+`dnsSANValidation` policy validates explicit DNS SAN annotations after
+admission-time interpolation and rejects malformed DNS-1123 names, labels over
+63 characters, names over 253 characters, empty list members, and unsupported
+placeholders.
+
+```yaml
+admissionPolicies:
+  dnsSANValidation:
+    enabled: true
+    validationActions:
+      - Warn
+      - Audit
+    namespaceSelector: {}
+    objectSelector: {}
+```
+
+Use `Warn` and `Audit` for rollout visibility, then change the actions to
+`[Deny]`. The policy only sees explicit `userAnnotations` on a Pod's projected
+`podCertificate` source. Signer-side validation remains mandatory and also
+covers CSR SANs and generated defaults, regardless of
+`signer.allow_unverified_identities`.
 
 ## Notes for this release
 

--- a/charts/pod-certificate-signer/templates/dns-san-validating-admission-policy.yaml
+++ b/charts/pod-certificate-signer/templates/dns-san-validating-admission-policy.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.admissionPolicies.dnsSANValidation.enabled }}
+{{- $name := printf "%s-dns-san-validation" (include "pod-certificate-signer.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $sanKey := printf "%s-san" .Values.signer.name }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "pod-certificate-signer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission-policy
+    podcertificate-signer.io/policy: dns-san-validation
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  variables:
+    - name: signerName
+      expression: {{ .Values.signer.name | quote }}
+    - name: sanKey
+      expression: {{ $sanKey | quote }}
+    - name: clusterFQDN
+      expression: {{ .Values.signer.cluster_fqdn | quote }}
+  validations:
+    - expression: >-
+        !has(object.spec.volumes) || object.spec.volumes.all(volume,
+          !has(volume.projected) || volume.projected.sources.all(source,
+            !has(source.podCertificate) ||
+            source.podCertificate.signerName != variables.signerName ||
+            !has(source.podCertificate.userAnnotations) ||
+            !(variables.sanKey in source.podCertificate.userAnnotations) ||
+            source.podCertificate.userAnnotations[variables.sanKey].split(',').all(rawSAN,
+              rawSAN.trim() != '' &&
+              !rawSAN.trim()
+                .replace('${pod.name}', object.metadata.name)
+                .replace('${pod.namespace}', request.namespace)
+                .replace('${pod.serviceAccountName}',
+                  has(object.spec.serviceAccountName) && object.spec.serviceAccountName != '' ?
+                    object.spec.serviceAccountName : 'default')
+                .replace('${cluster.fqdn}', variables.clusterFQDN)
+                .contains('${') &&
+              rawSAN.trim()
+                .replace('${pod.name}', object.metadata.name)
+                .replace('${pod.namespace}', request.namespace)
+                .replace('${pod.serviceAccountName}',
+                  has(object.spec.serviceAccountName) && object.spec.serviceAccountName != '' ?
+                    object.spec.serviceAccountName : 'default')
+                .replace('${cluster.fqdn}', variables.clusterFQDN).size() <= 253 &&
+              rawSAN.trim()
+                .replace('${pod.name}', object.metadata.name)
+                .replace('${pod.namespace}', request.namespace)
+                .replace('${pod.serviceAccountName}',
+                  has(object.spec.serviceAccountName) && object.spec.serviceAccountName != '' ?
+                    object.spec.serviceAccountName : 'default')
+                .replace('${cluster.fqdn}', variables.clusterFQDN)
+                .split('.').all(label, label.size() <= 63) &&
+              !format.dns1123Subdomain().validate(
+                rawSAN.trim()
+                  .replace('${pod.name}', object.metadata.name)
+                  .replace('${pod.namespace}', request.namespace)
+                  .replace('${pod.serviceAccountName}',
+                    has(object.spec.serviceAccountName) && object.spec.serviceAccountName != '' ?
+                      object.spec.serviceAccountName : 'default')
+                  .replace('${cluster.fqdn}', variables.clusterFQDN)
+              ).hasValue()
+            )
+          )
+        )
+      message: Pod certificate DNS SANs must resolve to valid DNS-1123 names; each label must be at most 63 characters, the complete name at most 253 characters, and only ${pod.name}, ${pod.namespace}, ${pod.serviceAccountName}, and ${cluster.fqdn} interpolation variables are supported.
+      reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "pod-certificate-signer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission-policy
+    podcertificate-signer.io/policy: dns-san-validation
+spec:
+  policyName: {{ $name }}
+  validationActions:
+    {{- toYaml .Values.admissionPolicies.dnsSANValidation.validationActions | nindent 4 }}
+  matchResources:
+    namespaceSelector:
+      {{- toYaml .Values.admissionPolicies.dnsSANValidation.namespaceSelector | nindent 6 }}
+    objectSelector:
+      {{- toYaml .Values.admissionPolicies.dnsSANValidation.objectSelector | nindent 6 }}
+{{- end }}

--- a/charts/pod-certificate-signer/templates/dns-san-validating-admission-policy.yaml
+++ b/charts/pod-certificate-signer/templates/dns-san-validating-admission-policy.yaml
@@ -19,11 +19,11 @@ spec:
         resources: ["pods"]
   variables:
     - name: signerName
-      expression: {{ .Values.signer.name | quote }}
+      expression: {{ printf "%q" .Values.signer.name | quote }}
     - name: sanKey
-      expression: {{ $sanKey | quote }}
+      expression: {{ printf "%q" $sanKey | quote }}
     - name: clusterFQDN
-      expression: {{ .Values.signer.cluster_fqdn | quote }}
+      expression: {{ printf "%q" .Values.signer.cluster_fqdn | quote }}
   validations:
     - expression: >-
         !has(object.spec.volumes) || object.spec.volumes.all(volume,

--- a/charts/pod-certificate-signer/values.schema.json
+++ b/charts/pod-certificate-signer/values.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "admissionPolicies": {
+      "type": "object",
+      "properties": {
+        "dnsSANValidation": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "validationActions": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": ["Deny", "Warn", "Audit"]
+              },
+              "not": {
+                "allOf": [
+                  { "contains": { "const": "Deny" } },
+                  { "contains": { "const": "Warn" } }
+                ]
+              }
+            },
+            "namespaceSelector": {
+              "type": "object"
+            },
+            "objectSelector": {
+              "type": "object"
+            }
+          },
+          "required": ["enabled", "validationActions", "namespaceSelector", "objectSelector"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/charts/pod-certificate-signer/values.yaml
+++ b/charts/pod-certificate-signer/values.yaml
@@ -113,6 +113,23 @@ signer:
   # Helm escape hatch for the --allow-unverified-identities controller flag.
   allow_unverified_identities: false
 
+# Optional, independently selectable ValidatingAdmissionPolicies. These
+# cluster-scoped policies provide preventive feedback when Pods are admitted;
+# signer-side validation remains authoritative even when every policy is off.
+admissionPolicies:
+  # Validates explicit DNS SANs requested through projected podCertificate
+  # userAnnotations for this signer, after expanding the interpolation values
+  # available during Pod admission.
+  dnsSANValidation:
+    enabled: false
+    # Supported modes: Deny, or Warn/Audit during a staged rollout. Kubernetes
+    # does not permit Deny and Warn in the same binding.
+    validationActions:
+      - Deny
+    # Empty selectors apply the binding to Pods in every namespace.
+    namespaceSelector: {}
+    objectSelector: {}
+
 # Controller manager settings
 manager:
   # Max concurrent reconciles

--- a/cmd/podcertificate-signer/chart_render_test.go
+++ b/cmd/podcertificate-signer/chart_render_test.go
@@ -8,13 +8,14 @@ import (
 
 func renderChartResult(t *testing.T, values ...string) (string, error) {
 	t.Helper()
-	args := []string{
+	args := make([]string, 0, 11+2*len(values))
+	args = append(args,
 		"template", "test", "../../charts/pod-certificate-signer",
 		"--namespace", "pcs-system",
 		"--kube-version", "1.35.0",
 		"--set", "signer.ca.secretRef.name=test-ca",
 		"--set", "signer.name=example.org/signer",
-	}
+	)
 	for _, value := range values {
 		args = append(args, "--set", value)
 	}

--- a/cmd/podcertificate-signer/chart_render_test.go
+++ b/cmd/podcertificate-signer/chart_render_test.go
@@ -156,7 +156,7 @@ func TestDNSSANAdmissionPolicyRendersIndependently(t *testing.T) {
 		"kind: ValidatingAdmissionPolicyBinding\n",
 		"name: test-pod-certificate-signer-dns-san-validation",
 		"podcertificate-signer.io/policy: dns-san-validation",
-		"validationActions:\n  - Warn\n  - Audit",
+		"validationActions:\n    - Warn\n    - Audit",
 		"policy: enabled",
 		"certificate: required",
 		"example.org/signer-san",

--- a/cmd/podcertificate-signer/chart_render_test.go
+++ b/cmd/podcertificate-signer/chart_render_test.go
@@ -6,6 +6,22 @@ import (
 	"testing"
 )
 
+func renderChartResult(t *testing.T, values ...string) (string, error) {
+	t.Helper()
+	args := []string{
+		"template", "test", "../../charts/pod-certificate-signer",
+		"--namespace", "pcs-system",
+		"--kube-version", "1.35.0",
+		"--set", "signer.ca.secretRef.name=test-ca",
+		"--set", "signer.name=example.org/signer",
+	}
+	for _, value := range values {
+		args = append(args, "--set", value)
+	}
+	out, err := exec.Command("helm", args...).CombinedOutput()
+	return string(out), err
+}
+
 // TestDeploymentRendersAllowUnverifiedIdentities guards the Helm escape hatch
 // for the identity-constraint default introduced in this change: the chart must
 // expose --allow-unverified-identities so operators can opt out via values
@@ -105,5 +121,75 @@ func TestNetworkPolicyOptional(t *testing.T) {
 		if !strings.Contains(on, want) {
 			t.Errorf("NetworkPolicy must keep %q reachable; missing from:\n%s", want, on)
 		}
+	}
+}
+
+func TestDNSSANAdmissionPolicyDisabledByDefault(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not installed; skipping chart render assertion")
+	}
+	out, err := renderChartResult(t)
+	if err != nil {
+		t.Fatalf("renderChart() error = %v\n%s", err, out)
+	}
+	if strings.Contains(out, "kind: ValidatingAdmissionPolicy") {
+		t.Fatalf("renderChart() contains admission policy while disabled by default:\n%s", out)
+	}
+}
+
+func TestDNSSANAdmissionPolicyRendersIndependently(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not installed; skipping chart render assertion")
+	}
+	out, err := renderChartResult(t,
+		"admissionPolicies.dnsSANValidation.enabled=true",
+		"admissionPolicies.dnsSANValidation.validationActions={Warn,Audit}",
+		"admissionPolicies.dnsSANValidation.namespaceSelector.matchLabels.policy=enabled",
+		"admissionPolicies.dnsSANValidation.objectSelector.matchLabels.certificate=required",
+	)
+	if err != nil {
+		t.Fatalf("renderChart() error = %v\n%s", err, out)
+	}
+
+	wants := []string{
+		"kind: ValidatingAdmissionPolicy\n",
+		"kind: ValidatingAdmissionPolicyBinding\n",
+		"name: test-pod-certificate-signer-dns-san-validation",
+		"podcertificate-signer.io/policy: dns-san-validation",
+		"validationActions:\n  - Warn\n  - Audit",
+		"policy: enabled",
+		"certificate: required",
+		"example.org/signer-san",
+		"cluster.local",
+		"format.dns1123Subdomain",
+	}
+	for _, want := range wants {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderChart() output does not contain %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDNSSANAdmissionPolicyRejectsInvalidActions(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not installed; skipping chart render assertion")
+	}
+	tests := []struct {
+		name   string
+		action string
+	}{
+		{name: "unknown action", action: "Block"},
+		{name: "deny and warn", action: "{Deny,Warn}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := renderChartResult(t,
+				"admissionPolicies.dnsSANValidation.enabled=true",
+				"admissionPolicies.dnsSANValidation.validationActions="+tt.action,
+			)
+			if err == nil {
+				t.Fatalf("renderChart(validationActions=%s) error = nil, want schema rejection\n%s", tt.action, out)
+			}
+		})
 	}
 }

--- a/cmd/podcertificate-signer/main.go
+++ b/cmd/podcertificate-signer/main.go
@@ -56,6 +56,7 @@ import (
 
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/controller"
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/authority"
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/podcertificate"
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/signer"
 	// +kubebuilder:scaffold:imports
 )
@@ -127,7 +128,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	if err := validateFlags(signerName); err != nil {
+	if err := validateFlags(signerName, clusterFqdn); err != nil {
 		setupLog.Error(err, "invalid command-line flags")
 		os.Exit(1)
 	}
@@ -260,13 +261,14 @@ func main() {
 	}
 }
 
-// validateFlags checks required command-line flags. An empty --signer-name is
-// rejected here so the controller fails fast at startup - mirroring the
-// required --ca-cert-path - instead of only surfacing the problem later, after
-// a Kubernetes API connection has been established.
-func validateFlags(signerName string) error {
+// validateFlags checks command-line flags that must fail before the controller
+// establishes a Kubernetes API connection.
+func validateFlags(signerName, clusterFQDN string) error {
 	if signerName == "" {
 		return errors.New("the --signer-name flag is required")
+	}
+	if err := podcertificate.ValidateClusterFQDN(clusterFQDN); err != nil {
+		return fmt.Errorf("invalid --cluster-fqdn %q: %w", clusterFQDN, err)
 	}
 	return nil
 }

--- a/cmd/podcertificate-signer/main_test.go
+++ b/cmd/podcertificate-signer/main_test.go
@@ -17,11 +17,29 @@ import (
 // An empty --signer-name must be rejected fast, before the controller attempts
 // any Kubernetes API calls, mirroring the required --ca-cert-path handling.
 func TestValidateFlagsRequiresSignerName(t *testing.T) {
-	if err := validateFlags(""); err == nil {
+	if err := validateFlags("", "cluster.local"); err == nil {
 		t.Error("validateFlags(\"\") = nil, want error for empty signer name")
 	}
-	if err := validateFlags("example.org/signer"); err != nil {
+	if err := validateFlags("example.org/signer", "cluster.local"); err != nil {
 		t.Errorf("validateFlags(%q) = %v, want nil", "example.org/signer", err)
+	}
+}
+
+func TestValidateFlagsRejectsInvalidClusterFQDN(t *testing.T) {
+	for _, clusterFQDN := range []string{
+		strings.Repeat("a", 64) + ".example",
+		"bad_fqdn.example",
+		"a..example",
+	} {
+		t.Run(clusterFQDN, func(t *testing.T) {
+			err := validateFlags("example.org/signer", clusterFQDN)
+			if err == nil {
+				t.Fatalf("validateFlags(clusterFQDN=%q) error = nil, want invalid DNS error", clusterFQDN)
+			}
+			if !strings.Contains(err.Error(), clusterFQDN) {
+				t.Errorf("validateFlags(clusterFQDN=%q) error = %q, want offending value", clusterFQDN, err)
+			}
+		})
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,9 @@ workload can only interpolate its **own** verified identity:
 
 Unknown variables and unterminated placeholders deny the request with reason
 `InvalidUnverifiedUserAnnotations`. Values are validated **after** expansion,
-including the 64-character common-name limit.
+including the 64-character common-name limit and DNS-1123 SAN limits. DNS SAN
+labels may contain at most 63 characters and the complete name at most 253;
+wildcard SANs are not supported.
 
 ### CSR-requested SANs (forward compatibility)
 
@@ -170,6 +172,44 @@ request a certificate for any name. Under the default constraints it is still
 worth applying as defense in depth: a pod rejected at admission gets an immediate
 error, instead of a volume that never mounts and a `Denied` request to go read.
 
+### Preventive DNS SAN admission policy
+
+The chart can also manage a signer-specific DNS SAN policy. Policies live under
+the `admissionPolicies` map so each policy remains independently selectable as
+the catalog grows:
+
+```yaml
+admissionPolicies:
+  dnsSANValidation:
+    enabled: true
+    validationActions:
+      - Warn
+      - Audit
+    namespaceSelector: {}
+    objectSelector: {}
+```
+
+The policy inspects Pods on create and update when a projected `podCertificate`
+volume names this chart's `signer.name` and supplies the matching `-san`
+`userAnnotations` key. It expands the values available at admission time
+(`${pod.name}`, `${pod.namespace}`, `${pod.serviceAccountName}`, and
+`${cluster.fqdn}`), then checks comma-separated DNS names, label lengths, total
+length, and DNS-1123 syntax. It ignores other signers, Pods without an explicit
+SAN annotation, CSR SANs, and generated defaults; those remain signer-side
+concerns.
+
+Start with `Warn` and `Audit`, observe warnings/audit events, narrow rollout with
+`namespaceSelector` or `objectSelector` if needed, then use `Deny`. Kubernetes
+does not allow `Deny` and `Warn` together in one binding, and the chart schema
+rejects that combination. The feature is disabled by default because enabling a
+cluster-scoped admission control is an operator rollout decision.
+
+This is complementary defense in depth, not an alternative to signer
+validation. The signer validates annotation, CSR, and generated DNS SANs after
+the source is resolved in both constrained and
+`--allow-unverified-identities` modes. That flag relaxes ownership checks only;
+it never permits malformed DNS identities.
+
 ## Validation rules
 
 The controller performs these validations by default:
@@ -186,6 +226,9 @@ The controller performs these validations by default:
    - `eku` accepts `client` and/or `server`; unknown tokens deny. The default is
      `serverAuth` only. Certificates for non-RSA keys carry only the
      `digitalSignature` key usage.
+   - Every selected DNS SAN is a DNS-1123 subdomain with labels of at most 63
+     characters and a total length of at most 253 characters. Invalid values are
+     rejected, never truncated or rewritten. Wildcard SANs are rejected.
 
 ## Controller CLI flags
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,7 +216,9 @@ The controller performs these validations by default:
 
 1. **CA files present** — the mounted CA cert/key files exist and load.
 2. **CA valid** — the CA is a valid, non-expired CA.
-3. **Request configuration** — the `unverifiedUserAnnotations` (or deprecated
+3. **Cluster FQDN valid** — `--cluster-fqdn` is a DNS-1123 subdomain; invalid
+   operator configuration fails controller startup.
+4. **Request configuration** — the `unverifiedUserAnnotations` (or deprecated
    annotations) are validated against the constraints the apiserver enforces on
    the request status, so misconfigurations are denied immediately:
    - Duration is at least `1h` and no more than the request's

--- a/internal/kubernetes/podcertificate/dns_validation_test.go
+++ b/internal/kubernetes/podcertificate/dns_validation_test.go
@@ -1,0 +1,108 @@
+package podcertificate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDNSNamesRejectMalformedValuesFromEverySource(t *testing.T) {
+	invalidName := strings.Repeat("a", 64) + ".example.org"
+	tests := []struct {
+		name string
+		pcr  func() map[string]string
+		opts Options
+	}{
+		{
+			name: "literal annotation with unverified identities allowed",
+			pcr: func() map[string]string {
+				return map[string]string{testSignerName + "-san": invalidName}
+			},
+			opts: Options{AllowUnverifiedIdentities: true},
+		},
+		{
+			name: "interpolated annotation that is allowlisted",
+			pcr: func() map[string]string {
+				return map[string]string{testSignerName + "-san": "${pod.name}.${pod.namespace}.pod.${cluster.fqdn}"}
+			},
+			opts: Options{EnableInterpolation: true},
+		},
+		{
+			name: "CSR with unverified identities allowed",
+			pcr:  func() map[string]string { return nil },
+			opts: Options{
+				HonorCSRSANs:              true,
+				AllowUnverifiedIdentities: true,
+				CSRDNSNames:               []string{invalidName},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pcr := testPCR(tt.pcr())
+			pod := testPod(nil)
+			if strings.Contains(tt.name, "interpolated") {
+				pcr.Spec.PodName = strings.Repeat("a", 64)
+				pod.Name = pcr.Spec.PodName
+			}
+
+			_, err := NewPodCertificateConfig(pcr, pod, tt.opts, nil, 0)
+			if err == nil {
+				t.Fatalf("NewPodCertificateConfig(DNS SAN %q) error = nil, want invalid DNS name error", invalidName)
+			}
+			if !strings.Contains(err.Error(), "DNS name") || !strings.Contains(err.Error(), "63") {
+				t.Errorf("NewPodCertificateConfig(DNS SAN %q) error = %q, want DNS label limit detail", invalidName, err)
+			}
+		})
+	}
+}
+
+func TestDNSNameValidationBoundaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		dnsName string
+		wantErr bool
+	}{
+		{name: "63 character label", dnsName: strings.Repeat("a", 63) + ".example.org"},
+		{name: "64 character label", dnsName: strings.Repeat("a", 64) + ".example.org", wantErr: true},
+		{name: "empty label", dnsName: "a..example.org", wantErr: true},
+		{name: "trailing hyphen", dnsName: "invalid-.example.org", wantErr: true},
+		{name: "invalid character", dnsName: "invalid_name.example.org", wantErr: true},
+		{name: "overlong complete name", dnsName: strings.Repeat("a.", 126) + "aa", wantErr: true},
+		{name: "wildcard rejected", dnsName: "*.example.org", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pcr := testPCR(map[string]string{testSignerName + "-san": tt.dnsName})
+			_, err := NewPodCertificateConfig(
+				pcr,
+				testPod(nil),
+				Options{AllowUnverifiedIdentities: true},
+				nil,
+				0,
+			)
+			if gotErr := err != nil; gotErr != tt.wantErr {
+				t.Errorf("NewPodCertificateConfig(DNS SAN %q) error = %v, want error = %t", tt.dnsName, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDNSNameValidationRejectsOneInvalidNameInList(t *testing.T) {
+	invalidName := strings.Repeat("a", 64) + ".example.org"
+	pcr := testPCR(map[string]string{
+		testSignerName + "-san": "valid.example.org," + invalidName + ",also-valid.example.org",
+	})
+
+	_, err := NewPodCertificateConfig(
+		pcr,
+		testPod(nil),
+		Options{AllowUnverifiedIdentities: true},
+		nil,
+		0,
+	)
+	if err == nil || !strings.Contains(err.Error(), invalidName) {
+		t.Fatalf("NewPodCertificateConfig(DNS SAN list containing %q) error = %v, want offending name", invalidName, err)
+	}
+}

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -14,6 +14,7 @@ import (
 
 	capiv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rafpe/kubernetes-podcertificate-signer/internal/api"
@@ -601,9 +602,28 @@ func keyUsageFor(alg x509.PublicKeyAlgorithm) x509.KeyUsage {
 	return x509.KeyUsageDigitalSignature
 }
 
+// validateDNSNames verifies that every resolved certificate DNS SAN is a valid
+// DNS-1123 subdomain. This syntax check is independent of identity ownership:
+// AllowUnverifiedIdentities may relax who owns a name, but it never permits a
+// malformed name. Wildcards are deliberately unsupported because the signer
+// authorizes identities by exact match.
+func validateDNSNames(names []string) error {
+	for _, name := range names {
+		if problems := validation.IsDNS1123Subdomain(name); len(problems) > 0 {
+			return fmt.Errorf("DNS name %q is invalid: %s", name, strings.Join(problems, "; "))
+		}
+		for _, label := range strings.Split(name, ".") {
+			if problems := validation.IsDNS1123Label(label); len(problems) > 0 {
+				return fmt.Errorf("DNS name %q is invalid: label %q: %s", name, label, strings.Join(problems, "; "))
+			}
+		}
+	}
+	return nil
+}
+
 // resolveDNSNames applies the san-annotation > CSR-requested > default
-// precedence for DNS SANs and, when identity constraints are enforced, verifies
-// each resolved name against the pod's verified identity.
+// precedence for DNS SANs, validates the selected names, and, when identity
+// constraints are enforced, verifies each name against the pod's identity.
 func resolveDNSNames(
 	lookup func(string) (string, bool),
 	expand func(string, string) (string, error),
@@ -615,6 +635,9 @@ func resolveDNSNames(
 	san, ok := lookup(AnnotationSuffixSAN)
 	if !ok {
 		if honorCSR && len(csrDNSNames) > 0 {
+			if err := validateDNSNames(csrDNSNames); err != nil {
+				return nil, err
+			}
 			// CSR-requested SANs are attacker-influenced just like annotation
 			// values, so they must clear the same verified-identity allowlist.
 			if !allowUnverified {
@@ -626,6 +649,9 @@ func resolveDNSNames(
 			}
 			return csrDNSNames, nil
 		}
+		if err := validateDNSNames(defaults); err != nil {
+			return nil, err
+		}
 		return defaults, nil
 	}
 	san, err := expand(AnnotationSuffixSAN, san)
@@ -635,6 +661,9 @@ func resolveDNSNames(
 	names := splitAndTrim(san)
 	if len(names) == 0 {
 		return nil, fmt.Errorf("annotation %q contains no DNS names", annotationKey(signerName, AnnotationSuffixSAN))
+	}
+	if err := validateDNSNames(names); err != nil {
+		return nil, err
 	}
 	if !allowUnverified {
 		for _, name := range names {

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -621,6 +621,12 @@ func validateDNSNames(names []string) error {
 	return nil
 }
 
+// ValidateClusterFQDN validates the operator-configured DNS suffix used for
+// generated and interpolated certificate identities.
+func ValidateClusterFQDN(clusterFQDN string) error {
+	return validateDNSNames([]string{clusterFQDN})
+}
+
 // resolveDNSNames applies the san-annotation > CSR-requested > default
 // precedence for DNS SANs, validates the selected names, and, when identity
 // constraints are enforced, verifies each name against the pod's identity.

--- a/test/e2e/admission_policy_test.go
+++ b/test/e2e/admission_policy_test.go
@@ -1,0 +1,116 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
+)
+
+func dryRunPodAdmission(name, requestedSigner string, annotations map[string]string) (string, error) {
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: workloadNamespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "workload",
+				Image:   "busybox:1.37",
+				Command: []string{"sleep", "60"},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "certificate",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{{
+							PodCertificate: &corev1.PodCertificateProjection{
+								SignerName:           requestedSigner,
+								KeyType:              "ED25519",
+								CredentialBundlePath: "credentialbundle.pem",
+								UserAnnotations:      annotations,
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	manifest, err := json.Marshal(pod)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("kubectl", "create", "--dry-run=server", "-f", "-")
+	cmd.Stdin = bytes.NewReader(manifest)
+	return utils.Run(cmd)
+}
+
+func defineAdmissionPolicyTests() {
+	Context("DNS SAN ValidatingAdmissionPolicy", func() {
+		BeforeAll(func() {
+			By("waiting for the admission policy to compile without type-check warnings")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "validatingadmissionpolicy",
+					releaseName+"-dns-san-validation", "-o", "json")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(ContainSubstring("expressionWarnings"))
+			}).Should(Succeed())
+		})
+
+		DescribeTable("admits valid or out-of-scope Pod certificate requests",
+			func(name, requestedSigner string, annotations map[string]string) {
+				output, err := dryRunPodAdmission(name, requestedSigner, annotations)
+				Expect(err).NotTo(HaveOccurred(), output)
+			},
+			Entry("a 63-character DNS label", "vap-valid-63", signerName, map[string]string{
+				signerName + "-san": strings.Repeat("a", 63) + ".example.org",
+			}),
+			Entry("multiple valid DNS SANs", "vap-valid-list", signerName, map[string]string{
+				signerName + "-san": "api.example.org, web.example.org",
+			}),
+			Entry("pod identity interpolation", "vap-valid-pod", signerName, map[string]string{
+				signerName + "-san": "${pod.name}.${pod.namespace}.svc.${cluster.fqdn}",
+			}),
+			Entry("default service account interpolation", "vap-valid-sa", signerName, map[string]string{
+				signerName + "-san": "${pod.serviceAccountName}.${pod.namespace}.svc",
+			}),
+			Entry("matching signer without SAN annotation", "vap-no-san", signerName, map[string]string{
+				signerName + "-cn": "valid.example.org",
+			}),
+			Entry("another signer", "vap-other-signer", "other.example/signer", map[string]string{
+				"other.example/signer-san": strings.Repeat("a", 64) + ".example.org",
+			}),
+		)
+
+		DescribeTable("rejects malformed effective DNS SANs at Pod admission",
+			func(name, san string) {
+				output, err := dryRunPodAdmission(name, signerName, map[string]string{signerName + "-san": san})
+				Expect(err).To(HaveOccurred(), output)
+				Expect(output).To(ContainSubstring("each label must be at most 63 characters"))
+			},
+			Entry("64-character label", "vap-invalid-64", strings.Repeat("a", 64)+".example.org"),
+			Entry("prefix makes interpolated pod label too long", strings.Repeat("p", 58), "prefix-${pod.name}.example.org"),
+			Entry("one invalid SAN in a list", "vap-invalid-list", "valid.example.org,"+strings.Repeat("a", 64)+".example.org"),
+			Entry("empty list member", "vap-empty-member", "valid.example.org,,other.example.org"),
+			Entry("empty DNS label", "vap-empty-label", "a..example.org"),
+			Entry("trailing hyphen", "vap-trailing-hyphen", "invalid-.example.org"),
+			Entry("invalid character", "vap-invalid-char", "invalid_name.example.org"),
+			Entry("complete name over 253 characters", "vap-too-long", strings.Repeat("a.", 126)+"aa"),
+			Entry("unsupported interpolation variable", "vap-unknown-var", "${pod.uid}.example.org"),
+			Entry("unterminated interpolation variable", "vap-unterminated", "${pod.name.example.org"),
+		)
+	})
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Manager", Ordered, func() {
 		// unit tests (identity_constraints_test.go).
 		cmd = exec.Command("make", "helm-install",
 			fmt.Sprintf("IMAGE=%s", projectImage),
-			"HELM_EXTRA_ARGS=--set replicaCount=1 --set signer.enable_annotation_interpolation=true --set signer.allow_unverified_identities=true")
+			"HELM_EXTRA_ARGS=--set replicaCount=1 --set signer.enable_annotation_interpolation=true --set signer.allow_unverified_identities=true --set admissionPolicies.dnsSANValidation.enabled=true")
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 	})
@@ -493,6 +493,8 @@ var _ = Describe("Manager", Ordered, func() {
 			}, 5*time.Minute).Should(Succeed())
 		})
 	})
+
+	defineAdmissionPolicyTests()
 })
 
 // getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.


### PR DESCRIPTION
## What does this PR do?

Closes PR #80's documented interpolated-DNS-SAN follow-up with two complementary layers:

- authoritative signer-side DNS validation after annotation, CSR, or default source selection and before identity authorization;
- an optional Helm-managed `ValidatingAdmissionPolicy` that gives Pod authors preventive feedback for malformed explicit DNS SAN annotations.

DNS identities are never truncated or rewritten. Labels are limited to 63 characters, complete names to 253 characters, DNS-1123 syntax is enforced, and wildcard SANs are rejected. `--allow-unverified-identities` continues to relax ownership only; it cannot bypass syntax validation. Invalid operator-supplied cluster FQDNs now fail startup, while PR #80's long-pod default-SAN omission and `ReasonDefaultSANSkipped` warning remain unchanged.

The chart exposes independently selectable policy configuration under `admissionPolicies.dnsSANValidation`, disabled by default, with `Deny`/`Warn`/`Audit` actions plus namespace and object selectors. README and configuration docs include the signer-versus-admission behavioral alignment table and staged rollout guidance.

## Related issues

Follow-up to #48 and #80. Part of #79.

## Verification

- `make test`
- `make lint`
- `make test-e2e` — 24/24 Kind specs passed with secure metrics from #82 and DNS admission enabled together
- Helm chart lint
- Signer package coverage: 92.4%

## Checklist

- [x] Exactly one `release/*` label is set (`release/minor`).
- [x] The PR title is descriptive.
- [x] `make test` and `make lint` pass locally.
- [x] Tests were added/updated for new behavior.
- [x] Docs were updated for user-facing changes.
