### PR TITLE
docs(#87): document what bounds annotation interpolation

### DIFF
--- a/.changes/unreleased/changed-interpolation-rationale.yaml
+++ b/.changes/unreleased/changed-interpolation-rationale.yaml
@@ -1,0 +1,2 @@
+kind: Changed
+body: "Documented what bounds `${...}` annotation interpolation: placeholders resolve only from apiserver-verified request fields plus the operator-set cluster FQDN, and every resolved value is checked against the pod's verified identity by exact string equality exactly as a literal value is - so interpolation grants no identity a pod does not already own. The security gate is `--allow-unverified-identities`, not `--enable-annotation-interpolation`."

--- a/charts/pod-certificate-signer/README.md
+++ b/charts/pod-certificate-signer/README.md
@@ -92,7 +92,7 @@ The signing CA is configured under `signer.ca` with an explicit `source`:
 | `signer.ca.secretRef.certKey` / `.keyKey` / `.mountPath` | Secret keys projected and where they mount. | `tls.crt` / `tls.key` / `/app/signer/ca` |
 | `signer.ca.file.certPath` / `.keyPath` | CA paths when `source=file` (you mount them yourself). | `/app/signer/ca/tls.crt` / `.../tls.key` |
 | `signer.max_previous_ca_certs` | Previous CAs retained in the ClusterTrustBundle across rotation. | `2` |
-| `signer.enable_annotation_interpolation` | Allow `${...}` placeholders in `cn`/`san`/`uris`, resolved from verified request fields. | `false` |
+| `signer.enable_annotation_interpolation` | Allow `${...}` placeholders in `cn`/`san`/`uris`, resolved only from apiserver-verified request fields plus `cluster_fqdn`. Resolved values are checked against the pod's verified identity by exact string equality, exactly as literal values are, so interpolation grants no identity the pod does not already own — the security gate is `signer.allow_unverified_identities`, not this flag. | `false` |
 | `signer.honor_csr_sans` | Honor SANs from the kubelet PKCS#10 CSR (forward-compat; kubelet emits empty CSRs today). | `false` |
 | **`signer.allow_unverified_identities`** | **Security escape hatch.** When `false`, annotation `cn`/`san`/`ip-san`/`uris` values must resolve to the pod's verified identity, and IP SANs are denied. See [Identity constraints](#identity-constraints-security). | `false` |
 | `admissionPolicies.dnsSANValidation.enabled` | Create a signer-specific policy and binding that validate explicit Pod certificate DNS SANs before admission. | `false` |

--- a/charts/pod-certificate-signer/values.yaml
+++ b/charts/pod-certificate-signer/values.yaml
@@ -95,6 +95,14 @@ signer:
   # Feature flag: allow ${...} placeholders (e.g. ${pod.name},
   # ${pod.serviceAccountName}) in certificate configuration annotations,
   # resolved from the verified fields of the PodCertificateRequest.
+  #
+  # Placeholders resolve only from apiserver-verified request fields plus
+  # cluster_fqdn above, and every resolved value must clear the identity
+  # constraints below by exact string equality - exactly as a literal value
+  # must. So interpolation grants no identity the pod does not already own; it
+  # changes the syntax you use to name one, not the set you may obtain. The
+  # security gate is allow_unverified_identities, not this flag. See the
+  # "Interpolating pod identity into values" section of docs/configuration.md.
   enable_annotation_interpolation: false
 
   # Feature flag: honor DNS and IP SANs embedded in the kubelet-generated

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,47 @@ including the 64-character common-name limit and DNS-1123 SAN limits. DNS SAN
 labels may contain at most 63 characters and the complete name at most 253;
 wildcard SANs are not supported.
 
+#### What bounds interpolation
+
+Interpolation is a **naming** mechanism, not an authorization one. Two properties
+bound it, and it is worth being precise about which does what, because the second
+is the one people mistake this feature flag for.
+
+1. **Where values come from.** The variable table above is the whole table.
+   Every entry resolves from a `PodCertificateRequest` spec field that kubelet
+   populates and kube-apiserver verifies, except `${cluster.fqdn}`, which comes
+   from the operator's own `--cluster-fqdn`. No user-controlled input reaches it.
+   Expansion is a single non-recursive pass — a resolved value cannot itself
+   contain `${...}`, because Kubernetes object names and UIDs cannot.
+2. **What the resolved value is then checked against.** Every expanded `cn`,
+   `san` and `uris` value must be an exact string member of the
+   [verified-identity allowlist](#identity-constraints-security). The comparison
+   is **exact string equality**, never a prefix or pattern match — which is why
+   `${pod.name}.evil.example.com` is denied even though it begins with a name the
+   pod owns.
+
+Together these mean an interpolated value is subject to **exactly the same
+identity check as a literal one**. The check is membership-based and does not
+care how the string was produced, so interpolation grants no identity a pod does
+not already own. What it buys is portability — the same pod template across
+namespaces and clusters — plus per-pod values like `${pod.name}` that cannot be
+written literally in a shared Deployment at all.
+
+> [!IMPORTANT]
+> **The security gate is `--allow-unverified-identities`, not this flag.** That
+> is the setting that decides whether a pod may claim an identity it does not
+> own. `--enable-annotation-interpolation` decides only whether `${...}` is
+> resolved or rejected as a value; it is not a substitute for the identity
+> constraints and does not weaken them.
+
+**Claimable** via interpolation: the pod's name, its canonical Kubernetes DNS
+forms, its SPIFFE ID, and its service account's short DNS form `<sa>.<ns>` and
+SPIFFE ID. `${node.name}` and `${pod.uid}` resolve but are **not** claimable as a
+subject — a node identity belongs to the kubelet, and a UID is an opaque token.
+The boundary of that set, including which forms are deliberately excluded and
+why, is recorded in
+[ADR-0001](adr/0001-verified-identity-allowlist-boundary.md).
+
 ### CSR-requested SANs (forward compatibility)
 
 Upstream Kubernetes plans to let pod authors request DNS and IP SANs that


### PR DESCRIPTION
## What does this PR do?

Answers the documentation half of #87.

`--enable-annotation-interpolation` is the only flag in the chart whose gate is stated without saying what it protects — `docs/configuration.md` says "disabled by default" and stops. The reasonable inference is that the flag is a security control, and it is not.

Adds a **"What bounds interpolation"** subsection that separates the two properties people conflate:

1. **Where values come from.** The variable table is the whole table. Every entry resolves from a `PodCertificateRequest` spec field kubelet populates and kube-apiserver verifies, except `${cluster.fqdn}`, which is the operator's own `--cluster-fqdn`. No user-controlled input reaches it; expansion is a single non-recursive pass.
2. **What the resolved value is then checked against.** Exact string membership of the verified-identity allowlist — never a prefix or pattern match, which is why `${pod.name}.evil.example.com` is denied despite beginning with a name the pod owns.

Together: an interpolated value is subject to **exactly the same identity check as a literal one**, so interpolation grants no identity a pod does not already own. What it buys is portability and per-pod values like `${pod.name}` that cannot be written literally in a shared Deployment at all.

Called out because it is the part people get wrong: **the security gate is `--allow-unverified-identities`, not this flag.** Plus which identities are claimable, that `${node.name}`/`${pod.uid}` resolve but are not claimable as a subject, and a pointer to ADR-0001 for the allowlist boundary.

### Scope

**This says nothing about which default ships.** The change is purely additive to `docs/configuration.md` — zero deleted lines. The existing "disabled by default" callout and the `--enable-annotation-interpolation` CLI flag reference are untouched, as are the chart README and `values.yaml` default columns. Everything added here stays true whichever way the default goes, so revisiting the default is a one-block diff that does not collide with this.

## Related issues

Addresses the documentation half of #87.

## Checklist

- [x] **Exactly one `release/*` label is set** — `release/patch`.
- [x] `.changes/unreleased/changed-interpolation-rationale.yaml` included (`kind: Changed`).
- [x] The PR title is descriptive.
- [x] `make lint` passes. `make test` passes except the pre-existing envtest suite, which cannot download its control-plane binaries locally (429 from the index) and fails identically on unmodified `main` — green on CI.
- [ ] Tests — not applicable, documentation only. The behavior described is covered by `identity_constraints_test.go` and, since the layer below, by the e2e secure-defaults profile.
- [x] Docs updated — that is the whole change.
