### PR TITLE
test(e2e): harden the E2E harness (serial guard, UID-scoped selection, outcome matchers, diagnostics)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -44,5 +44,18 @@ jobs:
       - name: Verify kind installation
         run: kind version
 
+      # The e2e package is behind //go:build e2e, so the repo-wide `go vet ./...`
+      # and `golangci-lint run` never look at it. Gate it here, before the
+      # 10-minute cluster run, so a compile-level mistake fails in seconds.
+      - name: Vet and lint the tagged e2e package
+        run: make vet-e2e lint-e2e
+
       - name: Running Test e2e
         run: make test-e2e
+
+      # make test-e2e tears the cluster down from an EXIT trap, so this is a
+      # backstop for the cases the trap cannot cover: a cancelled job, or a
+      # runner-level timeout that kills make outright.
+      - name: Tear down the kind cluster
+        if: always()
+        run: kind delete cluster --name pcs-e2e || true

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,14 @@ fmt: ## Run go fmt against code.
 	$(GOCMD) fmt ./...
 
 .PHONY: vet
-vet: ## Run go vet against code.
+vet: vet-e2e ## Run go vet against code, including the build-tagged e2e package.
 	$(GOCMD) vet ./...
+
+.PHONY: vet-e2e
+vet-e2e: ## Run go vet against the e2e package, which is behind //go:build e2e.
+	# Without -tags=e2e the e2e package has no files to vet, so `go vet ./...`
+	# matches nothing there and reports success on code it never looked at.
+	$(GOCMD) vet -tags=e2e ./test/e2e/...
 
 .PHONY: test
 test: generate vet  ## Run tests. Formatting is enforced separately (make fmt / CI gofmt gate), not auto-applied here.
@@ -96,17 +102,28 @@ test-e2e: generate fmt vet ## Run the e2e tests. Expected an isolated environmen
 		echo "Creating e2e Kind cluster '$(KIND_CLUSTER_E2E)' ..."; \
 		$(GO_TOOL) kind create cluster --name $(KIND_CLUSTER_E2E) --config $(SRC_ROOT)/kind/kind-config.yaml; \
 	fi
+	# The cluster teardown runs from an EXIT trap, not as a following recipe
+	# line: a failing `go test` aborts the recipe, and without the trap the Kind
+	# cluster survived every red run and leaked into the next one. The trap
+	# re-raises the test's exit code so a failure still fails the target.
+	@set -e; \
+	trap 'code=$$?; $(GO_TOOL) kind delete cluster --name $(KIND_CLUSTER_E2E); exit $$code' EXIT; \
 	env \
 		IMAGE=$(IMAGE) \
 		KIND=$(shell $(GOCMD) tool -modfile $(TOOLS_MOD_FILE) -n kind) \
 		KIND_CLUSTER=$(KIND_CLUSTER_E2E) \
 		CERT_MANAGER_INSTALL_SKIP=true \
 		$(GOCMD) test -tags=e2e ./test/e2e/ -v -ginkgo.v
-	@$(GO_TOOL) kind delete cluster --name $(KIND_CLUSTER_E2E)
 
 .PHONY: lint
-lint:  ## Run golangci-lint linter
+lint: lint-e2e ## Run golangci-lint linter, including the build-tagged e2e package.
 	$(GO_TOOL) golangci-lint run
+
+.PHONY: lint-e2e
+lint-e2e: ## Run golangci-lint against the e2e package, which is behind //go:build e2e.
+	# golangci-lint skips files whose build tags are not satisfied, so without
+	# --build-tags=e2e the e2e suite is never linted at all.
+	$(GO_TOOL) golangci-lint run --build-tags=e2e ./test/e2e/...
 
 .PHONY: lint-fix
 lint-fix:  ## Run golangci-lint linter and perform fixes

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,14 @@ test: generate vet  ## Run tests. Formatting is enforced separately (make fmt / 
 
 .PHONY: test-e2e
 test-e2e: generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	@if ! $(GO_TOOL) kind get clusters | grep $(KIND_CLUSTER_E2E); then \
+	# grep -qx, not a bare grep: `kind get clusters` prints one name per line and
+	# an unanchored match is satisfied by any cluster whose name merely contains
+	# this one. A leftover `pcs-e2e-stage3` would make the guard skip creating
+	# `pcs-e2e`, the suite would run against a cluster that does not exist, and
+	# the teardown would then delete the wrong thing. Anchoring is also what
+	# makes KIND_CLUSTER_E2E safe to override for an isolated run. -q keeps the
+	# matched name out of the target's output, matching kind-start below.
+	@if ! $(GO_TOOL) kind get clusters | grep -qx "$(KIND_CLUSTER_E2E)"; then \
 		echo "Creating e2e Kind cluster '$(KIND_CLUSTER_E2E)' ..."; \
 		$(GO_TOOL) kind create cluster --name $(KIND_CLUSTER_E2E) --config $(SRC_ROOT)/kind/kind-config.yaml; \
 	fi
@@ -135,7 +142,9 @@ lint-config:  ## Verify golangci-lint linter configuration
 
 .PHONY: kind-start
 kind-start:  ## Start a local development Kind cluster.
-	@if ! $(GO_TOOL) kind get clusters | grep $(KIND_CLUSTER_DEV) >& /dev/null; then \
+	# Anchored for the same reason as test-e2e above: an unanchored match is
+	# satisfied by any cluster whose name contains this one.
+	@if ! $(GO_TOOL) kind get clusters | grep -qx "$(KIND_CLUSTER_DEV)"; then \
 		echo "Creating dev Kind cluster '$(KIND_CLUSTER_DEV)' ..."; \
 		$(GO_TOOL) kind create cluster --name $(KIND_CLUSTER_DEV) --config $(SRC_ROOT)/kind/kind-config.yaml; \
 	fi

