### PR TITLE
chore: ignore local agent and tooling scratch directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,15 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
 bin/
+
+# Local agent and tooling scratch, plus VCS metadata. None of this is ever
+# COPYed - every Dockerfile here copies explicit source paths - but the whole
+# repo root is still uploaded to the daemon as build context on every build.
+# .claude/worktrees alone is ~650M of throwaway checkouts of this repository,
+# which made the context ~894M for a build that needs a couple of megabytes of
+# Go source. Excluding .git is safe for the same reason: the builder stage
+# copies go.mod/go.sum and the source trees, never the repository metadata.
+.claude/
+.codegraph/
+.ecc/
+.git/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,14 @@ profile.cov
 *-key.pem
 tls.key
 ca-key*
+
+# Local agent and tooling scratch. None of it is project source, and all of it
+# is large enough or personal enough that a stray `git add -A` would produce an
+# unreviewable commit: .claude/worktrees holds throwaway checkouts of this repo
+# (hundreds of megabytes), .codegraph is a local code index, and .ecc is an
+# agent memory vault. Deliberately scoped rather than ignoring .claude wholesale,
+# so a shared .claude/settings.json can still be committed if we ever want one.
+.claude/settings.local.json
+.claude/worktrees/
+.codegraph/
+.ecc/


### PR DESCRIPTION
`.claude/worktrees`, `.codegraph` and `.ecc` are agent and tooling artifacts that sit untracked in the repo root. The worktrees directory alone currently holds ~650 MB of throwaway checkouts of this repository, so a stray `git add -A` stages hundreds of paths of non-source material.

Scoped deliberately rather than ignoring `.claude` wholesale — only the local settings override and the scratch directories are ignored, so a shared `.claude/settings.json` stays committable if the project ever wants one.

Verified with `git check-ignore`:

| path | result |
| --- | --- |
| `.claude/worktrees/x/main.go` | ignored |
| `.codegraph/index.db` | ignored |
| `.ecc/memory/team/a.md` | ignored |
| `.claude/settings.local.json` | ignored |
| `.claude/settings.json` | **not** ignored |

Independent of the issue #87 stack, so it is based on `main` rather than stacked — it can merge at any time.