### PR TITLE
docs: adopt ADRs and record the verified-identity allowlist boundary

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,3 +16,4 @@
 - [ ] `make test` and `make lint` pass locally.
 - [ ] Tests were added/updated for new behavior.
 - [ ] Docs (README, chart docs, examples) were updated for user-facing changes.
+- [ ] An ADR in `docs/adr/` accompanies this change if it needs one — see [when an ADR is required](/CONTRIBUTING.md#when-an-adr-is-required). Not CI-enforced; use your judgement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,58 @@ Allowed kinds are `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`,
 Ordinary merges never publish; maintainers explicitly prepare and approve a
 generated release PR.
 
+## Architecture Decision Records
+
+Decisions that shape how the signer is built or operated are recorded in
+[`docs/adr/`](docs/adr/README.md). The record exists so the reasoning survives
+the pull request that carried it: a code comment explains what the code does, an
+ADR explains why the alternative was turned down.
+
+### When an ADR is required
+
+Open one alongside the PR (or before it) when the change touches:
+
+- **a default that affects issuance or security posture** — flipping
+  `enable_annotation_interpolation`, `allow_unverified_identities`,
+  `honor_csr_sans`, `metrics_secure`, or the default EKU set;
+- **the identity model** — anything that widens or narrows
+  `verifiedIdentities`, changes how a resolved value is compared against it, or
+  adds an interpolation variable;
+- **the trust boundary** — new RBAC, a new API the controller reads or writes,
+  new inputs it treats as trusted, or a change to what reaches the CA key;
+- **a flag that gates what ends up in a certificate** — subject, SANs, URIs,
+  EKU, validity;
+- **cluster-wide chart resources** — ClusterRoles, ValidatingAdmissionPolicies,
+  ClusterTrustBundles, or anything else installed outside the release namespace;
+- **anything carrying `release/major`.** A breaking change always warrants a
+  record of what was broken and why.
+
+Routine work inside an established pattern does not need one. Neither do bug
+fixes, dependency bumps, or docs. If you find yourself writing a long code
+comment that argues rather than describes, that argument belongs in an ADR.
+
+### Lifecycle
+
+An ADR is created as `proposed`, discussed on the PR, and then either `accepted`
+or `rejected`. **A rejected ADR is kept, not deleted** — the record that an
+option was considered and turned down is exactly what stops it being
+re-proposed. A decision that is later replaced becomes
+`superseded by [ADR-NNNN](NNNN-slug.md)`, with the new ADR linking back; one
+that no longer applies but has no replacement becomes `deprecated` with the
+reason stated. Status lives in the YAML front matter. Do not rewrite an accepted
+ADR's history — append to `## More Information` instead.
+
+### Review
+
+**An ADR needs at least one approving maintainer review before it is merged as
+`accepted`.** This is the one place in the project where a second pair of eyes
+is not optional: ordinary PRs merge on green CI, but a decision that governs
+future code should not be self-approved. An ADR may merge as `proposed` without
+that review — it just does not bind anything until accepted.
+
+Reference the ADR from the code it governs with a short `ADR-NNNN` comment at
+the relevant entry point, and from the PR description.
+
 ## Reporting issues
 
 Use the issue forms in this repository for bugs and feature requests. For

--- a/docs/adr/0001-verified-identity-allowlist-boundary.md
+++ b/docs/adr/0001-verified-identity-allowlist-boundary.md
@@ -1,0 +1,208 @@
+---
+status: accepted
+date: 2026-08-17
+decision-makers: RafPe
+---
+
+# Bound the verified-identity allowlist to identities the signer emits, plus the service-account short DNS form and SPIFFE ID
+
+## Context and Problem Statement
+
+Since [#26](https://github.com/RafPe/pod-certificate-signer/issues/26) /
+[#38](https://github.com/RafPe/pod-certificate-signer/issues/38) the signer
+enforces a default-deny identity model. Every `cn`, `san` and `uris` value —
+literal or `${...}`-interpolated — must be an exact string member of the set
+returned by `verifiedIdentities`
+(`internal/kubernetes/podcertificate/podcertificate.go:505-548`), computed
+solely from the apiserver-verified fields of the `PodCertificateRequest`. The
+exact-equality check is what closes literal-injection loopholes such as
+`${pod.name}.attacker.com`.
+
+That set currently contains:
+
+- for the pod: `<pod>`, `<pod>.<ns>`, `<pod>.<ns>.pod`, `<pod>.<ns>.svc`,
+  `<pod>.<ns>.pod.<fqdn>`, `<pod>.<ns>.svc.<fqdn>`, and
+  `spiffe://<fqdn>/ns/<ns>/pod/<pod>`;
+- for the service account: `<sa>.<ns>` and
+  `spiffe://<fqdn>/ns/<ns>/sa/<sa>`.
+
+The asymmetry is visible: the pod gets `.svc` and `.svc.<fqdn>` forms, the
+service account does not. Two things forced the question.
+
+1. [#87](https://github.com/RafPe/pod-certificate-signer/issues/87) asks for
+   `--enable-annotation-interpolation` to default on, so that per-pod
+   SPIFFE-style identity works out of the box.
+2. `examples/workload-pod.yaml` — the repository's flagship example, referenced
+   from the docs and applied by the e2e suite — requests
+   `${pod.serviceAccountName}.${pod.namespace}.svc`, which resolves to
+   `<sa>.<ns>.svc` and is **denied** under the default configuration. The e2e
+   suite masks this by installing with both `allow_unverified_identities=true`
+   and `enable_annotation_interpolation=true`, so the failure has never been
+   observed in CI.
+
+So there are two ways to make the example issue: widen the allowlist with the
+service-account `.svc` / `.svc.<fqdn>` forms, or keep the allowlist as it is and
+fix the example. That choice governs the identity model, and nothing in the repo
+records which way it should go.
+
+There is a second problem this decision solves. Nothing in the repository states
+what the allowlist's boundary *is* — only what it currently contains. Without a
+stated rule, the allowlist grows one plausible-looking entry at a time, each
+justified locally, until it no longer denies anything meaningful.
+
+## Decision
+
+**The verified-identity allowlist contains exactly two categories, and nothing
+else:**
+
+**(a) The identities the signer itself emits by default.** `defaultPodDNSNames`
+(`podcertificate.go:486-496`) emits `<pod>.<ns>.pod.<fqdn>` and
+`<pod>.<ns>.svc.<fqdn>`; `defaultCommonName` emits `<pod>`. Whatever the signer
+will put into a certificate on its own must be claimable explicitly, or the
+annotation path would be stricter than the default path — a contradiction. The
+shorter pod forms (`<pod>.<ns>`, `<pod>.<ns>.pod`, `<pod>.<ns>.svc`) and the pod
+SPIFFE ID are the search-path and SPIFFE spellings of the same emitted names.
+
+**(b) The service account's short DNS form `<sa>.<ns>` and its SPIFFE ID
+`spiffe://<fqdn>/ns/<ns>/sa/<sa>`.** The pod runs as this service account, so it
+may identify by it.
+
+**The service-account Service DNS forms `<sa>.<ns>.svc` and
+`<sa>.<ns>.svc.<fqdn>` are deliberately excluded**, and so are the corresponding
+`.pod` forms. Reasons, strongest first:
+
+1. **They would let a pod claim a real Service's DNS name.**
+   `<name>.<ns>.svc.<fqdn>` is exactly the Kubernetes *Service* record shape.
+   ServiceAccount names and Service names are independent within a namespace —
+   nothing prevents a ServiceAccount `api` in namespace `prod` while a Service
+   `api` in `prod` fronts a different team's workload. Granting the form means
+   any pod running as that service account can present a valid server
+   certificate for `api.prod.svc.cluster.local`, the exact name a strict TLS
+   client dials and verifies. This directly contradicts the project's own
+   documented threat model: the "Identity constraints" section of
+   `docs/configuration.md` names **`kubernetes.default.svc`** as the canonical
+   example of what the constraint exists to deny — and a
+   ServiceAccount named `kubernetes` in namespace
+   `default` would make precisely that claimable. Decisive on its own.
+2. **The name resolves to nothing, so it buys the workload nothing.**
+   Kubernetes DNS publishes no record for a ServiceAccount. A certificate
+   asserting `<sa>.<ns>.svc` can never be validated against a connection a
+   client actually opened by that name — pure risk, zero interoperability value.
+3. **The service-account identity already has two correct forms.** The SPIFFE
+   URI is *exactly* what #87 asks for; the reporter's own example is
+   `spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}`.
+   Nothing in #87 requires a service-account-derived DNS name.
+4. **The asymmetry with the pod forms is principled, not an oversight.** The
+   signer never emits any service-account-derived DNS name. Widening the
+   allowlist past what the signer will emit on its own is the thing to avoid.
+
+**Non-goals.** This ADR does not change any signer behavior — the allowlist
+already matches the rule above. It does not decide the fate of
+`examples/workload-pod.yaml`, nor the default of
+`--enable-annotation-interpolation`; both are separate changes that this
+boundary constrains. It says nothing about `--allow-unverified-identities`,
+which lifts the allowlist entirely and is an explicit operator decision.
+
+**Recorded caveat, deliberately not acted on.** The already-allowed `<sa>.<ns>`
+carries a weaker version of the same hazard. From inside a pod, `api.prod`
+(1 dot, below the default `ndots:5`) resolves through the resolver search path
+to `api.prod.svc.cluster.local` — i.e. the Service. So the collision risk is not
+*created* by the service-account forms; it is *amplified* by adding the
+fully-qualified ones, which turn an ambiguous search-path artifact into an
+unambiguous, canonical, SNI-matching claim. This argues for narrowing `<sa>.<ns>`
+later, never for widening now. Narrowing it is a breaking change and belongs in
+its own issue and ADR.
+
+## Consequences
+
+* Good, because the allowlist now has a stated boundary rather than a list of
+  contents. "Does the signer emit this name itself?" is a question a reviewer can
+  answer, so a future addition has to argue against a rule instead of merely
+  looking plausible.
+* Good, because per-pod service-account identity has one blessed spelling — the
+  SPIFFE URI — which is also what #87 asked for.
+* Good, because the decision is locked by characterization tests
+  (`TestServiceAccountServiceDNSFormsDenied`,
+  `TestServiceAccountSPIFFEIDAccepted`), so a future "just add `.svc`" patch
+  turns red with a pointer here rather than merging quietly.
+* Bad, because `examples/workload-pod.yaml` stays broken until it is fixed
+  separately: it requests `<sa>.<ns>.svc`, which this decision confirms is
+  denied. The example is now provably wrong rather than ambiguously wrong.
+* Bad, because an operator who genuinely wants a service-account-derived
+  `.svc` name has no path except `--allow-unverified-identities`, which lifts
+  every constraint at once rather than just this one. Accepted: the name
+  resolves to nothing, so the demand should be rare, and a narrow opt-in for it
+  would be a worse trade than the escape hatch.
+* Follow-up: open an issue for the `<sa>.<ns>` search-path hazard described in
+  the caveat above.
+* Follow-up: `examples/workload-pod.yaml` must be changed to request the
+  service-account SPIFFE ID instead of `<sa>.<ns>.svc`, and the e2e suite must
+  stop masking the denial with `allow_unverified_identities=true`.
+
+## Implementation Plan
+
+* **Affected paths**:
+  * `internal/kubernetes/podcertificate/podcertificate.go` —
+    `verifiedIdentities` (`:505-548`) is the sole implementation of this
+    decision. The "Deliberately excluded" comment on its `if sa != ""` branch
+    names the excluded forms and cites this ADR.
+  * `internal/kubernetes/podcertificate/identity_constraints_test.go` — the
+    characterization tests that lock it.
+* **Dependencies**: none.
+* **Patterns to follow**: identity checks go through `assertVerifiedIdentity`
+  against the map `verifiedIdentities` returns. Comparison is exact string
+  equality — never prefix, suffix, or pattern matching, which is what makes
+  `${pod.name}.attacker.com` fail.
+* **Patterns to avoid**: do not add an entry to `verifiedIdentities` that the
+  signer does not itself emit, unless an amendment to this ADR argues the case.
+  Do not relax the exact-equality comparison. Do not "fix" a denied example by
+  turning on `--allow-unverified-identities`.
+
+### Verification
+
+- [x] `verifiedIdentities` contains no `<sa>.<ns>.svc` or `<sa>.<ns>.pod` entry,
+      in either bare or FQDN-suffixed form.
+- [x] `go test ./internal/kubernetes/podcertificate/... -run ServiceAccount`
+      passes, covering both the denial of the four service-account Service/pod
+      DNS forms and the acceptance of the service-account SPIFFE ID.
+- [x] The `if sa != ""` branch of `verifiedIdentities` carries a comment naming
+      the excluded forms and citing this ADR.
+- [ ] A future allowlist addition either satisfies rule (a) or ships with an
+      amendment to this ADR.
+
+## Alternatives Considered
+
+* **Add `<sa>.<ns>.svc` and `<sa>.<ns>.svc.<fqdn>` to the allowlist.** Rejected:
+  it makes a real Service's canonical DNS name claimable by any pod running as a
+  same-named service account, which is the precise attack
+  the "Identity constraints" section of `docs/configuration.md` cites as the
+  reason the constraint exists.
+* **Add the forms but only when no Service of that name exists in the
+  namespace.** Rejected: it makes issuance depend on mutable cluster state the
+  signer would have to watch, turns a deterministic check into a TOCTOU race
+  (create the certificate, then create the Service), and requires the controller
+  to gain read access to Services — a trust-boundary expansion out of proportion
+  to a name that resolves to nothing anyway.
+* **Leave the allowlist undocumented and fix the example quietly.** Rejected:
+  the same question would be re-litigated the next time someone reads the
+  asymmetry as a bug, which is how #87 surfaced in the first place.
+
+## More Information
+
+* Issue [#87](https://github.com/RafPe/pod-certificate-signer/issues/87) —
+  `--enable-annotation-interpolation` on by default; the trigger for this ADR.
+* Issues [#26](https://github.com/RafPe/pod-certificate-signer/issues/26),
+  [#38](https://github.com/RafPe/pod-certificate-signer/issues/38) — introduced
+  the default-deny identity model.
+* Issue [#48](https://github.com/RafPe/pod-certificate-signer/issues/48) and PR
+  [#80](https://github.com/RafPe/pod-certificate-signer/pull/80) — routed CSR
+  DNS SANs through the same allowlist, so this boundary now governs the CSR path
+  too.
+* `docs/configuration.md` — "Identity constraints" documents the resulting
+  user-visible behavior.
+
+**Revisit if**: Kubernetes publishes DNS records for ServiceAccounts (removing
+reason 2); or the signer begins emitting a service-account-derived DNS name by
+default (making it fall under rule (a)); or the `<sa>.<ns>` search-path hazard
+is judged severe enough to narrow the allowlist, which would supersede this ADR
+rather than amend it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Architecture Decision Records (ADR)
+
+An Architecture Decision Record captures a decision that shapes how this signer
+is built or operated, together with the context that forced it and the
+consequences it carries. The record exists so that the next person — or the next
+agent — reading the code can find the reasoning without reconstructing it from
+git history.
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md#architecture-decision-records) for
+when an ADR is required and how one is reviewed.
+
+## Conventions
+
+- Directory: `docs/adr/`
+- Naming: `NNNN-title-with-dashes.md`, zero-padded sequential number, lowercase
+  slug.
+- Status lives in YAML front matter: `proposed`, `accepted`, `rejected`,
+  `deprecated`, or `superseded by [ADR-NNNN](NNNN-slug.md)`.
+- A rejected ADR is kept, not deleted. The record of what was considered and
+  turned down is the point.
+- Code governed by an ADR should carry a short `ADR-NNNN` comment at the
+  relevant entry point, so the reasoning is discoverable from the code.
+
+## ADRs
+
+| ADR | Title | Status |
+| --- | ----- | ------ |
+| [0001](0001-verified-identity-allowlist-boundary.md) | Bound the verified-identity allowlist to identities the signer emits, plus the service-account short DNS form and SPIFFE ID | Accepted |

--- a/internal/kubernetes/podcertificate/identity_constraints_test.go
+++ b/internal/kubernetes/podcertificate/identity_constraints_test.go
@@ -86,6 +86,81 @@ func TestNodeAndUIDNotClaimable(t *testing.T) {
 	}
 }
 
+// The service-account identity is claimable in its short DNS form and as a
+// SPIFFE ID, never as a Kubernetes Service DNS name: <sa>.<ns>.svc is the shape
+// of a Service record, and ServiceAccount and Service names are independent
+// within a namespace. Allowing it would let a pod running as ServiceAccount
+// "kubernetes" in "default" present a certificate for kubernetes.default.svc -
+// the exact case the identity constraint exists to deny. The signer emits no
+// service-account-derived DNS name of its own, so none is claimable. See
+// docs/adr/0001-verified-identity-allowlist-boundary.md.
+//
+// This is a characterization test: it passes today and exists to lock the
+// decision, so a future "just add .svc" patch turns red with a pointer to the
+// reasoning rather than merging quietly.
+func TestServiceAccountServiceDNSFormsDenied(t *testing.T) {
+	for _, san := range []string{
+		"${pod.serviceAccountName}.${pod.namespace}.svc",
+		"${pod.serviceAccountName}.${pod.namespace}.svc.${cluster.fqdn}",
+		"${pod.serviceAccountName}.${pod.namespace}.pod",
+		"${pod.serviceAccountName}.${pod.namespace}.pod.${cluster.fqdn}",
+	} {
+		t.Run(san, func(t *testing.T) {
+			pcr := verifiedPCR(map[string]string{testSignerName + "-san": san})
+			if _, err := NewPodCertificateConfig(pcr, testPod(nil), Options{EnableInterpolation: true}, nil, 0); err == nil {
+				t.Fatalf("want denial for san=%q, got nil", san)
+			}
+		})
+	}
+}
+
+// The SPIFFE ID of the pod's service account is the supported way to carry
+// per-pod workload identity (issue #87), and must be accepted under the default
+// identity constraints - it is the form the ADR points operators at once the
+// service-account Service DNS forms above are ruled out. See
+// docs/adr/0001-verified-identity-allowlist-boundary.md.
+func TestServiceAccountSPIFFEIDAccepted(t *testing.T) {
+	pcr := verifiedPCR(map[string]string{
+		testSignerName + "-uris": "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}",
+	})
+
+	config, err := NewPodCertificateConfig(pcr, testPod(nil), Options{EnableInterpolation: true}, nil, 0)
+	if err != nil {
+		t.Fatalf("NewPodCertificateConfig: %v", err)
+	}
+	if len(config.URIs) != 1 || config.URIs[0].String() != "spiffe://cluster.local/ns/myns/sa/mysa" {
+		t.Errorf("URIs = %v, want the service-account SPIFFE ID", config.URIs)
+	}
+}
+
+// The pod's own canonical Kubernetes DNS forms are claimable because the signer
+// emits them itself by default (defaultPodDNSNames) - the allowlist must contain
+// everything the default path already puts into a certificate, or the annotation
+// path would be stricter than doing nothing. This is the counterpart to
+// TestServiceAccountServiceDNSFormsDenied: it pins rule (a) of
+// docs/adr/0001-verified-identity-allowlist-boundary.md, and is what makes the
+// asymmetry between the pod and service-account forms principled rather than an
+// oversight.
+func TestPodServiceDNSFormsAccepted(t *testing.T) {
+	for san, want := range map[string]string{
+		"${pod.name}.${pod.namespace}.svc":                 "mypod.myns.svc",
+		"${pod.name}.${pod.namespace}.svc.${cluster.fqdn}": "mypod.myns.svc.cluster.local",
+		"${pod.name}.${pod.namespace}.pod":                 "mypod.myns.pod",
+		"${pod.name}.${pod.namespace}.pod.${cluster.fqdn}": "mypod.myns.pod.cluster.local",
+	} {
+		t.Run(san, func(t *testing.T) {
+			pcr := verifiedPCR(map[string]string{testSignerName + "-san": san})
+			config, err := NewPodCertificateConfig(pcr, testPod(nil), Options{EnableInterpolation: true}, nil, 0)
+			if err != nil {
+				t.Fatalf("NewPodCertificateConfig(san=%q): %v", san, err)
+			}
+			if len(config.DNSNames) != 1 || config.DNSNames[0] != want {
+				t.Errorf("DNSNames = %v, want [%s]", config.DNSNames, want)
+			}
+		})
+	}
+}
+
 // (3): The default extended key usage must be ServerAuth only; ClientAuth is an
 // explicit opt-in via the eku annotation.
 func TestDefaultEKUServerAuthOnly(t *testing.T) {

--- a/internal/kubernetes/podcertificate/podcertificate.go
+++ b/internal/kubernetes/podcertificate/podcertificate.go
@@ -534,9 +534,21 @@ func verifiedIdentities(pcr *capiv1beta1.PodCertificateRequest, clusterFQDN stri
 	// The workload's service-account identity - the pod runs as this service
 	// account, so it may identify by it (short DNS form and SPIFFE ID).
 	//
-	// Deliberately excluded: node.name (belongs to the kubelet, not the
-	// workload) and pod.uid (an opaque, non-identifying token). Both remain
-	// available for ${...} interpolation but are not claimable as a subject.
+	// Deliberately excluded:
+	//   - node.name (belongs to the kubelet, not the workload) and pod.uid (an
+	//     opaque, non-identifying token). Both remain available for ${...}
+	//     interpolation but are not claimable as a subject.
+	//   - the service-account Service/pod DNS forms <sa>.<ns>.svc[.<fqdn>] and
+	//     <sa>.<ns>.pod[.<fqdn>]. <name>.<ns>.svc.<fqdn> is the Kubernetes
+	//     *Service* record shape, and ServiceAccount and Service names are
+	//     independent within a namespace - granting the form would let a pod
+	//     running as ServiceAccount "kubernetes" in "default" present a valid
+	//     certificate for kubernetes.default.svc, the canonical example of what
+	//     this constraint exists to deny. The names also resolve to nothing in
+	//     Kubernetes DNS, so they buy no interoperability. The signer emits no
+	//     service-account-derived DNS name of its own; per-pod service-account
+	//     identity is carried by the SPIFFE ID below. See
+	//     docs/adr/0001-verified-identity-allowlist-boundary.md.
 	if sa != "" {
 		add(
 			sa+"."+ns,


### PR DESCRIPTION
## What does this PR do?

Bootstraps an ADR practice and records the first decision.

The signer's default-deny identity model has an asymmetry that reads as a bug on first contact: the pod gets its `.svc`/`.svc.<fqdn>` DNS forms in `verifiedIdentities`, the service account does not. That asymmetry is why `examples/workload-pod.yaml` cannot issue under default settings, and it is what #87 ran into. Nothing in the repository recorded which way the question should go, so it would be re-litigated every time someone read the code.

**ADR-0001** states the boundary rather than the contents: the allowlist holds exactly the identities the signer emits by default, plus the service account's short DNS form and SPIFFE ID. The service-account Service DNS forms are deliberately excluded — `<name>.<ns>.svc.<fqdn>` is the Kubernetes *Service* record shape, ServiceAccount and Service names are independent within a namespace, and granting it would let a pod running as ServiceAccount `kubernetes` in `default` present a certificate for `kubernetes.default.svc`, the canonical example `docs/configuration.md` cites as what the constraint exists to deny. The name also resolves to nothing in Kubernetes DNS, so it buys no interoperability.

Three characterization tests lock the decision. They pass today by design — the point is that a future "just add `.svc`" patch turns red with a pointer to the reasoning instead of merging quietly.

**No signer behavior changes.** The only source edit is the comment on the `verifiedIdentities` service-account branch, extended to name the excluded forms and cite the ADR.

`CONTRIBUTING.md` gains the process: when an ADR is required, the lifecycle (rejected ADRs are kept, not deleted), and that an ADR needs at least one approving maintainer review — the one place a second pair of eyes is not optional in a project where ordinary PRs merge on green CI. Enforcement stays advisory: a PR template checkbox, deliberately **not** wired into `pr-release-metadata.yml`.

## Related issues

Groundwork for #87.

## Checklist

- [x] **Exactly one `release/*` label is set** — `release/skip`.
- [x] No `.changes/unreleased/*.yaml` fragment (correct for `release/skip`).
- [x] The PR title is descriptive.
- [x] `make lint` passes. `make test` passes except the pre-existing envtest suite, which cannot download its control-plane binaries locally (429 from the index) and fails identically on unmodified `main`.
- [x] Tests were added — three characterization tests in `identity_constraints_test.go`.
- [x] Docs updated (`CONTRIBUTING.md`, PR template, new `docs/adr/`).