--- a/test/e2e/diagnostics_test.go
+++ b/test/e2e/diagnostics_test.go
@@ -1,0 +1,171 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
+)
+
+// Failure diagnostics.
+//
+// A CI e2e failure is only debuggable from what the run printed, so the dump
+// below is deliberately broad: every controller replica's log including the
+// previous container, the workload objects, the requests, the trust bundle, the
+// admission resources, the release as Helm rendered it, and the cluster's own
+// version. It runs after a failed spec and must never turn a spec failure into
+// a different failure - nothing here asserts, and every command that cannot run
+// records why and moves on.
+//
+// Secret material is never collected. There is no `kubectl get secret` and no
+// `describe secret` in this file, which matters because the suite runs with a
+// live signing CA in the cluster: the dev CA's private key sits in the
+// podcertificate-signer-ca-dev secret, and the rotation spec creates more. The
+// Helm collectors are safe by construction - the chart takes its CA by
+// secretRef only (charts/pod-certificate-signer/values.yaml: signer.ca.source is
+// secretRef or file), so neither the release values nor the rendered manifest
+// carry key material. Every collected output is still passed through
+// redactSensitive as a backstop, so a future chart change that starts
+// templating key material degrades to a redaction marker rather than a leak.
+
+// privateKeyBlockPattern matches a PEM private key block of any flavour
+// (PRIVATE KEY, RSA PRIVATE KEY, EC PRIVATE KEY, ENCRYPTED PRIVATE KEY).
+var privateKeyBlockPattern = regexp.MustCompile(
+	`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+
+// secretDataPattern matches the payload of the Secret data keys that hold key
+// material, in case an object carrying one is ever collected indirectly. The
+// key names are spelled out rather than matched loosely so the dump does not
+// redact the chart's own `key: tls.key` volume-item wiring, which is
+// configuration and often the thing under investigation.
+var secretDataPattern = regexp.MustCompile(`(?m)^(\s*)(tls\.key|ca\.key|password):\s*\S+$`)
+
+// redactSensitive removes private key material from diagnostic output.
+func redactSensitive(output string) string {
+	output = privateKeyBlockPattern.ReplaceAllString(output, "[REDACTED PRIVATE KEY]")
+	output = secretDataPattern.ReplaceAllString(output, "$1$2: [REDACTED]")
+	return output
+}
+
+// dump runs a command purely for diagnostics and writes its redacted output to
+// the Ginkgo report. Failures are reported, never raised.
+func dump(title string, name string, args ...string) {
+	cmd := exec.Command(name, args...)
+	output, err := utils.Run(cmd)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- %s: unavailable (%v)\n", title, err)
+		return
+	}
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n--- %s ---\n%s\n", title, redactSensitive(output))
+}
+
+// dumpKubectl is the kubectl-shaped shorthand for dump.
+func dumpKubectl(title string, args ...string) {
+	dump(title, "kubectl", args...)
+}
+
+// dumpHelm runs the repo-pinned helm tool. helm lives in the tools module, so it
+// is invoked the same way the Makefile invokes it.
+func dumpHelm(title string, args ...string) {
+	dump(title, "go", append([]string{"tool", "-modfile", "internal/tools/go.mod", "helm"}, args...)...)
+}
+
+// controllerPodNames lists every pod of the release, so a multi-replica or
+// mid-rollout failure dumps all of them rather than only the one the specs
+// happen to target.
+func controllerPodNames() []string {
+	cmd := exec.Command("kubectl", "get", "pods",
+		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", releaseName),
+		"-n", namespace, "-o", "jsonpath={.items[*].metadata.name}")
+	output, err := utils.Run(cmd)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- controller pod list: unavailable (%v)\n", err)
+		return nil
+	}
+	return strings.Fields(output)
+}
+
+// dumpDiagnostics collects everything needed to debug a failed spec after the
+// fact. It is called from the suite's AfterEach on failure only.
+func dumpDiagnostics() {
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n===== e2e failure diagnostics: %s =====\n",
+		CurrentSpecReport().FullText())
+
+	By("collecting controller replica logs")
+	pods := controllerPodNames()
+	if len(pods) == 0 && controllerPodName != "" {
+		// The label query failed; fall back to the pod the specs were using.
+		pods = []string{controllerPodName}
+	}
+	for _, pod := range pods {
+		dumpKubectl("logs "+pod, "logs", pod, "-n", namespace, "--all-containers=true")
+		// --previous fails outright when the container has never restarted,
+		// which is the common case; dump reports that and carries on.
+		dumpKubectl("logs "+pod+" (previous)", "logs", pod, "-n", namespace, "--all-containers=true", "--previous")
+	}
+
+	By("collecting the controller workload objects")
+	dumpKubectl("controller workloads", "get", "deployment,replicaset,pod", "-n", namespace, "-o", "wide")
+	dumpKubectl("controller deployment", "describe", "deployment", releaseName, "-n", namespace)
+	dumpKubectl("controller replicasets", "describe", "replicaset",
+		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", releaseName), "-n", namespace)
+	dumpKubectl("controller pods", "describe", "pod",
+		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", releaseName), "-n", namespace)
+	dumpKubectl("leader election leases", "get", "leases", "-n", namespace, "-o", "yaml")
+	dumpKubectl("controller namespace events", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+
+	By("collecting the curl-metrics probe output")
+	dumpKubectl("curl-metrics logs", "logs", "curl-metrics", "-n", namespace)
+
+	By("collecting the workload pods and their certificate requests")
+	dumpKubectl("workload pods", "get", "pods", "-n", workloadNamespace, "-o", "yaml")
+	dumpKubectl("pod certificate requests", "get", "podcertificaterequests", "-n", workloadNamespace, "-o", "yaml")
+	dumpKubectl("workload namespace events", "get", "events", "-n", workloadNamespace, "--sort-by=.lastTimestamp")
+
+	By("collecting the published trust bundles")
+	dumpKubectl("cluster trust bundles", "get", "clustertrustbundles", "-o", "yaml")
+
+	By("collecting the admission resources")
+	dumpKubectl("validating admission policies", "get",
+		"validatingadmissionpolicies,validatingadmissionpolicybindings", "-o", "yaml")
+
+	By("collecting the Helm release")
+	dumpHelm("helm values", "get", "values", releaseName, "-n", namespace, "--all")
+	dumpHelm("helm manifest", "get", "manifest", releaseName, "-n", namespace)
+
+	By("collecting the cluster version")
+	dumpKubectl("nodes", "get", "nodes", "-o", "wide")
+	dumpKubectl("versions", "version")
+
+	By("collecting the controller metrics")
+	// Reached through the apiserver's service proxy so the dump needs no token
+	// and no scraper pod; the secured endpoint may still refuse, in which case
+	// dump records the refusal.
+	dumpKubectl("metrics", "get", "--raw",
+		fmt.Sprintf("/api/v1/namespaces/%s/services/https:%s:9090/proxy/metrics", namespace, metricsServiceName))
+
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n===== end e2e failure diagnostics =====\n")
+}

--- a/test/e2e/diagnostics_test.go
+++ b/test/e2e/diagnostics_test.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 
@@ -108,6 +109,114 @@ func controllerPodNames() []string {
 	return strings.Fields(output)
 }
 
+// metricsDumpBinding and metricsDumpPod name the throwaway RBAC binding and
+// scraper the metrics dump creates.
+const (
+	metricsDumpBinding = releaseName + "-e2e-metrics-dump"
+	metricsDumpPod     = "e2e-metrics-dump"
+)
+
+// dumpMetrics scrapes the controller's metrics endpoint.
+//
+// The endpoint is secured (SecureServing plus a SubjectAccessReview on the
+// /metrics nonResourceURL) and only listens on a ClusterIP, which rules out the
+// two cheap options: an unauthenticated scrape is refused, and the apiserver's
+// service proxy reaches the port but presents its own identity, which the
+// authorizer rejects with a 401. So the dump does what a real scraper does -
+// runs in the cluster, presents a projected ServiceAccount token, and is bound
+// to the chart's metrics-reader ClusterRole for the duration.
+//
+// Everything here is best-effort and time-bounded: curl by --max-time and its
+// retry count, the wait for the scraper by its own deadline, so a broken cluster
+// makes the dump print less rather than hang.
+func dumpMetrics() {
+	binding := exec.Command("kubectl", "create", "clusterrolebinding", metricsDumpBinding,
+		"--clusterrole", metricsReaderClusterRole,
+		"--serviceaccount", fmt.Sprintf("%s:%s", namespace, serviceAccountName))
+	if _, err := utils.Run(binding); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- metrics: unavailable, could not authorize the scraper (%v)\n", err)
+		return
+	}
+	defer func() {
+		cleanup := exec.Command("kubectl", "delete", "clusterrolebinding", metricsDumpBinding, "--ignore-not-found=true")
+		_, _ = utils.Run(cleanup)
+	}()
+
+	// -k skips verification of the controller's self-signed serving
+	// certificate: this is a diagnostic scrape, not an assertion about the
+	// serving chain. -f plus the retry loop covers the SubjectAccessReview
+	// deny that the authorizer caches for 30s when the binding above has not
+	// propagated yet, and --show-error keeps a failed scrape visible instead of
+	// dumping an empty section.
+	scrape := fmt.Sprintf(
+		"for i in 1 2 3 4 5; do "+
+			"curl -fsSk --max-time 20 "+
+			"-H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" "+
+			"https://%s.%s.svc.cluster.local:9090/metrics && exit 0; "+
+			"echo 'scrape failed, retrying'; sleep 5; done; exit 0",
+		metricsServiceName, namespace)
+	overrides := fmt.Sprintf(`{
+		"spec": {
+			"containers": [{
+				"name": "curl",
+				"image": "curlimages/curl:latest",
+				"command": ["/bin/sh", "-c"],
+				"args": [%q],
+				"securityContext": {
+					"readOnlyRootFilesystem": true,
+					"allowPrivilegeEscalation": false,
+					"capabilities": {"drop": ["ALL"]},
+					"runAsNonRoot": true,
+					"runAsUser": 1000,
+					"seccompProfile": {"type": "RuntimeDefault"}
+				}
+			}],
+			"serviceAccountName": %q
+		}
+	}`, scrape, serviceAccountName)
+
+	// The scraper is created and then read back from its logs rather than run
+	// with --attach: curl finishes in milliseconds and an attach that has not
+	// been established by then silently yields nothing.
+	run := exec.Command("kubectl", "run", metricsDumpPod,
+		"--restart=Never",
+		"--namespace", namespace,
+		"--image=curlimages/curl:latest",
+		"--overrides", overrides)
+	if _, err := utils.Run(run); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- metrics: unavailable, scraper pod not created (%v)\n", err)
+		return
+	}
+	defer func() {
+		cleanup := exec.Command("kubectl", "delete", "pod", metricsDumpPod,
+			"-n", namespace, "--ignore-not-found=true", "--wait=false")
+		_, _ = utils.Run(cleanup)
+	}()
+
+	if !waitForScraperToFinish() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- metrics: unavailable, scraper pod did not finish\n")
+		return
+	}
+	dumpKubectl("metrics", "logs", metricsDumpPod, "-n", namespace)
+}
+
+// waitForScraperToFinish polls the metrics scraper until it terminates,
+// reporting whether it got there. It polls rather than asserting: this runs
+// while a spec is already failing and must not raise a second failure.
+func waitForScraperToFinish() bool {
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		cmd := exec.Command("kubectl", "get", "pod", metricsDumpPod,
+			"-n", namespace, "-o", "jsonpath={.status.phase}")
+		phase, err := utils.Run(cmd)
+		if err == nil && (phase == "Succeeded" || phase == "Failed") {
+			return true
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return false
+}
+
 // dumpDiagnostics collects everything needed to debug a failed spec after the
 // fact. It is called from the suite's AfterEach on failure only.
 func dumpDiagnostics() {
@@ -161,11 +270,7 @@ func dumpDiagnostics() {
 	dumpKubectl("versions", "version")
 
 	By("collecting the controller metrics")
-	// Reached through the apiserver's service proxy so the dump needs no token
-	// and no scraper pod; the secured endpoint may still refuse, in which case
-	// dump records the refusal.
-	dumpKubectl("metrics", "get", "--raw",
-		fmt.Sprintf("/api/v1/namespaces/%s/services/https:%s:9090/proxy/metrics", namespace, metricsServiceName))
+	dumpMetrics()
 
 	_, _ = fmt.Fprintf(GinkgoWriter, "\n===== end e2e failure diagnostics =====\n")
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -56,6 +56,26 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	By("verifying the suite is running in a single process")
+	// The suite mutates cluster-wide state mid-run: installProfile re-installs
+	// the Helm release in place with different signer flags, and the
+	// ClusterTrustBundle context rotates the CA secret. Neither is scoped to a
+	// spec, so a second process would silently run its specs against another
+	// process's install and produce results that describe a configuration that
+	// was never under test.
+	//
+	// The top-level container is decorated Serial, which is the correct
+	// declaration but not a sufficient guarantee - it orders specs, it does not
+	// stop the suite being launched with `--procs`. This guard does, and it runs
+	// in every process so a parallel invocation fails immediately and loudly
+	// rather than after the first profile switch corrupts the run.
+	suiteConfig, _ := GinkgoConfiguration()
+	Expect(suiteConfig.ParallelTotal).To(Equal(1),
+		"the e2e suite mutates cluster-wide state (Helm install profiles, CA rotation) and must run "+
+			"in a single process; it was started with %d. Run it via `make test-e2e`.", suiteConfig.ParallelTotal)
+	Expect(GinkgoParallelProcess()).To(Equal(1),
+		"the e2e suite must run as parallel process 1, got %d", GinkgoParallelProcess())
+
 	By("building the manager(Operator) image")
 	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMAGE=%s", projectImage))
 	_, err := utils.Run(cmd)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,14 +21,12 @@ package e2e
 
 import (
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -82,7 +80,14 @@ const workloadNamespace = "default"
 // pod; installProfile re-resolves it.
 var controllerPodName string
 
-var _ = Describe("Manager", Ordered, func() {
+// The suite is Serial as well as Ordered. Ordered fixes the declaration order
+// the install profiles depend on; Serial states the other half of the
+// contract - no other spec may run alongside these, because installProfile
+// re-installs the release in place and a profile switch is cluster-wide. The
+// belt-and-braces single-process guard lives in BeforeSuite (e2e_suite_test.go),
+// which fails the whole run rather than letting a parallel invocation corrupt
+// state one spec at a time.
+var _ = Describe("Manager", Ordered, Serial, func() {
 	// Before running the tests, set up the environment by creating the namespace,
 	// enforce the restricted security policy to the namespace, installing CRDs,
 	// and deploying the controller.
@@ -102,16 +107,17 @@ var _ = Describe("Manager", Ordered, func() {
 		// A single replica keeps the pod-targeted assertions (logs, pod phase)
 		// deterministic; the chart default is 2 for leader election.
 		//
-		// This is the escape-hatch profile: interpolation on and unverified
-		// identities allowed, so the specs below can request literal values
-		// (custom-cn.example.org, literal IP SANs) that a pod does not own. It
-		// is deliberately not the whole suite - the chart's shipped defaults and
-		// the secure-default path are exercised by their own install profiles,
-		// see install_profiles_test.go. Keeping this profile first means the
-		// pre-existing specs are unaffected by the profile split.
+		// This is the unverified-identities profile: interpolation on and the
+		// identity allowlist disabled, so the specs below can request literal
+		// values (custom-cn.example.org, literal IP SANs) that a pod does not
+		// own. It is deliberately not the whole suite - the chart's shipped
+		// defaults and the verified-interpolation path are exercised by their
+		// own install profiles, see install_profiles_test.go. Keeping this
+		// profile first means the pre-existing specs are unaffected by the
+		// profile split.
 		cmd = exec.Command("make", "helm-install",
 			fmt.Sprintf("IMAGE=%s", projectImage),
-			"HELM_EXTRA_ARGS="+escapeHatchInstallArgs)
+			"HELM_EXTRA_ARGS="+unverifiedIdentitiesInstallArgs)
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 	})
@@ -136,46 +142,12 @@ var _ = Describe("Manager", Ordered, func() {
 		_, _ = utils.Run(cmd)
 	})
 
-	// After each test, check for failures and collect logs, events,
-	// and pod descriptions for debugging.
+	// After each test, check for failures and collect the full diagnostic set
+	// (see diagnostics_test.go) so a CI failure is debuggable from the run's
+	// output alone.
 	AfterEach(func() {
-		specReport := CurrentSpecReport()
-		if specReport.Failed() {
-			By("Fetching controller manager pod logs")
-			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
-			controllerLogs, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerLogs)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Controller logs: %s", err)
-			}
-
-			By("Fetching Kubernetes events")
-			cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
-			eventsOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
-			}
-
-			By("Fetching curl-metrics logs")
-			cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
-			metricsOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
-			}
-
-			By("Fetching controller manager pod description")
-			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
-			podDescription, err := utils.Run(cmd)
-			if err == nil {
-				fmt.Println("Pod description:\n", podDescription)
-			} else {
-				fmt.Println("Failed to describe controller pod")
-			}
+		if CurrentSpecReport().Failed() {
+			dumpDiagnostics()
 		}
 	})
 
@@ -348,7 +320,7 @@ var _ = Describe("Manager", Ordered, func() {
 	Context("Certificate issuance", func() {
 		It("should issue a certificate with interpolated pod identity", func() {
 			By("creating a workload pod requesting an interpolated certificate")
-			applyWorkloadPod()
+			pod := applyWorkloadPod()
 			DeferCleanup(func() {
 				cmd := exec.Command("kubectl", "delete", "pod", workloadPodName,
 					"-n", workloadNamespace, "--ignore-not-found=true", "--wait=false")
@@ -356,7 +328,7 @@ var _ = Describe("Manager", Ordered, func() {
 			})
 
 			By("waiting for the PodCertificateRequest to be issued")
-			chain := waitForIssuedChain(workloadPodName)
+			chain := expectIssued(pod)
 
 			By("verifying the leaf certificate carries the interpolated values")
 			leaf := chain[0]
@@ -385,13 +357,13 @@ var _ = Describe("Manager", Ordered, func() {
 		It("should deliver a custom common name and DNS SANs in the issued certificate", func() {
 			const podName = "pcs-custom-san"
 			By("creating a workload pod with static cn and san annotations")
-			applyCertTestPod(podName, map[string]string{
+			pod := applyCertTestPod(podName, map[string]string{
 				signerName + "-cn":  "custom-cn.example.org",
 				signerName + "-san": "api.example.org,web.example.org",
 			})
 
 			By("waiting for the PodCertificateRequest to be issued")
-			leaf := waitForIssuedChain(podName)[0]
+			leaf := expectIssued(pod)[0]
 
 			By("verifying the configured values are delivered in the leaf certificate")
 			Expect(leaf.Subject.CommonName).To(Equal("custom-cn.example.org"),
@@ -405,13 +377,13 @@ var _ = Describe("Manager", Ordered, func() {
 		It("should deliver the requested IP SANs in the issued certificate", func() {
 			const podName = "pcs-ip-san"
 			By("creating a workload pod with an ip-san annotation")
-			applyCertTestPod(podName, map[string]string{
+			pod := applyCertTestPod(podName, map[string]string{
 				signerName + "-cn":     "ip-demo.example.org",
 				signerName + "-ip-san": "10.96.0.42,2001:db8::42",
 			})
 
 			By("waiting for the PodCertificateRequest to be issued")
-			leaf := waitForIssuedChain(podName)[0]
+			leaf := expectIssued(pod)[0]
 
 			By("verifying the IP SANs are delivered in the leaf certificate")
 			Expect(leaf.IPAddresses).To(HaveLen(2), "both requested IP SANs must be present")
@@ -430,13 +402,13 @@ var _ = Describe("Manager", Ordered, func() {
 		It("should deliver a client-only certificate when eku restricts it", func() {
 			const podName = "pcs-eku-client"
 			By("creating a workload pod with an eku annotation")
-			applyCertTestPod(podName, map[string]string{
+			pod := applyCertTestPod(podName, map[string]string{
 				signerName + "-cn":  "eku-demo.example.org",
 				signerName + "-eku": "client",
 			})
 
 			By("waiting for the PodCertificateRequest to be issued")
-			leaf := waitForIssuedChain(podName)[0]
+			leaf := expectIssued(pod)[0]
 
 			By("verifying the certificate is restricted to client auth")
 			Expect(leaf.ExtKeyUsage).To(ConsistOf(x509.ExtKeyUsageClientAuth),
@@ -445,19 +417,19 @@ var _ = Describe("Manager", Ordered, func() {
 	})
 
 	// Install profiles that re-install the release in place. They run after the
-	// escape-hatch specs above and must stay inside this Describe: its AfterAll
-	// uninstalls the release, so a sibling top-level container would run against
-	// a torn-down deployment. See install_profiles_test.go for why a mid-suite
-	// upgrade is safe here.
+	// unverified-identities specs above and must stay inside this Describe: its
+	// AfterAll uninstalls the release, so a sibling top-level container would run
+	// against a torn-down deployment. See install_profiles_test.go for why a
+	// mid-suite upgrade is safe here.
 	//
 	// They also run *before* the ClusterTrustBundle context, which deliberately
 	// rotates the CA secret out from under the controller. `make helm-install`
 	// re-applies the CA secret from bin/dev-ca, so a profile switch after that
 	// rotation would rotate the CA back mid-suite and race the controller's
 	// volume reload against the profile's own issuance specs.
-	defineCSRSANProfileTests()
-	defineSecureDefaultProfileTests()
-	defineChartDefaultProfileTests()
+	defineHonorCSRSANsProfileTests()
+	defineVerifiedInterpolationProfileTests()
+	defineChartDefaultsProfileTests()
 
 	Context("ClusterTrustBundle", func() {
 		AfterAll(func() {
@@ -528,144 +500,6 @@ func getMetricsOutput() string {
 	Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
 	Expect(metricsOutput).To(ContainSubstring("< HTTP/1.1 200 OK"))
 	return metricsOutput
-}
-
-// applyWorkloadPod creates the example workload pod, whose podCertificate
-// projected volume requests a certificate customized via ${...}
-// interpolation (see examples/workload-pod.yaml).
-func applyWorkloadPod() {
-	cmd := exec.Command("kubectl", "apply", "-f", "examples/workload-pod.yaml")
-	_, err := utils.Run(cmd)
-	Expect(err).NotTo(HaveOccurred(), "Failed to create the workload pod")
-}
-
-// applyCertTestPod creates a minimal workload pod whose podCertificate
-// projected volume carries the given userAnnotations, and registers its
-// cleanup.
-func applyCertTestPod(podName string, userAnnotations map[string]string) {
-	var annotations strings.Builder
-	for key, value := range userAnnotations {
-		fmt.Fprintf(&annotations, "            %s: %q\n", key, value)
-	}
-
-	manifest := fmt.Sprintf(`apiVersion: v1
-kind: Pod
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  restartPolicy: Never
-  containers:
-  - name: sleeper
-    image: busybox:1.37
-    command: ["sleep", "600"]
-    securityContext:
-      allowPrivilegeEscalation: false
-      runAsNonRoot: true
-      runAsUser: 65532
-      capabilities:
-        drop: ["ALL"]
-      seccompProfile:
-        type: RuntimeDefault
-    volumeMounts:
-    - name: x509
-      mountPath: /var/run/x509
-      readOnly: true
-  volumes:
-  - name: x509
-    projected:
-      sources:
-      - podCertificate:
-          keyType: ED25519
-          signerName: %s
-          credentialBundlePath: credentialbundle.pem
-          userAnnotations:
-%s`, podName, workloadNamespace, signerName, annotations.String())
-
-	dir, err := os.MkdirTemp("", "pcs-e2e-pod")
-	Expect(err).NotTo(HaveOccurred(), "Failed to create temp dir for the pod manifest")
-	DeferCleanup(func() { _ = os.RemoveAll(dir) })
-
-	manifestFile := filepath.Join(dir, "pod.yaml")
-	Expect(os.WriteFile(manifestFile, []byte(manifest), os.FileMode(0o600))).To(Succeed())
-
-	cmd := exec.Command("kubectl", "apply", "-f", manifestFile)
-	_, err = utils.Run(cmd)
-	Expect(err).NotTo(HaveOccurred(), "Failed to create pod %s", podName)
-
-	DeferCleanup(func() {
-		cmd := exec.Command("kubectl", "delete", "pod", podName,
-			"-n", workloadNamespace, "--ignore-not-found=true", "--wait=false")
-		_, _ = utils.Run(cmd)
-	})
-}
-
-// waitForIssuedChain waits until the PodCertificateRequest of the given pod
-// is issued and returns the parsed certificate chain.
-func waitForIssuedChain(podName string) []*x509.Certificate {
-	GinkgoHelper()
-	var chain []*x509.Certificate
-	Eventually(func(g Gomega) {
-		chain = getIssuedCertificateChain(g, podName, workloadNamespace)
-		g.Expect(chain).NotTo(BeEmpty())
-	}, 3*time.Minute).Should(Succeed())
-	return chain
-}
-
-// getIssuedCertificateChain finds the PodCertificateRequest belonging to the
-// given pod and, once it carries an Issued condition, parses its certificate
-// chain.
-func getIssuedCertificateChain(g Gomega, podName, namespace string) []*x509.Certificate {
-	cmd := exec.Command("kubectl", "get", "podcertificaterequests",
-		"-n", namespace, "-o", "json")
-	output, err := utils.Run(cmd)
-	g.Expect(err).NotTo(HaveOccurred(), "Failed to list PodCertificateRequests")
-
-	var list struct {
-		Items []struct {
-			Spec struct {
-				PodName string `json:"podName"`
-			} `json:"spec"`
-			Status struct {
-				CertificateChain string `json:"certificateChain"`
-				Conditions       []struct {
-					Type    string `json:"type"`
-					Reason  string `json:"reason"`
-					Message string `json:"message"`
-				} `json:"conditions"`
-			} `json:"status"`
-		} `json:"items"`
-	}
-	g.Expect(json.Unmarshal([]byte(output), &list)).To(Succeed())
-
-	for _, item := range list.Items {
-		if item.Spec.PodName != podName {
-			continue
-		}
-		for _, cond := range item.Status.Conditions {
-			g.Expect(cond.Type).To(Equal("Issued"),
-				"request must not be %s: %s: %s", cond.Type, cond.Reason, cond.Message)
-		}
-		if item.Status.CertificateChain == "" {
-			continue
-		}
-
-		var certs []*x509.Certificate
-		data := []byte(item.Status.CertificateChain)
-		for {
-			var block *pem.Block
-			block, data = pem.Decode(data)
-			if block == nil {
-				break
-			}
-			cert, err := x509.ParseCertificate(block.Bytes)
-			g.Expect(err).NotTo(HaveOccurred(), "chain entry must be a valid certificate")
-			certs = append(certs, cert)
-		}
-		return certs
-	}
-
-	return nil
 }
 
 // getTrustBundleCertificates reads the ClusterTrustBundle of the signer and

--- a/test/e2e/fixtures_test.go
+++ b/test/e2e/fixtures_test.go
@@ -1,0 +1,242 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
+)
+
+// defaultCredentialBundlePath is the file kubelet writes the issued private key
+// and certificate chain to, relative to the projected volume's mount point.
+const defaultCredentialBundlePath = "credentialbundle.pem"
+
+// certTestPodMountPath is where the projected volume is mounted in the
+// workload container.
+const certTestPodMountPath = "/var/run/x509"
+
+// certTestPod describes the workload pod the certificate specs create.
+//
+// The fields mirror the knobs corev1.PodCertificateProjection exposes, so a
+// spec states what it wants rather than assembling a YAML document by string
+// concatenation. Building a typed corev1.Pod is what makes the projection
+// type-checked against the k8s.io/api version the controller itself builds
+// against: a field the API renames or drops becomes a compile error here
+// instead of a request the apiserver silently admits with the setting ignored.
+//
+// Zero values are filled in by withDefaults, so a spec sets only what it cares
+// about. serviceAccountName, keyType, maxExpirationSeconds and
+// clusterTrustBundleName have no caller in this stage's specs; they exist
+// because the projection exposes them and the credential-conformance and
+// key-type specs that follow need them addressable without another refactor.
+type certTestPod struct {
+	// name and namespace identify the pod. namespace defaults to
+	// workloadNamespace.
+	name      string
+	namespace string
+
+	// serviceAccountName is the identity the pod runs as, and therefore the
+	// identity ${pod.serviceAccountName} resolves to. Defaults to "default".
+	serviceAccountName string
+
+	// keyType is the projection's requested key algorithm. Defaults to
+	// ED25519.
+	keyType string
+
+	// credentialBundlePath is the file kubelet writes the key and chain to.
+	// Defaults to defaultCredentialBundlePath.
+	credentialBundlePath string
+
+	// maxExpirationSeconds caps the lifetime the signer may issue. nil leaves
+	// the field unset, so kube-apiserver applies its own 24-hour default.
+	maxExpirationSeconds *int32
+
+	// userAnnotations are the signer-scoped annotations the projection carries
+	// into the PodCertificateRequest.
+	userAnnotations map[string]string
+
+	// clusterTrustBundleName, when set, adds a clusterTrustBundle projection
+	// alongside the podCertificate one so the pod also mounts the signer's
+	// published trust anchors at ca.crt.
+	clusterTrustBundleName string
+}
+
+// withDefaults returns the fixture with every unset field filled in. The
+// defaults reproduce the pod the string-built helper created, so switching to
+// typed fixtures changes how the manifest is produced and nothing about what
+// is deployed.
+func (p certTestPod) withDefaults() certTestPod {
+	if p.namespace == "" {
+		p.namespace = workloadNamespace
+	}
+	if p.serviceAccountName == "" {
+		p.serviceAccountName = "default"
+	}
+	if p.keyType == "" {
+		p.keyType = "ED25519"
+	}
+	if p.credentialBundlePath == "" {
+		p.credentialBundlePath = defaultCredentialBundlePath
+	}
+	return p
+}
+
+// build renders the fixture as a typed corev1.Pod.
+func (p certTestPod) build() *corev1.Pod {
+	p = p.withDefaults()
+
+	sources := []corev1.VolumeProjection{{
+		PodCertificate: &corev1.PodCertificateProjection{
+			SignerName:           signerName,
+			KeyType:              p.keyType,
+			CredentialBundlePath: p.credentialBundlePath,
+			MaxExpirationSeconds: p.maxExpirationSeconds,
+			UserAnnotations:      p.userAnnotations,
+		},
+	}}
+	if p.clusterTrustBundleName != "" {
+		name := p.clusterTrustBundleName
+		sources = append(sources, corev1.VolumeProjection{
+			ClusterTrustBundle: &corev1.ClusterTrustBundleProjection{
+				Name: &name,
+				Path: "ca.crt",
+			},
+		})
+	}
+
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.name,
+			Namespace: p.namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ServiceAccountName: p.serviceAccountName,
+			Containers: []corev1.Container{{
+				Name:    "sleeper",
+				Image:   "busybox:1.37",
+				Command: []string{"sleep", "600"},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: ptr(false),
+					RunAsNonRoot:             ptr(true),
+					RunAsUser:                ptr(int64(65532)),
+					Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+					SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				},
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "x509",
+					MountPath: certTestPodMountPath,
+					ReadOnly:  true,
+				}},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "x509",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{Sources: sources},
+				},
+			}},
+		},
+	}
+}
+
+// ptr returns a pointer to v. The corev1 security context fields are all
+// pointers and a fixture reads better with the literal inline.
+func ptr[T any](v T) *T { return &v }
+
+// applyCertTestPod creates a minimal workload pod whose podCertificate
+// projected volume carries the given userAnnotations, registers its cleanup and
+// returns a reference that pins the pod's UID.
+//
+// It is the thin, backwards-compatible spelling of createCertTestPod for the
+// specs that only vary the annotations.
+func applyCertTestPod(podName string, userAnnotations map[string]string) podRef {
+	GinkgoHelper()
+	return createCertTestPod(certTestPod{name: podName, userAnnotations: userAnnotations})
+}
+
+// createCertTestPod creates the fixture pod and registers its cleanup.
+//
+// It uses `kubectl create`, not `kubectl apply`, deliberately. `make test-e2e`
+// reuses a surviving Kind cluster if one is already present, so a pod left over
+// from a previous run can carry the same name. `apply` would return that pod's
+// UID and every UID-keyed lookup afterwards would silently follow the stale
+// object; `create` fails loudly on the conflict instead.
+func createCertTestPod(fixture certTestPod) podRef {
+	GinkgoHelper()
+
+	pod := fixture.build()
+	manifest, err := json.Marshal(pod)
+	Expect(err).NotTo(HaveOccurred(), "Failed to marshal the pod fixture for %s", pod.Name)
+
+	cmd := exec.Command("kubectl", "create", "-f", "-", "-o", "json")
+	cmd.Stdin = bytes.NewReader(manifest)
+	output, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create pod %s: %s", pod.Name, output)
+
+	DeferCleanup(func() {
+		cmd := exec.Command("kubectl", "delete", "pod", pod.Name,
+			"-n", pod.Namespace, "--ignore-not-found=true", "--wait=false")
+		_, _ = utils.Run(cmd)
+	})
+
+	return decodePodRef(output)
+}
+
+// decodePodRef reads the pod the apiserver returned and pins its identity:
+// namespace, name and the UID the PodCertificateRequest will carry.
+func decodePodRef(createdPodJSON string) podRef {
+	GinkgoHelper()
+
+	var created corev1.Pod
+	Expect(json.Unmarshal([]byte(createdPodJSON), &created)).To(Succeed(),
+		"Failed to decode the created pod")
+	Expect(created.UID).NotTo(BeEmpty(), "the created pod must carry a UID")
+
+	return podRef{
+		namespace: created.Namespace,
+		name:      created.Name,
+		uid:       created.UID,
+	}
+}
+
+// applyWorkloadPod creates the example workload pod, whose podCertificate
+// projected volume requests a certificate customized via ${...} interpolation
+// (see examples/workload-pod.yaml), and returns a reference pinning its UID.
+//
+// This one stays a manifest read rather than a typed fixture on purpose: the
+// spec's value is that the manifest shipped to users is the thing that issues.
+func applyWorkloadPod() podRef {
+	GinkgoHelper()
+
+	cmd := exec.Command("kubectl", "create", "-f", "examples/workload-pod.yaml", "-o", "json")
+	output, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create the workload pod: %s", output)
+
+	return decodePodRef(output)
+}

--- a/test/e2e/fixtures_test.go
+++ b/test/e2e/fixtures_test.go
@@ -214,8 +214,8 @@ func decodePodRef(createdPodJSON string) podRef {
 	GinkgoHelper()
 
 	var created corev1.Pod
-	Expect(json.Unmarshal([]byte(createdPodJSON), &created)).To(Succeed(),
-		"Failed to decode the created pod")
+	Expect(json.Unmarshal([]byte(trimToJSON(createdPodJSON)), &created)).To(Succeed(),
+		"Failed to decode the created pod: %s", createdPodJSON)
 	Expect(created.UID).NotTo(BeEmpty(), "the created pod must carry a UID")
 
 	return podRef{

--- a/test/e2e/install_profiles_test.go
+++ b/test/e2e/install_profiles_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
 )
@@ -196,8 +197,8 @@ func defineVerifiedInterpolationProfileTests() {
 		// hand. The default EKU in particular has no annotation of its own to
 		// exercise - it is what you get when you ask for nothing - so it is only
 		// ever observable on a certificate issued for some other reason. The
-		// eku=client opt-in is covered separately under the escape-hatch profile
-		// in e2e_test.go.
+		// eku=client opt-in is covered separately under the
+		// unverified-identities profile in e2e_test.go.
 		It("issues an interpolated identity and SPIFFE ID, with no IP SANs and a serverAuth-only EKU", func() {
 			const podName = "pcs-secure-interpolated"
 			By("creating a workload pod requesting only identities it owns")
@@ -294,16 +295,12 @@ func defineVerifiedInterpolationProfileTests() {
 				"a >63-character DNS label must yield no default SANs rather than a truncated one")
 
 			By("verifying the operator was warned that a default was dropped")
-			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "events", "-n", workloadNamespace,
-					"--field-selector", "reason=DefaultSANSkipped",
-					"-o", "jsonpath={.items[*].message}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring(podName),
-					"a DefaultSANSkipped warning event must name the pod whose SANs were dropped")
-				g.Expect(output).To(ContainSubstring("DNS label limit"))
-			}).Should(Succeed())
+			// Scoped to this pod's own request rather than filtered on
+			// reason across the namespace: the pod name is deterministic, so
+			// a namespace-wide match would also be satisfied by a stale event
+			// from an earlier run against a reused cluster.
+			expectRequestEvent(pod, corev1.EventTypeWarning, "DefaultSANSkipped",
+				podName, "DNS label limit")
 		})
 	})
 }
@@ -314,7 +311,7 @@ func defineVerifiedInterpolationProfileTests() {
 // It exists for one assertion that no other profile can make: with
 // --enable-annotation-interpolation off, a value containing ${...} is denied
 // outright rather than resolved or issued verbatim. Running that assertion under
-// the secure-defaults profile would pass for the wrong reason - the value would
+// the verified-interpolation profile would pass for the wrong reason - the value would
 // be rejected by the allowlist rather than by the disabled interpolation gate.
 func defineChartDefaultsProfileTests() {
 	Context("Install profile: chart-defaults", func() {

--- a/test/e2e/install_profiles_test.go
+++ b/test/e2e/install_profiles_test.go
@@ -21,14 +21,13 @@ package e2e
 
 import (
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
 
 	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
 )
@@ -43,10 +42,14 @@ import (
 // This is safe only because the suite is single-threaded: `make test-e2e` runs
 // `go test -tags=e2e ./test/e2e/ -v -ginkgo.v`, which is plain `go test` with no
 // ginkgo CLI and therefore no `-p`/`--procs`. Ginkgo runs every spec serially in
-// one process, in declaration order. Two profiles can never be live at once. If
-// the suite is ever moved to the `ginkgo` CLI with parallel procs, these
-// containers must be reworked - a mid-suite upgrade would race the other
-// profile's specs.
+// one process, in declaration order. Two profiles can never be live at once.
+//
+// That invariant is now stated rather than assumed. The top-level container
+// carries the Serial decorator, and BeforeSuite (e2e_suite_test.go) fails the
+// run outright if it is started with more than one process. If the suite is ever
+// moved to the `ginkgo` CLI with parallel procs, these containers must be
+// reworked before that guard can be relaxed - a mid-suite upgrade would race the
+// other profile's specs.
 //
 // Each profile container lives inside the top-level Describe("Manager",
 // Ordered), which is what makes BeforeAll legal here without a further Ordered
@@ -59,22 +62,25 @@ import (
 // bin/dev-ca, so a profile switch after that rotation would rotate the CA back
 // and race the controller's volume reload against the profile's issuance specs.
 const (
-	// escapeHatchInstallArgs is the historical install: both escape hatches
-	// open. Every spec that requests an identity the pod does not own
+	// unverifiedIdentitiesInstallArgs is the historical install: both escape
+	// hatches open. Every spec that requests an identity the pod does not own
 	// (custom-cn.example.org, literal IP SANs) depends on it.
-	escapeHatchInstallArgs = "--set replicaCount=1 " +
+	unverifiedIdentitiesInstallArgs = "--set replicaCount=1 " +
 		"--set signer.enable_annotation_interpolation=true " +
 		"--set signer.allow_unverified_identities=true " +
 		"--set admissionPolicies.dnsSANValidation.enabled=true"
 
-	// csrSANsInstallArgs adds the CSR-SAN opt-in to the escape-hatch profile.
-	csrSANsInstallArgs = escapeHatchInstallArgs + " --set signer.honor_csr_sans=true"
+	// honorCSRSANsInstallArgs adds the CSR-SAN opt-in to the
+	// unverified-identities profile.
+	honorCSRSANsInstallArgs = unverifiedIdentitiesInstallArgs + " --set signer.honor_csr_sans=true"
 
-	// secureDefaultsInstallArgs is the configuration issue #87 proposes and the
-	// one the suite never exercised: interpolation on, identity constraints
-	// enforced, no escape hatch. Resolved ${...} values must still clear the
-	// verified-identity allowlist.
-	secureDefaultsInstallArgs = "--set replicaCount=1 " +
+	// verifiedInterpolationInstallArgs is the configuration issue #87 proposes
+	// and the one the suite never exercised: interpolation on, identity
+	// constraints enforced, no escape hatch. Resolved ${...} values must still
+	// clear the verified-identity allowlist. It is deliberately not called
+	// "secure defaults": it is not what the chart ships, which is
+	// chartDefaultsInstallArgs below.
+	verifiedInterpolationInstallArgs = "--set replicaCount=1 " +
 		"--set signer.enable_annotation_interpolation=true " +
 		"--set admissionPolicies.dnsSANValidation.enabled=true"
 
@@ -124,69 +130,7 @@ func installProfile(extraArgs string) {
 	}).Should(Succeed())
 }
 
-// deniedRequest is the terminal outcome recorded on a PodCertificateRequest the
-// signer refuses.
-type deniedRequest struct {
-	Reason  string
-	Message string
-}
-
-// waitForDeniedRequest waits until the PodCertificateRequest belonging to the
-// given pod carries a Denied condition and returns its reason and message.
-//
-// This is the counterpart to waitForIssuedChain, which fails on any condition
-// that is not Issued and so cannot be used to assert a denial. Asserting on the
-// reason and message - not merely on the absence of a certificate - is what
-// distinguishes "denied by the identity constraint" from "denied because the
-// value was malformed" or "never reconciled at all".
-func waitForDeniedRequest(podName string) deniedRequest {
-	GinkgoHelper()
-
-	var denial deniedRequest
-	Eventually(func(g Gomega) {
-		cmd := exec.Command("kubectl", "get", "podcertificaterequests",
-			"-n", workloadNamespace, "-o", "json")
-		output, err := utils.Run(cmd)
-		g.Expect(err).NotTo(HaveOccurred(), "Failed to list PodCertificateRequests")
-
-		var list struct {
-			Items []struct {
-				Spec struct {
-					PodName string `json:"podName"`
-				} `json:"spec"`
-				Status struct {
-					CertificateChain string `json:"certificateChain"`
-					Conditions       []struct {
-						Type    string `json:"type"`
-						Reason  string `json:"reason"`
-						Message string `json:"message"`
-					} `json:"conditions"`
-				} `json:"status"`
-			} `json:"items"`
-		}
-		g.Expect(json.Unmarshal([]byte(output), &list)).To(Succeed())
-
-		found := false
-		for _, item := range list.Items {
-			if item.Spec.PodName != podName {
-				continue
-			}
-			g.Expect(item.Status.CertificateChain).To(BeEmpty(),
-				"a denied request must never carry a certificate chain")
-			for _, cond := range item.Status.Conditions {
-				if cond.Type == "Denied" {
-					denial = deniedRequest{Reason: cond.Reason, Message: cond.Message}
-					found = true
-				}
-			}
-		}
-		g.Expect(found).To(BeTrue(), "no PodCertificateRequest for pod %q carries a Denied condition yet", podName)
-	}, 3*time.Minute).Should(Succeed())
-
-	return denial
-}
-
-// defineCSRSANProfileTests covers the --honor-csr-sans opt-in.
+// defineHonorCSRSANsProfileTests covers the --honor-csr-sans opt-in.
 //
 // Scope note, and the reason this container is thin: kubelet generates an empty
 // PKCS#10 CSR today (see Options.HonorCSRSANs), so there is no way from a Pod
@@ -198,21 +142,21 @@ func waitForDeniedRequest(podName string) deniedRequest {
 // issuance: with an inert CSR the certificate is built from the annotations and
 // the controller defaults exactly as with the flag off. Convert these specs into
 // real CSR-SAN assertions once Kubernetes starts embedding requested SANs.
-func defineCSRSANProfileTests() {
-	Context("Install profile: escape hatches with --honor-csr-sans", func() {
+func defineHonorCSRSANsProfileTests() {
+	Context("Install profile: honor-csr-sans", func() {
 		BeforeAll(func() {
-			installProfile(csrSANsInstallArgs)
+			installProfile(honorCSRSANsInstallArgs)
 		})
 
 		It("issues from annotations and defaults while kubelet CSRs stay empty", func() {
 			const podName = "pcs-csr-sans"
 			By("creating a workload pod with no san annotation, so any CSR SAN would show")
-			applyCertTestPod(podName, map[string]string{
+			pod := applyCertTestPod(podName, map[string]string{
 				signerName + "-cn": "csr-demo.example.org",
 			})
 
 			By("waiting for the PodCertificateRequest to be issued")
-			leaf := waitForIssuedChain(podName)[0]
+			leaf := expectIssued(pod)[0]
 
 			By("verifying the certificate carries the annotation CN and the controller default SANs")
 			Expect(leaf.Subject.CommonName).To(Equal("csr-demo.example.org"))
@@ -226,7 +170,7 @@ func defineCSRSANProfileTests() {
 	})
 }
 
-// defineSecureDefaultProfileTests covers the configuration issue #87 proposes:
+// defineVerifiedInterpolationProfileTests covers the configuration issue #87 proposes:
 // ${...} interpolation on, identity constraints enforced, no escape hatch.
 //
 // Before this container existed the suite only ever ran interpolation with
@@ -240,10 +184,10 @@ func defineCSRSANProfileTests() {
 // manifest's IP SAN is denied without the escape hatch. Pinning them now is
 // deliberate - a later change to either surfaces as a visible diff in this file
 // rather than as silence.
-func defineSecureDefaultProfileTests() {
-	Context("Install profile: secure defaults with interpolation", func() {
+func defineVerifiedInterpolationProfileTests() {
+	Context("Install profile: verified-interpolation", func() {
 		BeforeAll(func() {
-			installProfile(secureDefaultsInstallArgs)
+			installProfile(verifiedInterpolationInstallArgs)
 		})
 
 		// Asserts four properties of one issued certificate rather than splitting
@@ -257,14 +201,14 @@ func defineSecureDefaultProfileTests() {
 		It("issues an interpolated identity and SPIFFE ID, with no IP SANs and a serverAuth-only EKU", func() {
 			const podName = "pcs-secure-interpolated"
 			By("creating a workload pod requesting only identities it owns")
-			applyCertTestPod(podName, map[string]string{
+			pod := applyCertTestPod(podName, map[string]string{
 				signerName + "-cn":   "${pod.name}.${pod.namespace}.svc.${cluster.fqdn}",
 				signerName + "-san":  "${pod.name}.${pod.namespace}.svc,${pod.serviceAccountName}.${pod.namespace}",
 				signerName + "-uris": "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}",
 			})
 
 			By("waiting for the PodCertificateRequest to be issued")
-			leaf := waitForIssuedChain(podName)[0]
+			leaf := expectIssued(pod)[0]
 
 			By("verifying every interpolated value cleared the verified-identity allowlist")
 			Expect(leaf.Subject.CommonName).To(Equal(
@@ -294,11 +238,10 @@ func defineSecureDefaultProfileTests() {
 		DescribeTable("denies identities the pod does not own",
 			func(podName string, annotations map[string]string, wantMessage string) {
 				By("creating a workload pod requesting an identity it cannot prove")
-				applyCertTestPod(podName, annotations)
+				pod := applyCertTestPod(podName, annotations)
 
 				By("waiting for the PodCertificateRequest to be denied")
-				denial := waitForDeniedRequest(podName)
-				Expect(denial.Reason).To(Equal("InvalidUnverifiedUserAnnotations"))
+				denial := expectDenied(pod, capiv1beta1.PodCertificateRequestConditionInvalidUserConfig)
 				Expect(denial.Message).To(ContainSubstring(wantMessage))
 			},
 			// The example manifest requests exactly this, which is why it
@@ -338,12 +281,12 @@ func defineSecureDefaultProfileTests() {
 			Expect(podName).To(HaveLen(64))
 
 			By("creating a workload pod whose name exceeds the 63-character DNS label limit")
-			applyCertTestPod(podName, map[string]string{
+			pod := applyCertTestPod(podName, map[string]string{
 				signerName + "-duration": "2h",
 			})
 
 			By("waiting for the PodCertificateRequest to be issued")
-			leaf := waitForIssuedChain(podName)[0]
+			leaf := expectIssued(pod)[0]
 
 			By("verifying the common name carries the identity and no default SANs were emitted")
 			Expect(leaf.Subject.CommonName).To(Equal(podName))
@@ -365,7 +308,7 @@ func defineSecureDefaultProfileTests() {
 	})
 }
 
-// defineChartDefaultProfileTests covers the chart exactly as it ships, with no
+// defineChartDefaultsProfileTests covers the chart exactly as it ships, with no
 // feature flag turned on.
 //
 // It exists for one assertion that no other profile can make: with
@@ -373,8 +316,8 @@ func defineSecureDefaultProfileTests() {
 // outright rather than resolved or issued verbatim. Running that assertion under
 // the secure-defaults profile would pass for the wrong reason - the value would
 // be rejected by the allowlist rather than by the disabled interpolation gate.
-func defineChartDefaultProfileTests() {
-	Context("Install profile: chart defaults", func() {
+func defineChartDefaultsProfileTests() {
+	Context("Install profile: chart-defaults", func() {
 		BeforeAll(func() {
 			installProfile(chartDefaultsInstallArgs)
 		})
@@ -385,13 +328,12 @@ func defineChartDefaultProfileTests() {
 			// The pod's own name is inside the verified-identity allowlist, so
 			// the only thing that can deny this request is the interpolation
 			// gate itself. That is the point of the spec.
-			applyCertTestPod(podName, map[string]string{
+			pod := applyCertTestPod(podName, map[string]string{
 				signerName + "-cn": "${pod.name}",
 			})
 
 			By("waiting for the PodCertificateRequest to be denied")
-			denial := waitForDeniedRequest(podName)
-			Expect(denial.Reason).To(Equal("InvalidUnverifiedUserAnnotations"))
+			denial := expectDenied(pod, capiv1beta1.PodCertificateRequestConditionInvalidUserConfig)
 			Expect(denial.Message).To(ContainSubstring("interpolation, which is disabled on this signer"),
 				"the denial must name the disabled flag, not the identity constraint")
 		})

--- a/test/e2e/outcomes_test.go
+++ b/test/e2e/outcomes_test.go
@@ -309,13 +309,32 @@ func expectTerminalConditionStable(ref podRef, want metav1.Condition) {
 	}, 5*time.Second, time.Second).Should(Succeed())
 }
 
+// expectRequestEvent waits for an event on the request belonging to the given
+// pod.
+//
+// It exists so a spec can assert on an event without reaching for a
+// namespace-wide `--field-selector reason=...`, which selects every request in
+// the namespace including ones a previous run against a reused cluster left
+// behind. Resolving the request first scopes the search to this pod's own
+// request, the same way findPodCertificateRequest scopes a status assertion.
+func expectRequestEvent(ref podRef, eventType, reason string, messageContains ...string) {
+	GinkgoHelper()
+
+	var requestName string
+	Eventually(func(g Gomega) {
+		requestName = findPodCertificateRequest(g, ref).Name
+	}).Should(Succeed())
+
+	expectEvent(ref.namespace, requestName, eventType, reason, messageContains...)
+}
+
 // expectEvent waits for an event of the given type and reason naming the given
-// object.
+// object, optionally requiring substrings in its message.
 //
 // The event is the operator-visible half of the outcome: a status condition is
 // only reachable by someone who already knows to look at the request, while the
 // event is what surfaces in `kubectl get events` and in whatever collects them.
-func expectEvent(namespace, involvedName, eventType, reason string) {
+func expectEvent(namespace, involvedName, eventType, reason string, messageContains ...string) {
 	GinkgoHelper()
 
 	Eventually(func(g Gomega) {
@@ -327,15 +346,17 @@ func expectEvent(namespace, involvedName, eventType, reason string) {
 		var list corev1.EventList
 		g.Expect(json.Unmarshal([]byte(trimToJSON(output)), &list)).To(Succeed(), "Failed to decode the event list")
 
+		matched := false
 		observed := make([]string, 0, len(list.Items))
 		for _, event := range list.Items {
-			if event.Type == eventType && event.Reason == reason {
-				return
+			if event.Type == eventType && event.Reason == reason && containsAll(event.Message, messageContains) {
+				matched = true
 			}
-			observed = append(observed, fmt.Sprintf("%s/%s", event.Type, event.Reason))
+			observed = append(observed, fmt.Sprintf("%s/%s: %s", event.Type, event.Reason, event.Message))
 		}
-		g.Expect(observed).To(ContainElement(eventType+"/"+reason),
-			"no %s event with reason %q was recorded for %s", eventType, reason, involvedName)
+		g.Expect(matched).To(BeTrue(),
+			"no %s event with reason %q and message containing %v was recorded for %s; observed: %v",
+			eventType, reason, messageContains, involvedName, observed)
 	}, time.Minute).Should(Succeed())
 }
 
@@ -364,6 +385,16 @@ func controllerLogLineCount(needles ...string) int {
 		}
 	}
 	return count
+}
+
+// containsAll reports whether s contains every one of the given substrings.
+func containsAll(s string, substrings []string) bool {
+	for _, want := range substrings {
+		if !strings.Contains(s, want) {
+			return false
+		}
+	}
+	return true
 }
 
 // trimToJSON strips anything kubectl wrote before the JSON document.

--- a/test/e2e/outcomes_test.go
+++ b/test/e2e/outcomes_test.go
@@ -1,0 +1,386 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
+)
+
+// terminalOutcomeTimeout bounds how long a spec waits for the signer to record
+// a terminal condition on a request.
+const terminalOutcomeTimeout = 3 * time.Minute
+
+// reconcileNudgeAnnotation is written onto a terminal PodCertificateRequest to
+// force the controller to reconcile it once more. See
+// expectTerminalConditionStable.
+const reconcileNudgeAnnotation = "e2e.pod-certificate-signer/reconcile-nudge"
+
+// podRef pins the identity of a workload pod for the lifetime of a spec.
+//
+// The UID is the load-bearing field. A PodCertificateRequest names the pod it
+// belongs to *and* that pod's UID, and only the pair identifies it: a pod name
+// is unique in a namespace at a point in time, not over the life of a cluster.
+// `make test-e2e` reuses a Kind cluster that is already present, so requests
+// from an earlier run outlive the pods that caused them and can share a name
+// with a pod the current run just created.
+type podRef struct {
+	namespace string
+	name      string
+	uid       types.UID
+}
+
+func (p podRef) String() string {
+	return fmt.Sprintf("%s/%s (uid %s)", p.namespace, p.name, p.uid)
+}
+
+// deniedRequest is the terminal outcome recorded on a PodCertificateRequest the
+// signer refuses.
+type deniedRequest struct {
+	Reason  string
+	Message string
+}
+
+// terminalConditionTypes are the three condition types the PodCertificateRequest
+// API gives special handling: at most one may be present, and it must have
+// status True.
+var terminalConditionTypes = []string{
+	capiv1beta1.PodCertificateRequestConditionTypeIssued,
+	capiv1beta1.PodCertificateRequestConditionTypeDenied,
+	capiv1beta1.PodCertificateRequestConditionTypeFailed,
+}
+
+// findPodCertificateRequest returns the single PodCertificateRequest belonging
+// to the given pod.
+//
+// Selection is on namespace + pod name + pod UID + signer name. Matching on the
+// pod name alone - as the suite did before - picks up a request left over from
+// a previous run against a reused cluster, or a request another signer is
+// serving, and reports its outcome as this pod's.
+//
+// More than one match is not a condition that resolves by waiting, so it aborts
+// the retry loop immediately rather than burning the whole timeout.
+func findPodCertificateRequest(g Gomega, ref podRef) *capiv1beta1.PodCertificateRequest {
+	cmd := exec.Command("kubectl", "get", "podcertificaterequests", "-n", ref.namespace, "-o", "json")
+	output, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred(), "Failed to list PodCertificateRequests")
+
+	var list capiv1beta1.PodCertificateRequestList
+	g.Expect(json.Unmarshal([]byte(output), &list)).To(Succeed(),
+		"Failed to decode the PodCertificateRequest list")
+
+	var matches []*capiv1beta1.PodCertificateRequest
+	for i := range list.Items {
+		pcr := &list.Items[i]
+		if pcr.Spec.PodName == ref.name && pcr.Spec.PodUID == ref.uid && pcr.Spec.SignerName == signerName {
+			matches = append(matches, pcr)
+		}
+	}
+
+	if len(matches) > 1 {
+		names := make([]string, 0, len(matches))
+		for _, pcr := range matches {
+			names = append(names, pcr.Name)
+		}
+		StopTrying(fmt.Sprintf(
+			"ambiguous PodCertificateRequest selection for pod %s and signer %q: %s; "+
+				"a spec must assert against exactly one request",
+			ref, signerName, strings.Join(names, ", "))).Now()
+	}
+	g.Expect(matches).To(HaveLen(1),
+		"no PodCertificateRequest for pod %s and signer %q exists yet", ref, signerName)
+
+	return matches[0]
+}
+
+// terminalCondition returns the request's single terminal condition, failing if
+// the request carries none yet or - which kube-apiserver is supposed to prevent
+// - carries more than one.
+func terminalCondition(g Gomega, pcr *capiv1beta1.PodCertificateRequest) metav1.Condition {
+	var terminal []metav1.Condition
+	for _, cond := range pcr.Status.Conditions {
+		for _, want := range terminalConditionTypes {
+			if cond.Type == want {
+				terminal = append(terminal, cond)
+			}
+		}
+	}
+
+	g.Expect(terminal).To(HaveLen(1),
+		"request %s must carry exactly one terminal condition, has %d: %v", pcr.Name, len(terminal), terminal)
+	g.Expect(terminal[0].Status).To(Equal(metav1.ConditionTrue),
+		"a terminal condition must have status True")
+
+	return terminal[0]
+}
+
+// expectIssued waits until the pod's request is issued and returns the parsed
+// certificate chain.
+//
+// A complete Issued outcome is: exactly one terminal condition, of type Issued
+// with reason CertificateIssued; a parseable certificate chain; all three
+// status timestamps populated; and a matching Normal event. Asserting the whole
+// set is what distinguishes "issued" from "half-written status that happens to
+// carry a certificate".
+func expectIssued(ref podRef) []*x509.Certificate {
+	GinkgoHelper()
+
+	var chain []*x509.Certificate
+	var requestName string
+	Eventually(func(g Gomega) {
+		pcr := findPodCertificateRequest(g, ref)
+		cond := terminalCondition(g, pcr)
+		if cond.Type != capiv1beta1.PodCertificateRequestConditionTypeIssued {
+			StopTrying(fmt.Sprintf("request %s for pod %s reached the terminal outcome %s (%s): %s",
+				pcr.Name, ref, cond.Type, cond.Reason, cond.Message)).Now()
+		}
+		g.Expect(cond.Reason).To(Equal("CertificateIssued"),
+			"an issued request must carry the CertificateIssued reason")
+
+		g.Expect(pcr.Status.CertificateChain).NotTo(BeEmpty(),
+			"an issued request must carry a certificate chain")
+		g.Expect(pcr.Status.NotBefore).NotTo(BeNil(), "an issued request must carry notBefore")
+		g.Expect(pcr.Status.NotAfter).NotTo(BeNil(), "an issued request must carry notAfter")
+		g.Expect(pcr.Status.BeginRefreshAt).NotTo(BeNil(), "an issued request must carry beginRefreshAt")
+
+		chain = parseCertificateChain(g, pcr.Status.CertificateChain)
+		g.Expect(chain).NotTo(BeEmpty(), "the certificate chain must contain at least the leaf")
+		requestName = pcr.Name
+	}, terminalOutcomeTimeout).Should(Succeed())
+
+	expectEvent(ref.namespace, requestName, corev1.EventTypeNormal, "CertificateIssued")
+
+	return chain
+}
+
+// expectDenied waits until the pod's request is denied with the given reason
+// and returns the recorded denial.
+//
+// A complete Denied outcome is: exactly one terminal condition, of type Denied
+// with the expected reason; no certificate and no timestamps; a matching
+// Warning event; and no further change once the controller has had another
+// chance to reconcile the request.
+func expectDenied(ref podRef, wantReason string) deniedRequest {
+	GinkgoHelper()
+	return expectTerminalDenialOrFailure(ref, capiv1beta1.PodCertificateRequestConditionTypeDenied, wantReason)
+}
+
+// expectFailed is the counterpart of expectDenied for requests the signer
+// accepts but cannot fulfil.
+//
+// It has no caller yet: the only path that records a Failed condition is a
+// signing failure (ReasonSigningFailed), which needs a broken or unusable CA
+// and is therefore reachable only once the CA-lifecycle specs land. It is
+// defined here so that stage does not have to re-derive the assertion set, and
+// so the Failed shape is documented alongside the Denied one it must match.
+//
+//nolint:unused // wired up by the CA-lifecycle stage; see the comment above.
+func expectFailed(ref podRef, wantReason string) deniedRequest {
+	GinkgoHelper()
+	return expectTerminalDenialOrFailure(ref, capiv1beta1.PodCertificateRequestConditionTypeFailed, wantReason)
+}
+
+// expectTerminalDenialOrFailure implements the shared shape of expectDenied and
+// expectFailed: both are non-issuing terminal outcomes, and the guarantees that
+// matter - cleared status fields, a warning event, immutability - are identical.
+func expectTerminalDenialOrFailure(ref podRef, wantType, wantReason string) deniedRequest {
+	GinkgoHelper()
+
+	var outcome deniedRequest
+	var requestName string
+	var recorded metav1.Condition
+	Eventually(func(g Gomega) {
+		pcr := findPodCertificateRequest(g, ref)
+		cond := terminalCondition(g, pcr)
+		if cond.Type != wantType {
+			StopTrying(fmt.Sprintf("request %s for pod %s reached the terminal outcome %s (%s), want %s: %s",
+				pcr.Name, ref, cond.Type, cond.Reason, wantType, cond.Message)).Now()
+		}
+		g.Expect(cond.Reason).To(Equal(wantReason),
+			"a %s request must carry the expected reason; message was: %s", wantType, cond.Message)
+
+		expectStatusFieldsCleared(g, pcr)
+
+		outcome = deniedRequest{Reason: cond.Reason, Message: cond.Message}
+		requestName = pcr.Name
+		recorded = cond
+	}, terminalOutcomeTimeout).Should(Succeed())
+
+	expectEvent(ref.namespace, requestName, corev1.EventTypeWarning, wantReason)
+	expectTerminalConditionStable(ref, recorded)
+
+	return outcome
+}
+
+// expectStatusFieldsCleared asserts that a non-issuing terminal outcome left no
+// certificate material behind.
+//
+// The API declares certificateChain, notBefore, notAfter and beginRefreshAt
+// immutable once populated, so a signer that populates any of them next to a
+// Denied or Failed condition has written a status it can never take back. The
+// timestamps matter as much as the chain: kubelet reads beginRefreshAt to
+// schedule renewal, and a denied request advertising one is a renewal loop
+// waiting to happen.
+func expectStatusFieldsCleared(g Gomega, pcr *capiv1beta1.PodCertificateRequest) {
+	g.Expect(pcr.Status.CertificateChain).To(BeEmpty(),
+		"a non-issuing terminal outcome must never carry a certificate chain")
+	g.Expect(pcr.Status.NotBefore).To(BeNil(),
+		"a non-issuing terminal outcome must leave notBefore unset")
+	g.Expect(pcr.Status.NotAfter).To(BeNil(),
+		"a non-issuing terminal outcome must leave notAfter unset")
+	g.Expect(pcr.Status.BeginRefreshAt).To(BeNil(),
+		"a non-issuing terminal outcome must leave beginRefreshAt unset")
+}
+
+// expectTerminalConditionStable proves a terminal outcome is final by giving the
+// controller another chance to reconcile the request and asserting nothing
+// moved.
+//
+// The nudge is a metadata annotation on the request. The reconciler's event
+// filter only overrides CreateFunc (see SetupWithManager), and predicate.Funcs
+// returns true for an unset UpdateFunc, so writing an annotation enqueues a
+// real reconcile - which Reconcile then drops on its immutability check. To keep
+// this from degrading into a sleep in assertion's clothing if that ever changes,
+// the helper counts the controller's "immutable" log lines for this request
+// before and after the nudge and requires the count to rise.
+func expectTerminalConditionStable(ref podRef, want metav1.Condition) {
+	GinkgoHelper()
+
+	var requestName string
+	Eventually(func(g Gomega) {
+		requestName = findPodCertificateRequest(g, ref).Name
+	}).Should(Succeed())
+
+	By("nudging the controller to reconcile the terminal request once more")
+	before := controllerLogLineCount(requestName, "PodCertificateRequest is immutable")
+	cmd := exec.Command("kubectl", "annotate", "podcertificaterequest", requestName,
+		"-n", ref.namespace, "--overwrite",
+		fmt.Sprintf("%s=%d", reconcileNudgeAnnotation, time.Now().UnixNano()))
+	output, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to annotate request %s: %s", requestName, output)
+
+	By("waiting for the controller to observe the nudged request")
+	Eventually(func() int {
+		return controllerLogLineCount(requestName, "PodCertificateRequest is immutable")
+	}, time.Minute).Should(BeNumerically(">", before),
+		"the annotation must produce a further reconcile of request %s, otherwise this proves nothing", requestName)
+
+	By("verifying the terminal outcome did not change")
+	Consistently(func(g Gomega) {
+		pcr := findPodCertificateRequest(g, ref)
+		cond := terminalCondition(g, pcr)
+		g.Expect(cond.Type).To(Equal(want.Type), "the terminal condition type must not change")
+		g.Expect(cond.Reason).To(Equal(want.Reason), "the terminal condition reason must not change")
+		g.Expect(cond.Message).To(Equal(want.Message), "the terminal condition message must not change")
+		g.Expect(cond.LastTransitionTime).To(Equal(want.LastTransitionTime),
+			"a re-recorded condition would move lastTransitionTime")
+		expectStatusFieldsCleared(g, pcr)
+	}, 5*time.Second, time.Second).Should(Succeed())
+}
+
+// expectEvent waits for an event of the given type and reason naming the given
+// object.
+//
+// The event is the operator-visible half of the outcome: a status condition is
+// only reachable by someone who already knows to look at the request, while the
+// event is what surfaces in `kubectl get events` and in whatever collects them.
+func expectEvent(namespace, involvedName, eventType, reason string) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "get", "events", "-n", namespace,
+			"--field-selector", "involvedObject.name="+involvedName, "-o", "json")
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to list events for %s", involvedName)
+
+		var list corev1.EventList
+		g.Expect(json.Unmarshal([]byte(output), &list)).To(Succeed(), "Failed to decode the event list")
+
+		observed := make([]string, 0, len(list.Items))
+		for _, event := range list.Items {
+			if event.Type == eventType && event.Reason == reason {
+				return
+			}
+			observed = append(observed, fmt.Sprintf("%s/%s", event.Type, event.Reason))
+		}
+		g.Expect(observed).To(ContainElement(eventType+"/"+reason),
+			"no %s event with reason %q was recorded for %s", eventType, reason, involvedName)
+	}, time.Minute).Should(Succeed())
+}
+
+// controllerLogLineCount reports how many lines of the current controller pod's
+// log contain all of the given substrings. It is diagnostic-grade on purpose:
+// an unreadable log counts as zero rather than failing, so the caller's
+// Eventually keeps polling across a pod that is still starting.
+func controllerLogLineCount(needles ...string) int {
+	cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return 0
+	}
+
+	count := 0
+	for _, line := range strings.Split(output, "\n") {
+		matched := true
+		for _, needle := range needles {
+			if !strings.Contains(line, needle) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			count++
+		}
+	}
+	return count
+}
+
+// parseCertificateChain decodes every PEM block of an issued chain.
+func parseCertificateChain(g Gomega, chainPEM string) []*x509.Certificate {
+	var certs []*x509.Certificate
+	data := []byte(chainPEM)
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+		g.Expect(block.Type).To(Equal("CERTIFICATE"),
+			"an issued chain must contain only CERTIFICATE blocks")
+		cert, err := x509.ParseCertificate(block.Bytes)
+		g.Expect(err).NotTo(HaveOccurred(), "chain entry must be a valid certificate")
+		certs = append(certs, cert)
+	}
+	return certs
+}

--- a/test/e2e/outcomes_test.go
+++ b/test/e2e/outcomes_test.go
@@ -97,7 +97,7 @@ func findPodCertificateRequest(g Gomega, ref podRef) *capiv1beta1.PodCertificate
 	g.Expect(err).NotTo(HaveOccurred(), "Failed to list PodCertificateRequests")
 
 	var list capiv1beta1.PodCertificateRequestList
-	g.Expect(json.Unmarshal([]byte(output), &list)).To(Succeed(),
+	g.Expect(json.Unmarshal([]byte(trimToJSON(output)), &list)).To(Succeed(),
 		"Failed to decode the PodCertificateRequest list")
 
 	var matches []*capiv1beta1.PodCertificateRequest
@@ -325,7 +325,7 @@ func expectEvent(namespace, involvedName, eventType, reason string) {
 		g.Expect(err).NotTo(HaveOccurred(), "Failed to list events for %s", involvedName)
 
 		var list corev1.EventList
-		g.Expect(json.Unmarshal([]byte(output), &list)).To(Succeed(), "Failed to decode the event list")
+		g.Expect(json.Unmarshal([]byte(trimToJSON(output)), &list)).To(Succeed(), "Failed to decode the event list")
 
 		observed := make([]string, 0, len(list.Items))
 		for _, event := range list.Items {
@@ -364,6 +364,25 @@ func controllerLogLineCount(needles ...string) int {
 		}
 	}
 	return count
+}
+
+// trimToJSON strips anything kubectl wrote before the JSON document.
+//
+// utils.Run reports CombinedOutput, so an apiserver warning - a PodSecurity
+// notice, a deprecation, an admission webhook's advice - lands on stderr and
+// arrives interleaved ahead of the `-o json` payload. Decoding the raw output
+// then fails on the warning's first character rather than on anything about the
+// object. Taking the document from the first line that opens an object is
+// enough: kubectl prints warnings as whole lines and the payload is a single
+// top-level object.
+func trimToJSON(output string) string {
+	lines := strings.Split(output, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "{") {
+			return strings.Join(lines[i:], "\n")
+		}
+	}
+	return output
 }
 
 // parseCertificateChain decodes every PEM block of an issued chain.


### PR DESCRIPTION
Stage 1 of the E2E coverage plan: harden the framework. Test infrastructure
only — no signer behaviour changes.

PR #92 added install profiles that re-install the Helm release mid-suite, which
made three latent weaknesses matter: nothing in the code said the suite must be
single-threaded, a request was located by pod name alone, and a denial was
proved only by its reason string.

## What changed

**Serial execution.** The top-level container is decorated `Serial`, and
`BeforeSuite` fails the run if it is started with more than one process
(`ParallelTotal` and `GinkgoParallelProcess`). A profile switch is cluster-wide,
so a parallel invocation would report results for a configuration that was never
under test. `make test-e2e` runs plain `go test`, so this matches how the suite
is actually invoked.

**Request selection.** Requests are located by namespace + pod name + pod UID +
signer name, and an ambiguous match aborts the retry immediately instead of
taking the first candidate. `make test-e2e` reuses a Kind cluster that is already
present, so requests from an earlier run outlive their pods and can share a name
with a pod the current run just created.

**Typed fixtures.** The workload pod is built as a `corev1.Pod` covering the
whole `podCertificate` projection — annotations, key type, `maxExpirationSeconds`,
service account, and an optional ClusterTrustBundle projection — instead of a
formatted YAML string. The deployed pod is unchanged. Creation uses `kubectl
create`, so a leftover pod of the same name is a loud conflict rather than a
stale UID.

**Outcome matchers.** `expectIssued`, `expectDenied`, `expectFailed`,
`expectEvent`, `expectRequestEvent`, `expectStatusFieldsCleared` and
`expectTerminalConditionStable` replace the ad-hoc waits, and every existing
assertion is routed through them.

- Issued: exactly one terminal condition, `Issued`/`CertificateIssued`, a
  parseable chain, all three timestamps, a matching Normal event.
- Denied: exactly one terminal condition, empty `certificateChain`, `notBefore`
  / `notAfter` / `beginRefreshAt` nil, a matching Warning event, and unchanged
  after a further reconcile.

The immutability check does not sleep and hope. It writes a metadata annotation
on the terminal request — `SetupWithManager` only overrides `CreateFunc`, and
`predicate.Funcs` returns true for an unset `UpdateFunc`, so that enqueues a real
reconcile — then requires the controller's "PodCertificateRequest is immutable"
log count for that request to rise before asserting nothing moved.

**Diagnostics.** A failed spec dumps every replica's log including `--previous`,
the Deployment/ReplicaSets/pods/leases, workload pods and requests with events,
trust bundles, admission resources, the Helm values and rendered manifest, node
versions, and metrics. No Secret is ever read. The chart takes its CA by
`secretRef` only, so the Helm collectors carry no key material by construction;
every output still passes through a private-key redactor as a backstop.

**Cleanup and tagged analysis.** The Kind cluster is torn down from an EXIT trap
that re-raises the test's exit code, with an `if: always()` backstop in CI. The
cluster-existence guard is now anchored — `kind get clusters | grep pcs-e2e` was
satisfied by any cluster whose name merely *contained* `pcs-e2e`, so a leftover
`pcs-e2e-stage3` made the guard skip creating the cluster the suite then ran
against. `grep -qx` fixes that and stops leaking the matched name into the
target's output; `kind-start` carried the identical bug and is fixed the same
way.
`make vet-e2e` and `make lint-e2e` run `go vet -tags=e2e` and `golangci-lint
--build-tags=e2e`; without the tag both tools silently skip the entire package.

**Profile names** are now `chart-defaults`, `verified-interpolation`,
`unverified-identities` and `honor-csr-sans`. "Secure defaults with
interpolation" was misleading — it is not what the chart ships.

## Verification

`make test-e2e` on a local Kind cluster: **32/32 specs, 188s** (baseline ~160s;
the delta is the per-denial reconcile nudges). `make test` and `make lint` pass.

Tagged vet and lint were clean on the pre-existing suite; on the new code
`unused` flagged `expectFailed`, which has no caller because a `Failed` condition
requires a broken CA and is only reachable once the CA-lifecycle stage lands. It
carries a `//nolint:unused` naming that stage.

The diagnostics path was verified by forcing a spec failure: every collector
produced output, `--previous` was correctly unavailable (no container had
restarted), and no private key material appeared. Two red runs confirmed the
cluster is deleted and the target still exits non-zero.

The anchored cluster guard was verified with a real `pcs-e2e-stage3` cluster
present: the guard created `pcs-e2e` rather than skipping it, the suite passed
32/32, and the teardown removed only `pcs-e2e` while the decoy survived.

Note for reviewers: `release.yml` runs `make test vet`, and `vet` now depends on
`vet-e2e`, so the release job compiles the e2e package for the first time. It is
strictly stricter, not looser, and it compiles today.

## Out of scope

No CSR-SAN assertions. kubelet emits an empty stub CSR, so that behaviour is
unreachable end to end; #92 documents this correctly and it stays unit-tested.
