### PR TITLE
test(e2e): prove the projected credential works, not just parses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,16 @@ run: generate fmt vet ## Run a controller from your host.
 docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMAGE} .
 
+## Image of the in-cluster credential probe the e2e suite runs as its workload
+## (see test/credprobe). It is built from this repository and loaded into the
+## Kind cluster, never pulled, so the specs work on a runner with no access to
+## a registry holding a third-party workload image.
+E2E_WORKLOAD_IMAGE ?= example.com/pcs-credprobe:v0.0.1
+
+.PHONY: e2e-workload-image
+e2e-workload-image: ## Build the e2e credential-probe workload image.
+	$(CONTAINER_TOOL) build -t $(E2E_WORKLOAD_IMAGE) -f $(SRC_ROOT)/test/credprobe/Dockerfile $(SRC_ROOT)
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMAGE}

--- a/test/credprobe/Dockerfile
+++ b/test/credprobe/Dockerfile
@@ -1,0 +1,31 @@
+# The in-cluster credential probe used by the e2e suite (see test/credprobe).
+#
+# It is built from this repository rather than pulled, so a CI runner that can
+# run `make test-e2e` can run these specs: there is no third-party workload
+# image to publish, pin or keep available. The build copies only the module
+# files and the probe itself - the probe imports nothing outside the standard
+# library and its own report package, so there is nothing to download.
+#
+# The base images and their digests are deliberately the same as the manager's
+# (see the repository root Dockerfile); refresh them together.
+FROM golang:1.26@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY test/credprobe test/credprobe
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -a -trimpath -ldflags="-s -w" -o credprobe ./test/credprobe
+
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
+LABEL org.opencontainers.image.source=https://github.com/rafpe/pod-certificate-signer
+WORKDIR /
+COPY --from=builder /workspace/credprobe .
+# The same non-root uid the workload fixtures run as, so "readable by the
+# container's user" is a claim about an unprivileged reader.
+USER 65532:65532
+
+ENTRYPOINT ["/credprobe"]

--- a/test/credprobe/main.go
+++ b/test/credprobe/main.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command credprobe validates, from inside a workload pod, the credential
+// kubelet projected into it.
+//
+// The e2e suite can read a PodCertificateRequest's status from outside the
+// cluster and check that it carries a well-formed certificate. What it cannot
+// do from there is answer the question the workload actually cares about:
+// whether the files under the projected volume are present, readable by the
+// user the container runs as, internally consistent, and usable to complete a
+// TLS handshake against the trust anchors projected alongside them. This
+// binary answers that, writes one line of JSON (see the report package), and
+// then holds the process open so the pod stays Running while the suite reads
+// it.
+//
+// It asserts nothing about material it cannot publish: the private key is used
+// and never reported, and everything in the report is public - fingerprints,
+// PEM block types, sizes, certificate fields and booleans.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+)
+
+func main() {
+	var cfg config
+	flag.StringVar(&cfg.bundlePath, "bundle", "/var/run/x509/credentialbundle.pem",
+		"path of the projected credential bundle")
+	flag.StringVar(&cfg.trustPath, "trust", "/var/run/x509/ca.crt",
+		"path of the projected ClusterTrustBundle")
+	flag.StringVar(&cfg.role, "role", report.RoleServer,
+		"extended key usage the projected certificate was issued with: server or client")
+	flag.IntVar(&cfg.expectChainLen, "expect-chain-len", 2,
+		"number of certificates the bundle must carry after the private key")
+	flag.StringVar(&cfg.allowedDNS, "allowed-dns", "",
+		"a DNS name the projected certificate is expected to carry")
+	flag.StringVar(&cfg.unrelatedDNS, "unrelated-dns", "unrelated.invalid",
+		"a DNS name the projected certificate must not be accepted for")
+	flag.DurationVar(&cfg.hold, "hold", 15*time.Minute,
+		"how long to stay alive after reporting, so the pod stays Running")
+	flag.Parse()
+
+	encoded, err := json.Marshal(probe(cfg))
+	if err != nil {
+		// Nothing useful can be reported if the report itself cannot be
+		// encoded, so this is the one path that exits non-zero.
+		fmt.Fprintf(os.Stderr, "credprobe: encoding the report: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%s%s\n", report.Prefix, encoded)
+
+	// The probe never exits on a failed check: the suite is the judge, and a
+	// pod that stays Running lets it assert on the pod phase and read the log
+	// without racing a container that has already terminated. Cleanup is the
+	// suite's, via the pod deletion its DeferCleanup registers - which arrives
+	// here as SIGTERM.
+	hold(cfg.hold)
+}
+
+// hold blocks until the deadline passes or the container is asked to stop.
+func hold(d time.Duration) {
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-stop:
+	case <-timer.C:
+	}
+}

--- a/test/credprobe/probe.go
+++ b/test/credprobe/probe.go
@@ -1,0 +1,433 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+)
+
+// config is what the e2e suite tells the probe about the credential it is
+// about to inspect. Everything the probe can observe for itself - fingerprints,
+// subject, SANs, lifetimes - is reported rather than passed in, so the suite
+// judges those against the PodCertificateRequest status and the
+// ClusterTrustBundle instead of the probe grading its own homework.
+type config struct {
+	bundlePath string
+	trustPath  string
+
+	// role is the EKU the projected certificate was issued with; see
+	// report.RoleServer / report.RoleClient.
+	role string
+
+	// expectChainLen is how many certificates the bundle must carry after the
+	// private key.
+	expectChainLen int
+
+	// allowedDNS is a DNS name the certificate carries, and unrelatedDNS one it
+	// must not: the pair is what separates "the handshake worked" from "the
+	// handshake verified the name".
+	allowedDNS   string
+	unrelatedDNS string
+
+	hold time.Duration
+}
+
+// probe runs every check for the configured role and returns the report.
+//
+// Checks that later ones depend on stop the run: with no parseable bundle there
+// is nothing to say about the key, and reporting a cascade of failures whose
+// only cause is the first one buries the actual fault. The suite asserts on the
+// full expected set of check names, so a short report fails just as loudly as a
+// failing check - and says why in the last check it did record.
+func probe(cfg config) report.Report {
+	r := &reporter{}
+	r.report.Role = cfg.role
+	r.report.Facts.ProcessUID = os.Getuid()
+
+	bundlePEM, ok := r.readProjectedFile(report.CheckBundleFile, cfg.bundlePath, &r.report.Facts.Bundle)
+	if !ok {
+		return r.report
+	}
+
+	key, chain, ok := r.checkBundleBlocks(cfg, bundlePEM)
+	if !ok {
+		return r.report
+	}
+	r.recordLeafFacts(chain)
+
+	if !r.checkKeyMatchesLeaf(key, chain[0]) {
+		return r.report
+	}
+
+	trustPEM, ok := r.readProjectedFile(report.CheckTrustFile, cfg.trustPath, &r.report.Facts.Trust)
+	if !ok {
+		return r.report
+	}
+
+	anchors, ok := r.checkTrustAnchors(trustPEM)
+	if !ok {
+		return r.report
+	}
+
+	pool := x509.NewCertPool()
+	for _, anchor := range anchors {
+		pool.AddCert(anchor)
+	}
+	if !r.checkTrustVerifiesLeaf(chain, pool) {
+		return r.report
+	}
+
+	r.checkTLS(cfg, tls.Certificate{
+		Certificate: rawChain(chain),
+		PrivateKey:  key,
+		Leaf:        chain[0],
+	}, pool)
+
+	return r.report
+}
+
+// reporter accumulates checks and facts.
+type reporter struct {
+	report report.Report
+}
+
+// pass records a satisfied check. The detail states what was observed anyway:
+// a green run is the baseline a later red one is read against.
+func (r *reporter) pass(name, format string, args ...any) bool {
+	r.report.Checks = append(r.report.Checks, report.Check{
+		Name: name, OK: true, Detail: fmt.Sprintf(format, args...),
+	})
+	return true
+}
+
+// fail records an unsatisfied check and returns false, so callers can write
+// `if !r.check(...) { return }`.
+func (r *reporter) fail(name, format string, args ...any) bool {
+	r.report.Checks = append(r.report.Checks, report.Check{
+		Name: name, OK: false, Detail: fmt.Sprintf(format, args...),
+	})
+	return false
+}
+
+// readProjectedFile stats and reads one projected file, recording what it found
+// either way.
+//
+// The stat facts are collected before the read so a permission failure is
+// reported alongside the mode and ownership that caused it. That combination is
+// the whole point of running this in-cluster: the suite cannot see from outside
+// whether kubelet made the credential readable by the user the container
+// actually runs as.
+func (r *reporter) readProjectedFile(checkName, path string, facts *report.FileFacts) ([]byte, bool) {
+	facts.Path = path
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, r.fail(checkName, "stat %s: %v", path, err)
+	}
+	facts.Mode = info.Mode().Perm().String()
+	facts.Size = info.Size()
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		facts.UID = stat.Uid
+		facts.GID = stat.Gid
+	}
+
+	//nolint:gosec // G304: the path is a probe flag set by the e2e suite.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, r.fail(checkName, "read %s as uid %d (mode %s, owner %d:%d): %v",
+			path, r.report.Facts.ProcessUID, facts.Mode, facts.UID, facts.GID, err)
+	}
+	if len(data) == 0 {
+		return nil, r.fail(checkName, "%s is empty", path)
+	}
+
+	r.pass(checkName, "read %d bytes from %s as uid %d (mode %s, owner %d:%d)",
+		len(data), path, r.report.Facts.ProcessUID, facts.Mode, facts.UID, facts.GID)
+	return data, true
+}
+
+// checkBundleBlocks decodes the credential bundle and asserts its shape:
+// exactly one private key block, first, then exactly the expected number of
+// certificates, and nothing else.
+//
+// The order and the count both matter. A bundle whose trailing bytes are not
+// PEM, or which carries a second key, or which is missing the issuer, is a
+// bundle a workload cannot use to serve TLS - and none of that is visible in
+// the PodCertificateRequest status, which is why it is checked here.
+func (r *reporter) checkBundleBlocks(cfg config, bundlePEM []byte) (crypto.Signer, []*x509.Certificate, bool) {
+	blocks, rest := decodePEM(bundlePEM)
+	for _, block := range blocks {
+		r.report.Facts.Bundle.BlockTypes = append(r.report.Facts.Bundle.BlockTypes, block.Type)
+	}
+
+	if len(strings.TrimSpace(string(rest))) != 0 {
+		return nil, nil, r.fail(report.CheckBundleBlocks,
+			"%d trailing bytes after the last PEM block; blocks were %v",
+			len(rest), r.report.Facts.Bundle.BlockTypes)
+	}
+	if want := cfg.expectChainLen + 1; len(blocks) != want {
+		return nil, nil, r.fail(report.CheckBundleBlocks,
+			"want %d PEM blocks (1 private key + %d certificates), got %d: %v",
+			want, cfg.expectChainLen, len(blocks), r.report.Facts.Bundle.BlockTypes)
+	}
+	if !isPrivateKeyBlock(blocks[0].Type) {
+		return nil, nil, r.fail(report.CheckBundleBlocks,
+			"the first PEM block must be a private key, got %q; blocks were %v",
+			blocks[0].Type, r.report.Facts.Bundle.BlockTypes)
+	}
+
+	key, err := parsePrivateKey(blocks[0])
+	if err != nil {
+		return nil, nil, r.fail(report.CheckBundleBlocks, "parsing the private key: %v", err)
+	}
+
+	var chain []*x509.Certificate
+	for i, block := range blocks[1:] {
+		if block.Type != "CERTIFICATE" {
+			return nil, nil, r.fail(report.CheckBundleBlocks,
+				"PEM block %d must be a CERTIFICATE, got %q; blocks were %v",
+				i+1, block.Type, r.report.Facts.Bundle.BlockTypes)
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, nil, r.fail(report.CheckBundleBlocks, "parsing certificate %d: %v", i, err)
+		}
+		chain = append(chain, cert)
+		r.report.Facts.ChainSHA256 = append(r.report.Facts.ChainSHA256, fingerprint(cert))
+	}
+
+	r.pass(report.CheckBundleBlocks, "bundle carries %v and no other blocks",
+		r.report.Facts.Bundle.BlockTypes)
+	return key, chain, true
+}
+
+// checkKeyMatchesLeaf proves the projected private key is the one the leaf
+// certifies. A bundle pairing a valid key with someone else's certificate
+// parses perfectly and fails at the first handshake.
+func (r *reporter) checkKeyMatchesLeaf(key crypto.Signer, leaf *x509.Certificate) bool {
+	pub, ok := key.Public().(interface{ Equal(crypto.PublicKey) bool })
+	if !ok {
+		return r.fail(report.CheckBundleKeyMatchesLeaf,
+			"private key of type %T cannot be compared to the leaf public key", key.Public())
+	}
+	if !pub.Equal(leaf.PublicKey) {
+		return r.fail(report.CheckBundleKeyMatchesLeaf,
+			"the projected private key does not match the public key of leaf %s", fingerprint(leaf))
+	}
+	return r.pass(report.CheckBundleKeyMatchesLeaf,
+		"the projected %s private key matches leaf %s", leaf.PublicKeyAlgorithm, fingerprint(leaf))
+}
+
+// checkTrustAnchors decodes the projected ClusterTrustBundle and asserts every
+// entry is a CA certificate. An end-entity certificate in a trust store is a
+// trust bug: anything it signs would be accepted.
+func (r *reporter) checkTrustAnchors(trustPEM []byte) ([]*x509.Certificate, bool) {
+	blocks, rest := decodePEM(trustPEM)
+	for _, block := range blocks {
+		r.report.Facts.Trust.BlockTypes = append(r.report.Facts.Trust.BlockTypes, block.Type)
+	}
+
+	if len(strings.TrimSpace(string(rest))) != 0 {
+		return nil, r.fail(report.CheckTrustOnlyCAs,
+			"%d trailing bytes after the last PEM block; blocks were %v",
+			len(rest), r.report.Facts.Trust.BlockTypes)
+	}
+	if len(blocks) == 0 {
+		return nil, r.fail(report.CheckTrustOnlyCAs, "the projected trust bundle carries no PEM blocks")
+	}
+
+	var anchors []*x509.Certificate
+	for i, block := range blocks {
+		if block.Type != "CERTIFICATE" {
+			return nil, r.fail(report.CheckTrustOnlyCAs,
+				"trust anchor %d must be a CERTIFICATE, got %q", i, block.Type)
+		}
+		anchor, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, r.fail(report.CheckTrustOnlyCAs, "parsing trust anchor %d: %v", i, err)
+		}
+		if !anchor.IsCA {
+			return nil, r.fail(report.CheckTrustOnlyCAs,
+				"trust anchor %d (%s, subject %q) is not a CA certificate",
+				i, fingerprint(anchor), anchor.Subject)
+		}
+		anchors = append(anchors, anchor)
+		r.report.Facts.TrustSHA256 = append(r.report.Facts.TrustSHA256, fingerprint(anchor))
+	}
+
+	r.pass(report.CheckTrustOnlyCAs, "%d trust anchors, all CA certificates: %v",
+		len(anchors), r.report.Facts.TrustSHA256)
+	return anchors, true
+}
+
+// checkTrustVerifiesLeaf builds a chain from the projected leaf to the
+// projected trust anchors.
+func (r *reporter) checkTrustVerifiesLeaf(chain []*x509.Certificate, pool *x509.CertPool) bool {
+	intermediates := x509.NewCertPool()
+	for _, cert := range chain[1:] {
+		intermediates.AddCert(cert)
+	}
+
+	// KeyUsageAny keeps this check about the chain: whether the leaf is usable
+	// for a given role is what the TLS checks below prove.
+	_, err := chain[0].Verify(x509.VerifyOptions{
+		Roots:         pool,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	})
+	if err != nil {
+		return r.fail(report.CheckTrustVerifiesLeaf,
+			"leaf %s does not chain to the projected trust anchors %v: %v",
+			fingerprint(chain[0]), r.report.Facts.TrustSHA256, err)
+	}
+	return r.pass(report.CheckTrustVerifiesLeaf,
+		"leaf %s chains to the projected trust anchors", fingerprint(chain[0]))
+}
+
+// recordLeafFacts copies the public fields of the leaf into the report so the
+// suite can compare them against the request status.
+func (r *reporter) recordLeafFacts(chain []*x509.Certificate) {
+	leaf := chain[0]
+	facts := &r.report.Facts
+
+	facts.LeafSubject = leaf.Subject.String()
+	facts.LeafDNSNames = leaf.DNSNames
+	facts.LeafNotBefore = leaf.NotBefore.UTC().Format(time.RFC3339)
+	facts.LeafNotAfter = leaf.NotAfter.UTC().Format(time.RFC3339)
+	facts.LeafKeyAlgorithm = leaf.PublicKeyAlgorithm.String()
+
+	for _, ip := range leaf.IPAddresses {
+		facts.LeafIPAddresses = append(facts.LeafIPAddresses, ip.String())
+	}
+	for _, uri := range leaf.URIs {
+		facts.LeafURIs = append(facts.LeafURIs, uri.String())
+	}
+	for _, eku := range leaf.ExtKeyUsage {
+		facts.LeafExtKeyUsage = append(facts.LeafExtKeyUsage, extKeyUsageName(eku))
+	}
+}
+
+// decodePEM decodes every PEM block in data and returns them with whatever the
+// decoder could not consume.
+func decodePEM(data []byte) ([]*pem.Block, []byte) {
+	var blocks []*pem.Block
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			return blocks, rest
+		}
+		blocks = append(blocks, block)
+	}
+}
+
+// isPrivateKeyBlock reports whether a PEM block type names a private key, in
+// any of the encodings x509 can produce.
+func isPrivateKeyBlock(blockType string) bool {
+	return strings.HasSuffix(blockType, "PRIVATE KEY")
+}
+
+// parsePrivateKey decodes a private key PEM block, accepting the PKCS#8 form
+// kubelet writes today as well as the algorithm-specific forms, and requires
+// the result to be usable for signing.
+func parsePrivateKey(block *pem.Block) (crypto.Signer, error) {
+	var (
+		key any
+		err error
+	)
+	switch block.Type {
+	case "EC PRIVATE KEY":
+		key, err = x509.ParseECPrivateKey(block.Bytes)
+	case "RSA PRIVATE KEY":
+		key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+	default:
+		key, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("private key of type %T cannot sign", key)
+	}
+	return signer, nil
+}
+
+// rawChain returns the DER of every certificate in the chain, the form
+// tls.Certificate wants.
+func rawChain(chain []*x509.Certificate) [][]byte {
+	raw := make([][]byte, 0, len(chain))
+	for _, cert := range chain {
+		raw = append(raw, cert.Raw)
+	}
+	return raw
+}
+
+// fingerprint returns the SHA-256 fingerprint of a certificate, the identifier
+// the suite compares against the request status and the trust bundle.
+func fingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// extKeyUsageName renders an extended key usage for the report.
+func extKeyUsageName(eku x509.ExtKeyUsage) string {
+	switch eku {
+	case x509.ExtKeyUsageAny:
+		return "any"
+	case x509.ExtKeyUsageServerAuth:
+		return "serverAuth"
+	case x509.ExtKeyUsageClientAuth:
+		return "clientAuth"
+	default:
+		return fmt.Sprintf("eku(%d)", eku)
+	}
+}
+
+// isHostnameError reports whether err is, or wraps, a name mismatch.
+func isHostnameError(err error) bool {
+	var hostname x509.HostnameError
+	return errors.As(err, &hostname)
+}
+
+// isIncompatibleUsage reports whether err is, or wraps, a rejection for the
+// certificate's extended key usage - the specific reason a serverAuth-only
+// certificate must be refused in the client role and vice versa.
+//
+// Classifying rather than checking for any error is what keeps these negative
+// cases honest: a handshake that fails because the probe misconfigured the
+// listener would otherwise read as proof of an EKU boundary that was never
+// tested.
+func isIncompatibleUsage(err error) bool {
+	var invalid x509.CertificateInvalidError
+	return errors.As(err, &invalid) && invalid.Reason == x509.IncompatibleUsage
+}

--- a/test/credprobe/probe_test.go
+++ b/test/credprobe/probe_test.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/testutil"
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+)
+
+// These tests drive the probe against synthesized material that mirrors what
+// kubelet projects: a PKCS#8 private key followed by the leaf and its issuer,
+// and a trust bundle holding the issuing CA.
+//
+// They exist so the probe's logic - particularly the TLS role boundaries and
+// the classification of *why* a handshake failed - is debugged here, in
+// milliseconds, rather than through three-minute pod timeouts in the e2e suite.
+// When the in-cluster probe later goes red with these green, the fault is in
+// the cluster or the signer, not in the probe.
+
+const (
+	testAllowedDNS    = "workload.default.pod.cluster.local"
+	testUnrelatedDNS  = "unrelated.example.org"
+	testCALifetime    = time.Hour
+	testLeafLifetime  = 30 * time.Minute
+	testChainCertsLen = 2
+)
+
+// issueLeaf signs an Ed25519 leaf with the given CA, mirroring what the signer
+// issues by default.
+func issueLeaf(t *testing.T, ca *testutil.KeyPair, ekus []x509.ExtKeyUsage, dnsNames []string) (ed25519.PrivateKey, *x509.Certificate) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: dnsNames[0]},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(testLeafLifetime),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  ekus,
+		DNSNames:     dnsNames,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.Cert, pub, ca.Key)
+	if err != nil {
+		t.Fatalf("sign leaf: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	return priv, leaf
+}
+
+// writeBundle writes a credential bundle in kubelet's layout: the PKCS#8
+// private key first, then the certificate chain.
+func writeBundle(t *testing.T, dir string, key ed25519.PrivateKey, chain ...*x509.Certificate) string {
+	t.Helper()
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	var buf bytes.Buffer
+	buf.Write(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}))
+	for _, cert := range chain {
+		buf.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+	}
+
+	path := filepath.Join(dir, "credentialbundle.pem")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return path
+}
+
+// readBundle reads a bundle a test is about to corrupt.
+func readBundle(t *testing.T, path string) []byte {
+	t.Helper()
+
+	//nolint:gosec // G304/G703: the path came from writeBundle a few lines above.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read bundle: %v", err)
+	}
+	return data
+}
+
+// writeRawBundle writes bundle bytes verbatim into a fresh directory, for the
+// tests that hand the probe something malformed on purpose.
+func writeRawBundle(t *testing.T, data []byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "credentialbundle.pem")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return path
+}
+
+// writeTrust writes a projected ClusterTrustBundle holding the given anchors.
+func writeTrust(t *testing.T, dir string, anchors ...*x509.Certificate) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	for _, anchor := range anchors {
+		buf.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: anchor.Raw}))
+	}
+
+	path := filepath.Join(dir, "ca.crt")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write trust bundle: %v", err)
+	}
+	return path
+}
+
+// fixture is a complete projected volume plus the probe config that reads it.
+type fixture struct {
+	ca   *testutil.KeyPair
+	leaf *x509.Certificate
+	cfg  config
+}
+
+// newFixture builds a projected volume for the given role.
+func newFixture(t *testing.T, role string) fixture {
+	t.Helper()
+
+	ca, err := testutil.NewCA("credprobe-test-ca", testCALifetime)
+	if err != nil {
+		t.Fatalf("generate CA: %v", err)
+	}
+
+	eku := x509.ExtKeyUsageServerAuth
+	if role == report.RoleClient {
+		eku = x509.ExtKeyUsageClientAuth
+	}
+	key, leaf := issueLeaf(t, ca, []x509.ExtKeyUsage{eku}, []string{testAllowedDNS})
+
+	dir := t.TempDir()
+	return fixture{
+		ca:   ca,
+		leaf: leaf,
+		cfg: config{
+			bundlePath:     writeBundle(t, dir, key, leaf, ca.Cert),
+			trustPath:      writeTrust(t, dir, ca.Cert),
+			role:           role,
+			expectChainLen: testChainCertsLen,
+			allowedDNS:     testAllowedDNS,
+			unrelatedDNS:   testUnrelatedDNS,
+		},
+	}
+}
+
+// requireAllPassed fails the test unless the report contains exactly the checks
+// expected for its role and all of them passed.
+func requireAllPassed(t *testing.T, got report.Report) {
+	t.Helper()
+
+	want := report.ExpectedChecks(got.Role)
+	if names := got.CheckNames(); !slices.Equal(names, want) {
+		t.Fatalf("checks = %v, want %v\n%s", names, want, got)
+	}
+	if failed := got.Failures(); len(failed) > 0 {
+		t.Fatalf("%d checks failed\n%s", len(failed), got)
+	}
+}
+
+// requireFailed fails the test unless the named check is present and failed.
+func requireFailed(t *testing.T, got report.Report, name string) {
+	t.Helper()
+
+	for _, check := range got.Checks {
+		if check.Name != name {
+			continue
+		}
+		if check.OK {
+			t.Fatalf("check %s passed, want failure\n%s", name, got)
+		}
+		return
+	}
+	t.Fatalf("check %s was not recorded\n%s", name, got)
+}
+
+func TestProbeServerRolePasses(t *testing.T) {
+	f := newFixture(t, report.RoleServer)
+
+	got := probe(f.cfg)
+	requireAllPassed(t, got)
+
+	if want := []string{testAllowedDNS}; !slices.Equal(got.Facts.LeafDNSNames, want) {
+		t.Errorf("leaf DNS names = %v, want %v", got.Facts.LeafDNSNames, want)
+	}
+	if want := []string{"serverAuth"}; !slices.Equal(got.Facts.LeafExtKeyUsage, want) {
+		t.Errorf("leaf EKU = %v, want %v", got.Facts.LeafExtKeyUsage, want)
+	}
+	if len(got.Facts.ChainSHA256) != testChainCertsLen {
+		t.Errorf("chain fingerprints = %v, want %d entries", got.Facts.ChainSHA256, testChainCertsLen)
+	}
+	if got.Facts.ChainSHA256[0] != fingerprint(f.leaf) {
+		t.Errorf("leaf fingerprint = %s, want %s", got.Facts.ChainSHA256[0], fingerprint(f.leaf))
+	}
+	if want := []string{fingerprint(f.ca.Cert)}; !slices.Equal(got.Facts.TrustSHA256, want) {
+		t.Errorf("trust fingerprints = %v, want %v", got.Facts.TrustSHA256, want)
+	}
+	if want := []string{"PRIVATE KEY", "CERTIFICATE", "CERTIFICATE"}; !slices.Equal(got.Facts.Bundle.BlockTypes, want) {
+		t.Errorf("bundle block types = %v, want %v", got.Facts.Bundle.BlockTypes, want)
+	}
+}
+
+func TestProbeClientRolePasses(t *testing.T) {
+	f := newFixture(t, report.RoleClient)
+
+	got := probe(f.cfg)
+	requireAllPassed(t, got)
+
+	if want := []string{"clientAuth"}; !slices.Equal(got.Facts.LeafExtKeyUsage, want) {
+		t.Errorf("leaf EKU = %v, want %v", got.Facts.LeafExtKeyUsage, want)
+	}
+}
+
+// A serverAuth-only certificate must be refused for client authentication, and
+// a clientAuth-only one for server authentication. Both are asserted by the
+// role fixtures above; this test pins the classification itself, so a future
+// Go release that stops reporting IncompatibleUsage cannot turn the negative
+// checks into ones that pass for the wrong reason.
+func TestRoleRejectionsAreClassified(t *testing.T) {
+	server := probe(newFixture(t, report.RoleServer).cfg)
+	clientAuthRejected := detail(t, server, report.CheckTLSClientAuthRejected)
+	if !strings.Contains(clientAuthRejected, "incompatible key usage") {
+		t.Errorf("client-auth rejection detail = %q, want an incompatible key usage error", clientAuthRejected)
+	}
+
+	client := probe(newFixture(t, report.RoleClient).cfg)
+	serverRoleRejected := detail(t, client, report.CheckTLSServerRoleRejected)
+	if !strings.Contains(serverRoleRejected, "incompatible key usage") {
+		t.Errorf("server-role rejection detail = %q, want an incompatible key usage error", serverRoleRejected)
+	}
+
+	unrelated := detail(t, server, report.CheckTLSServerUnrelatedDNS)
+	if !strings.Contains(unrelated, testUnrelatedDNS) {
+		t.Errorf("unrelated-name detail = %q, want it to name %q", unrelated, testUnrelatedDNS)
+	}
+}
+
+func TestProbeDetectsKeyNotMatchingLeaf(t *testing.T) {
+	f := newFixture(t, report.RoleServer)
+
+	// Replace the bundle's key with one belonging to nobody in the chain.
+	otherKey, _ := issueLeaf(t, f.ca, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, []string{testAllowedDNS})
+	dir := t.TempDir()
+	f.cfg.bundlePath = writeBundle(t, dir, otherKey, f.leaf, f.ca.Cert)
+
+	requireFailed(t, probe(f.cfg), report.CheckBundleKeyMatchesLeaf)
+}
+
+func TestProbeDetectsUnexpectedBundleBlock(t *testing.T) {
+	f := newFixture(t, report.RoleServer)
+
+	extra := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("extra")})
+	f.cfg.bundlePath = writeRawBundle(t, append(readBundle(t, f.cfg.bundlePath), extra...))
+
+	requireFailed(t, probe(f.cfg), report.CheckBundleBlocks)
+}
+
+func TestProbeDetectsTrailingGarbageInBundle(t *testing.T) {
+	f := newFixture(t, report.RoleServer)
+
+	// A truncated PEM block is what a non-atomic projection update would leave
+	// behind, and it must not read as a valid bundle.
+	truncated := []byte("-----BEGIN CERTIFICATE-----\nAAAA\n")
+	f.cfg.bundlePath = writeRawBundle(t, append(readBundle(t, f.cfg.bundlePath), truncated...))
+
+	requireFailed(t, probe(f.cfg), report.CheckBundleBlocks)
+}
+
+func TestProbeDetectsNonCATrustAnchor(t *testing.T) {
+	f := newFixture(t, report.RoleServer)
+
+	nonCA, err := testutil.NewNonCA("credprobe-not-a-ca", testCALifetime)
+	if err != nil {
+		t.Fatalf("generate non-CA: %v", err)
+	}
+	f.cfg.trustPath = writeTrust(t, t.TempDir(), f.ca.Cert, nonCA.Cert)
+
+	requireFailed(t, probe(f.cfg), report.CheckTrustOnlyCAs)
+}
+
+func TestProbeDetectsUntrustedIssuer(t *testing.T) {
+	f := newFixture(t, report.RoleServer)
+
+	otherCA, err := testutil.NewCA("credprobe-other-ca", testCALifetime)
+	if err != nil {
+		t.Fatalf("generate CA: %v", err)
+	}
+	f.cfg.trustPath = writeTrust(t, t.TempDir(), otherCA.Cert)
+
+	requireFailed(t, probe(f.cfg), report.CheckTrustVerifiesLeaf)
+}
+
+func TestProbeDetectsMissingBundle(t *testing.T) {
+	f := newFixture(t, report.RoleServer)
+	f.cfg.bundlePath = filepath.Join(t.TempDir(), "absent.pem")
+
+	requireFailed(t, probe(f.cfg), report.CheckBundleFile)
+}
+
+// The probe holds the workload's private key and must never publish it. This
+// pins that: the encoded report may not contain a PEM key block, nor the key's
+// own bytes. The block *type* "PRIVATE KEY" does appear, in the list of block
+// types the bundle carried - that is a description of the file's structure and
+// is exactly what the suite asserts on.
+func TestReportCarriesNoPrivateKeyMaterial(t *testing.T) {
+	ca, err := testutil.NewCA("credprobe-test-ca", testCALifetime)
+	if err != nil {
+		t.Fatalf("generate CA: %v", err)
+	}
+	key, leaf := issueLeaf(t, ca, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, []string{testAllowedDNS})
+
+	dir := t.TempDir()
+	cfg := config{
+		bundlePath:     writeBundle(t, dir, key, leaf, ca.Cert),
+		trustPath:      writeTrust(t, dir, ca.Cert),
+		role:           report.RoleServer,
+		expectChainLen: testChainCertsLen,
+		allowedDNS:     testAllowedDNS,
+		unrelatedDNS:   testUnrelatedDNS,
+	}
+
+	encoded, err := json.Marshal(probe(cfg))
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	if strings.Contains(string(encoded), "-----BEGIN") {
+		t.Errorf("the report carries a PEM block: %s", encoded)
+	}
+	if bytes.Contains(encoded, key.Seed()) {
+		t.Error("the report contains the private key seed")
+	}
+	if bytes.Contains(encoded, []byte(key)) {
+		t.Error("the report contains the private key bytes")
+	}
+}
+
+// The report travels as one line of a pod log, so parsing must survive
+// whatever else the runtime wrote around it.
+func TestParseReportFromLog(t *testing.T) {
+	f := newFixture(t, report.RoleServer)
+	encoded, err := json.Marshal(probe(f.cfg))
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+
+	log := strings.Join([]string{
+		"some unrelated runtime line",
+		report.Prefix + string(encoded),
+		"a trailing line",
+		"",
+	}, "\n")
+
+	parsed, err := report.Parse(log)
+	if err != nil {
+		t.Fatalf("parse report: %v", err)
+	}
+	requireAllPassed(t, parsed)
+
+	if _, err := report.Parse("no report here\n"); err == nil {
+		t.Error("parsing a log without a report must fail")
+	}
+}
+
+// detail returns the detail of the named check, failing when it is absent.
+func detail(t *testing.T, got report.Report, name string) string {
+	t.Helper()
+
+	for _, check := range got.Checks {
+		if check.Name == name {
+			if !check.OK {
+				t.Fatalf("check %s failed\n%s", name, got)
+			}
+			return check.Detail
+		}
+	}
+	t.Fatalf("check %s was not recorded\n%s", name, got)
+	return ""
+}

--- a/test/credprobe/report/report.go
+++ b/test/credprobe/report/report.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package report defines the wire format the in-cluster credential probe
+// (test/credprobe) writes and the e2e suite reads.
+//
+// It exists so the two halves cannot drift: the probe runs as its own binary in
+// its own image, the suite decodes what the pod logged, and a renamed check or
+// a retyped fact is a compile error rather than a silently unmatched string.
+//
+// Nothing here may carry private key material. The probe is the only component
+// in the suite that holds the workload's private key, and everything it reports
+// about that key is derived and public: fingerprints of certificates, PEM block
+// *types*, sizes, and booleans. See the e2e suite's diagnostics_test.go for the
+// same rule applied to the failure dump.
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Prefix marks the single line of JSON the probe writes to stdout. The suite
+// takes the last line of the pod log carrying this prefix, so a runtime message
+// on stdout or stderr can never be mistaken for the report.
+const Prefix = "CREDPROBE-REPORT "
+
+// Roles the probe can be run in. The role is the EKU the projected certificate
+// was issued with, and it selects which TLS checks are meaningful: a
+// serverAuth-only certificate cannot be asserted to succeed as a client, and a
+// clientAuth-only one cannot be asserted to succeed as a server.
+const (
+	RoleServer = "server"
+	RoleClient = "client"
+)
+
+// Check names. The suite asserts on the exact set for a role, so a check that
+// fails to run is as visible as one that fails.
+const (
+	// CheckBundleFile covers the credential bundle as a file: present,
+	// non-empty and readable by the (non-root) user the container runs as.
+	CheckBundleFile = "bundle.file"
+
+	// CheckBundleBlocks covers the bundle's PEM structure: exactly one private
+	// key block, first, followed by the expected number of certificates and
+	// nothing else.
+	CheckBundleBlocks = "bundle.blocks"
+
+	// CheckBundleKeyMatchesLeaf proves the projected private key belongs to the
+	// projected leaf certificate.
+	CheckBundleKeyMatchesLeaf = "bundle.keyMatchesLeaf"
+
+	// CheckTrustFile covers the projected ClusterTrustBundle as a file.
+	CheckTrustFile = "trust.file"
+
+	// CheckTrustOnlyCAs proves the trust anchors are certificates, and are all
+	// CA certificates - an end-entity certificate in a trust store is a trust
+	// bug, not a formatting one.
+	CheckTrustOnlyCAs = "trust.onlyCAs"
+
+	// CheckTrustVerifiesLeaf proves the projected leaf chains to the projected
+	// trust anchors.
+	CheckTrustVerifiesLeaf = "trust.verifiesLeaf"
+
+	// CheckTLSServerAllowedDNS proves a real TLS handshake succeeds when the
+	// peer verifies the projected certificate against the projected trust
+	// anchors for a DNS name the certificate carries.
+	CheckTLSServerAllowedDNS = "tls.server.allowedDNS"
+
+	// CheckTLSServerUnrelatedDNS proves the same handshake fails, with a
+	// hostname error specifically, for a name the certificate does not carry.
+	CheckTLSServerUnrelatedDNS = "tls.server.unrelatedDNS"
+
+	// CheckTLSClientAuthRejected proves a serverAuth-only certificate is
+	// refused when presented for client authentication, with an incompatible
+	// key usage error specifically.
+	CheckTLSClientAuthRejected = "tls.clientAuth.rejectsServerOnlyCert"
+
+	// CheckTLSClientAuthAccepted proves a clientAuth certificate is accepted by
+	// a server that requires and verifies client certificates.
+	CheckTLSClientAuthAccepted = "tls.clientAuth.acceptsClientCert"
+
+	// CheckTLSServerRoleRejected proves a clientAuth-only certificate is
+	// refused when presented as a server certificate.
+	CheckTLSServerRoleRejected = "tls.server.rejectsClientOnlyCert"
+)
+
+// ExpectedChecks returns the checks a report for the given role must contain,
+// in the order the probe runs them.
+func ExpectedChecks(role string) []string {
+	common := []string{
+		CheckBundleFile,
+		CheckBundleBlocks,
+		CheckBundleKeyMatchesLeaf,
+		CheckTrustFile,
+		CheckTrustOnlyCAs,
+		CheckTrustVerifiesLeaf,
+	}
+	if role == RoleClient {
+		return append(common, CheckTLSClientAuthAccepted, CheckTLSServerRoleRejected)
+	}
+	return append(common,
+		CheckTLSServerAllowedDNS,
+		CheckTLSServerUnrelatedDNS,
+		CheckTLSClientAuthRejected)
+}
+
+// Check is one assertion the probe made about the projected credential.
+type Check struct {
+	Name string `json:"name"`
+	OK   bool   `json:"ok"`
+	// Detail states what was observed, whether the check passed or failed, so a
+	// red run needs no second run to explain itself.
+	Detail string `json:"detail"`
+}
+
+// FileFacts is what the probe observed about a projected file. The mode and
+// ownership are reported rather than asserted: whether kubelet chowns a
+// projected credential to the container's user is kubelet's contract, not this
+// signer's, and recording it makes a change visible without pinning it.
+type FileFacts struct {
+	Path       string   `json:"path"`
+	Mode       string   `json:"mode"`
+	UID        uint32   `json:"uid"`
+	GID        uint32   `json:"gid"`
+	Size       int64    `json:"size"`
+	BlockTypes []string `json:"blockTypes"`
+}
+
+// Facts are the observations the probe made. They are what lets the suite judge
+// properties the probe cannot know on its own - that the projected leaf is the
+// one the PodCertificateRequest status published, that the projected trust
+// anchors are the ones the ClusterTrustBundle carries - and what makes a failed
+// check readable.
+type Facts struct {
+	// ProcessUID is the uid the probe ran as, so "readable" is qualified by who
+	// read it.
+	ProcessUID int `json:"processUid"`
+
+	Bundle FileFacts `json:"bundle"`
+	Trust  FileFacts `json:"trust"`
+
+	// ChainSHA256 are the SHA-256 fingerprints of the bundle's certificates in
+	// order, leaf first.
+	ChainSHA256 []string `json:"chainSha256"`
+	// TrustSHA256 are the SHA-256 fingerprints of the trust anchors in order.
+	TrustSHA256 []string `json:"trustSha256"`
+
+	LeafSubject     string   `json:"leafSubject"`
+	LeafDNSNames    []string `json:"leafDnsNames"`
+	LeafIPAddresses []string `json:"leafIpAddresses"`
+	LeafURIs        []string `json:"leafUris"`
+	LeafExtKeyUsage []string `json:"leafExtKeyUsage"`
+	LeafNotBefore   string   `json:"leafNotBefore"`
+	LeafNotAfter    string   `json:"leafNotAfter"`
+	// LeafKeyAlgorithm is the public key algorithm of the projected leaf, e.g.
+	// Ed25519.
+	LeafKeyAlgorithm string `json:"leafKeyAlgorithm"`
+}
+
+// Report is the probe's whole output.
+type Report struct {
+	Role   string  `json:"role"`
+	Checks []Check `json:"checks"`
+	Facts  Facts   `json:"facts"`
+}
+
+// Failures returns the checks that did not pass.
+func (r Report) Failures() []Check {
+	var failed []Check
+	for _, check := range r.Checks {
+		if !check.OK {
+			failed = append(failed, check)
+		}
+	}
+	return failed
+}
+
+// CheckNames returns the names of every check in the report, in order.
+func (r Report) CheckNames() []string {
+	names := make([]string, 0, len(r.Checks))
+	for _, check := range r.Checks {
+		names = append(names, check.Name)
+	}
+	return names
+}
+
+// String renders the report for a test failure message: every check with its
+// detail, then the facts as JSON.
+func (r Report) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "credprobe report (role %s):\n", r.Role)
+	for _, check := range r.Checks {
+		status := "PASS"
+		if !check.OK {
+			status = "FAIL"
+		}
+		fmt.Fprintf(&b, "  [%s] %s: %s\n", status, check.Name, check.Detail)
+	}
+	facts, err := json.MarshalIndent(r.Facts, "  ", "  ")
+	if err != nil {
+		fmt.Fprintf(&b, "  facts: unavailable (%v)\n", err)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "  facts: %s\n", facts)
+	return b.String()
+}
+
+// Parse extracts the report from a pod log.
+//
+// It takes the last prefixed line rather than the first so a probe that somehow
+// reported twice is read at its latest state, and returns an error naming what
+// it saw when there is no report at all - a probe that crashed before reporting
+// must not look like a probe that reported nothing.
+func Parse(log string) (Report, error) {
+	var line string
+	for _, candidate := range strings.Split(log, "\n") {
+		if idx := strings.Index(candidate, Prefix); idx >= 0 {
+			line = candidate[idx+len(Prefix):]
+		}
+	}
+	if line == "" {
+		return Report{}, fmt.Errorf("no %q line in the probe log", strings.TrimSpace(Prefix))
+	}
+
+	var parsed Report
+	if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+		return Report{}, fmt.Errorf("decoding the probe report: %w", err)
+	}
+	return parsed, nil
+}

--- a/test/credprobe/tls.go
+++ b/test/credprobe/tls.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+)
+
+// The TLS checks are the point of running in-cluster at all. A credential that
+// parses is not a credential that works: the questions that matter are whether
+// a peer verifying the projected trust anchors accepts the projected
+// certificate for a name it is supposed to have, refuses it for a name it is
+// not, and refuses it outright in a role its extended key usage does not
+// permit. Each of those is answered by a real TLS 1.3 handshake over a loopback
+// socket, not by inspecting fields.
+//
+// TLS 1.3 is pinned at both ends so the observations are stable. It also moves
+// client-certificate verification entirely to the server side of the
+// handshake - the client's Handshake returns before the server has judged its
+// certificate - which is why every client-authentication assertion below reads
+// the *server's* error and not the client's.
+
+const (
+	// handshakeTimeout bounds every socket operation, so a check that cannot
+	// complete fails the run instead of hanging the pod.
+	handshakeTimeout = 10 * time.Second
+
+	// handshakePayload is written by the server after a successful handshake
+	// and read back by the client, so a passing check proves a usable session
+	// rather than a completed handshake.
+	handshakePayload = "credprobe-ok"
+)
+
+// handshakeResult is what one handshake attempt observed from both ends.
+type handshakeResult struct {
+	serverErr error
+	clientErr error
+
+	// clientPeers are the certificates the server received from the client.
+	clientPeers []*x509.Certificate
+
+	// payload is what the client managed to read over the established session.
+	payload string
+}
+
+// String renders the result for a check detail.
+func (h handshakeResult) String() string {
+	return fmt.Sprintf("server error: %v; client error: %v", h.serverErr, h.clientErr)
+}
+
+// handshake runs one TLS handshake between the two configurations over a
+// loopback TCP connection and reports what each end saw.
+func handshake(serverCfg, clientCfg *tls.Config) handshakeResult {
+	var result handshakeResult
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		result.serverErr = fmt.Errorf("listen: %w", err)
+		return result
+	}
+	defer func() { _ = listener.Close() }()
+	if tcp, ok := listener.(*net.TCPListener); ok {
+		// Bounds Accept, so a client that never connects cannot wedge the
+		// goroutine below.
+		_ = tcp.SetDeadline(time.Now().Add(handshakeTimeout))
+	}
+
+	type serverOutcome struct {
+		err   error
+		peers []*x509.Certificate
+	}
+	done := make(chan serverOutcome, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- serverOutcome{err: fmt.Errorf("accept: %w", err)}
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetDeadline(time.Now().Add(handshakeTimeout))
+
+		server := tls.Server(conn, serverCfg)
+		if err := server.Handshake(); err != nil {
+			done <- serverOutcome{err: err}
+			return
+		}
+		peers := server.ConnectionState().PeerCertificates
+		_, err = server.Write([]byte(handshakePayload))
+		done <- serverOutcome{err: err, peers: peers}
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		result.clientErr = fmt.Errorf("dial: %w", err)
+	} else {
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetDeadline(time.Now().Add(handshakeTimeout))
+
+		client := tls.Client(conn, clientCfg)
+		if err := client.Handshake(); err != nil {
+			result.clientErr = err
+		} else {
+			buf := make([]byte, len(handshakePayload))
+			if _, err := io.ReadFull(client, buf); err != nil {
+				// Under TLS 1.3 a server that rejected the client certificate
+				// surfaces here rather than during the handshake.
+				result.clientErr = err
+			} else {
+				result.payload = string(buf)
+			}
+		}
+	}
+
+	outcome := <-done
+	result.serverErr = outcome.err
+	result.clientPeers = outcome.peers
+	return result
+}
+
+// serverConfig serves the given certificate.
+func serverConfig(cert tls.Certificate) *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+		MaxVersion:   tls.VersionTLS13,
+	}
+}
+
+// verifyingClientConfig verifies the peer against the projected trust anchors
+// for the given name, which is what a workload's own client would do.
+func verifyingClientConfig(pool *x509.CertPool, serverName string) *tls.Config {
+	return &tls.Config{
+		RootCAs:    pool,
+		ServerName: serverName,
+		MinVersion: tls.VersionTLS13,
+		MaxVersion: tls.VersionTLS13,
+	}
+}
+
+// checkTLS runs the handshakes that are meaningful for the certificate's role.
+func (r *reporter) checkTLS(cfg config, cert tls.Certificate, pool *x509.CertPool) {
+	if cfg.role == report.RoleClient {
+		r.checkClientAuthAccepted(cert, pool)
+		r.checkServerRoleRejected(cfg, cert, pool)
+		return
+	}
+
+	r.checkServerAllowedDNS(cfg, cert, pool)
+	r.checkServerUnrelatedDNS(cfg, cert, pool)
+	r.checkClientAuthRejected(cfg, cert, pool)
+}
+
+// checkServerAllowedDNS proves the projected credential serves TLS for a name
+// it carries, to a client that trusts only the projected anchors.
+func (r *reporter) checkServerAllowedDNS(cfg config, cert tls.Certificate, pool *x509.CertPool) {
+	result := handshake(serverConfig(cert), verifyingClientConfig(pool, cfg.allowedDNS))
+	if result.serverErr != nil || result.clientErr != nil {
+		r.fail(report.CheckTLSServerAllowedDNS,
+			"a handshake for %q must succeed; %s", cfg.allowedDNS, result)
+		return
+	}
+	if result.payload != handshakePayload {
+		r.fail(report.CheckTLSServerAllowedDNS,
+			"the session for %q carried %q, want %q", cfg.allowedDNS, result.payload, handshakePayload)
+		return
+	}
+	r.pass(report.CheckTLSServerAllowedDNS,
+		"a client trusting only the projected anchors completed a TLS 1.3 session for %q", cfg.allowedDNS)
+}
+
+// checkServerUnrelatedDNS proves the same credential is refused for a name it
+// does not carry, and refused for that reason.
+func (r *reporter) checkServerUnrelatedDNS(cfg config, cert tls.Certificate, pool *x509.CertPool) {
+	result := handshake(serverConfig(cert), verifyingClientConfig(pool, cfg.unrelatedDNS))
+	if !isHostnameError(result.clientErr) {
+		r.fail(report.CheckTLSServerUnrelatedDNS,
+			"a handshake for the unrelated name %q must fail with a hostname error; %s",
+			cfg.unrelatedDNS, result)
+		return
+	}
+	r.pass(report.CheckTLSServerUnrelatedDNS,
+		"the client refused the certificate for the unrelated name %q: %v",
+		cfg.unrelatedDNS, result.clientErr)
+}
+
+// checkClientAuthRejected proves a serverAuth-only credential cannot be used to
+// authenticate as a client.
+//
+// The server here both serves the projected certificate and requires one from
+// the client, so the only thing that changes between this check and the
+// allowed-name check above is the role the certificate is asked to play.
+func (r *reporter) checkClientAuthRejected(cfg config, cert tls.Certificate, pool *x509.CertPool) {
+	serverCfg := serverConfig(cert)
+	serverCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	serverCfg.ClientCAs = pool
+
+	clientCfg := verifyingClientConfig(pool, cfg.allowedDNS)
+	clientCfg.Certificates = []tls.Certificate{cert}
+
+	result := handshake(serverCfg, clientCfg)
+	if !isIncompatibleUsage(result.serverErr) {
+		r.fail(report.CheckTLSClientAuthRejected,
+			"a server-only certificate presented for client authentication must be refused "+
+				"for an incompatible key usage; %s", result)
+		return
+	}
+	r.pass(report.CheckTLSClientAuthRejected,
+		"the server refused the server-only certificate for client authentication: %v", result.serverErr)
+}
+
+// checkClientAuthAccepted proves a clientAuth credential authenticates against
+// a server that requires and verifies client certificates.
+//
+// The counterparty is a throwaway self-signed server certificate generated
+// here: the projected credential is a client certificate and has no server
+// identity to offer, and what is under test is the server's verification of the
+// *client* certificate against the projected trust anchors. The client still
+// verifies its peer properly - against a pool holding exactly that throwaway
+// certificate - so this check turns nothing off.
+func (r *reporter) checkClientAuthAccepted(cert tls.Certificate, pool *x509.CertPool) {
+	peerCert, err := ephemeralServerCertificate()
+	if err != nil {
+		r.fail(report.CheckTLSClientAuthAccepted, "generating the peer server certificate: %v", err)
+		return
+	}
+	peerPool := x509.NewCertPool()
+	peerPool.AddCert(peerCert.Leaf)
+
+	serverCfg := serverConfig(peerCert)
+	serverCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	serverCfg.ClientCAs = pool
+
+	clientCfg := verifyingClientConfig(peerPool, ephemeralPeerName)
+	clientCfg.Certificates = []tls.Certificate{cert}
+
+	result := handshake(serverCfg, clientCfg)
+	if result.serverErr != nil || result.clientErr != nil {
+		r.fail(report.CheckTLSClientAuthAccepted,
+			"a client-auth certificate must be accepted for client authentication; %s", result)
+		return
+	}
+	if len(result.clientPeers) == 0 {
+		r.fail(report.CheckTLSClientAuthAccepted, "the server received no client certificate")
+		return
+	}
+	if got := fingerprint(result.clientPeers[0]); got != fingerprint(cert.Leaf) {
+		r.fail(report.CheckTLSClientAuthAccepted,
+			"the server authenticated a different certificate: got %s, want %s", got, fingerprint(cert.Leaf))
+		return
+	}
+	r.pass(report.CheckTLSClientAuthAccepted,
+		"a server requiring client certificates verified the projected leaf %s against the projected anchors",
+		fingerprint(cert.Leaf))
+}
+
+// checkServerRoleRejected proves a clientAuth-only credential is refused when
+// offered as a server certificate.
+func (r *reporter) checkServerRoleRejected(cfg config, cert tls.Certificate, pool *x509.CertPool) {
+	result := handshake(serverConfig(cert), verifyingClientConfig(pool, cfg.allowedDNS))
+	if !isIncompatibleUsage(result.clientErr) {
+		r.fail(report.CheckTLSServerRoleRejected,
+			"a client-only certificate served for %q must be refused for an incompatible key usage; %s",
+			cfg.allowedDNS, result)
+		return
+	}
+	r.pass(report.CheckTLSServerRoleRejected,
+		"the client refused the client-only certificate served for %q: %v", cfg.allowedDNS, result.clientErr)
+}
+
+// ephemeralPeerName is the identity of the throwaway counterparty.
+const ephemeralPeerName = "credprobe-ephemeral-peer"
+
+// ephemeralServerCertificate returns a throwaway self-signed server
+// certificate, used as the counterparty in the client-authentication check.
+//
+// It is marked as a CA so the client can trust it directly by putting it in a
+// root pool - a self-signed certificate present in Roots verifies as its own
+// chain - which keeps certificate verification switched on at both ends of that
+// handshake.
+func ephemeralServerCertificate() (tls.Certificate, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate serial: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: ephemeralPeerName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		DNSNames:              []string{ephemeralPeerName},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("create certificate: %w", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("parse certificate: %w", err)
+	}
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv, Leaf: leaf}, nil
+}

--- a/test/e2e/credential_conformance_test.go
+++ b/test/e2e/credential_conformance_test.go
@@ -1,0 +1,299 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
+)
+
+// Workload credential conformance.
+//
+// Everything else in this suite reads the PodCertificateRequest status from
+// outside the cluster, which answers "did the signer produce a certificate" and
+// nothing about whether the workload can use it. These specs close that: the
+// workload is the credential probe (test/credprobe), it reads the projected
+// volume as the non-root user the container runs as, and it completes real TLS
+// 1.3 handshakes with the projected key against the projected trust anchors.
+// The suite then judges the probe's report against the request status and the
+// published ClusterTrustBundle, so neither half can grade its own homework.
+//
+// They run under the chart-defaults profile, where nothing is turned on. That
+// is deliberate and is the other gap this file closes: until now the shipped
+// configuration was only ever proven to *deny* (see
+// defineChartDefaultsProfileTests), and nothing showed that an unmodified
+// install hands a workload a usable credential.
+
+// defaultCertificateLifetime is what the signer issues when nothing asks for
+// anything else: podcertificate.DefaultDuration, clamped by the projection's
+// maxExpirationSeconds, which kube-apiserver defaults to the same 24 hours.
+const defaultCertificateLifetime = 24 * time.Hour
+
+// defaultMaxExpirationSeconds is kube-apiserver's default for a podCertificate
+// projection that does not set maxExpirationSeconds. It is asserted rather than
+// assumed: it is the other half of the lifetime above, so if the apiserver
+// default ever moves, this says why the lifetime changed.
+const defaultMaxExpirationSeconds = int32(86400)
+
+// defaultChainLength is how many certificates an issued chain carries: the leaf
+// and the CA that signed it.
+const defaultChainLength = 2
+
+// probeTimeout bounds the wait for the probe to publish its report. It covers
+// pulling nothing (the image is loaded into Kind) but does cover kubelet
+// blocking pod start until the certificate is issued.
+const probeTimeout = 3 * time.Minute
+
+// defineCredentialConformanceTests is called from the chart-defaults install
+// profile, so these specs describe the chart exactly as it ships.
+func defineCredentialConformanceTests() {
+	Context("Workload credential conformance", func() {
+		var trustAnchors []string
+
+		BeforeAll(func() {
+			By("waiting for the signer to publish its ClusterTrustBundle")
+			// The probe pods project the bundle by name, and kubelet blocks pod
+			// start until it exists. Waiting here turns a missing bundle into
+			// one clear failure rather than every spec below timing out on a
+			// pod stuck in ContainerCreating.
+			Eventually(func(g Gomega) {
+				certs := getTrustBundleCertificates(g)
+				g.Expect(certs).NotTo(BeEmpty(), "the trust bundle must carry the current CA")
+				trustAnchors = certificateFingerprints(certs)
+			}).Should(Succeed())
+		})
+
+		It("delivers a usable default credential to a workload that asks for nothing", func() {
+			const podName = "pcs-defaults-credential"
+
+			By("creating a workload pod with no annotations and no feature flags in play")
+			pod := createCertTestPod(certTestPod{
+				name:                   podName,
+				image:                  workloadProbeImage,
+				args:                   probeArgs(podName, report.RoleServer),
+				clusterTrustBundleName: trustBundleName,
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			chain := expectIssued(pod)
+
+			By("verifying the chain is the leaf and its issuing CA")
+			Expect(chain).To(HaveLen(defaultChainLength),
+				"an issued chain must carry the leaf and the CA that signed it")
+			leaf, issuer := chain[0], chain[1]
+			Expect(issuer.IsCA).To(BeTrue(), "the second chain entry must be the issuing CA")
+			Expect(leaf.CheckSignatureFrom(issuer)).To(Succeed(),
+				"the leaf must be signed by the CA it is served with")
+
+			By("verifying the default subject and the two canonical DNS SANs")
+			Expect(leaf.Subject.CommonName).To(Equal(podName),
+				"the default common name is the pod name")
+			Expect(leaf.DNSNames).To(ConsistOf(
+				fmt.Sprintf("%s.%s.pod.cluster.local", podName, workloadNamespace),
+				fmt.Sprintf("%s.%s.svc.cluster.local", podName, workloadNamespace),
+			), "the default SANs are the canonical pod and service DNS forms")
+
+			By("verifying no identity beyond those DNS names was asserted")
+			Expect(leaf.IPAddresses).To(BeEmpty(), "the defaults must add no IP SAN")
+			Expect(leaf.URIs).To(BeEmpty(), "the defaults must add no URI SAN")
+
+			By("verifying the default extended key usage and lifetime")
+			Expect(leaf.ExtKeyUsage).To(ConsistOf(x509.ExtKeyUsageServerAuth),
+				"the default EKU is serverAuth only")
+			Expect(leaf.UnknownExtKeyUsage).To(BeEmpty(),
+				"the defaults must add no extended key usage the suite cannot name")
+			request := getPodCertificateRequest(pod)
+			Expect(request.Spec.MaxExpirationSeconds).NotTo(BeNil(),
+				"kube-apiserver defaults maxExpirationSeconds on the projection")
+			Expect(*request.Spec.MaxExpirationSeconds).To(Equal(defaultMaxExpirationSeconds),
+				"the default lifetime below is the signer default clamped by this")
+			Expect(leaf.NotAfter.Sub(leaf.NotBefore)).To(Equal(defaultCertificateLifetime),
+				"the default certificate lifetime must be exact")
+
+			By("waiting for the pod to run with the projected credential")
+			expectPodRunning(pod)
+
+			By("verifying the workload can read and use the credential it was given")
+			observed := expectProbeReport(pod, report.RoleServer)
+
+			By("verifying the projected chain is the one the request status published")
+			Expect(observed.Facts.ChainSHA256).To(Equal(certificateFingerprints(chain)),
+				"the credential bundle must carry exactly the chain from the request status")
+
+			By("verifying the projected trust anchors are the published ClusterTrustBundle")
+			Expect(observed.Facts.TrustSHA256).To(Equal(trustAnchors),
+				"ca.crt must carry exactly the anchors the signer published")
+			Expect(observed.Facts.TrustSHA256).To(ContainElement(fingerprint(issuer)),
+				"the trust anchors must include the CA that signed the leaf")
+		})
+
+		It("delivers a client-auth credential that works only in the client role", func() {
+			const podName = "pcs-defaults-client-credential"
+
+			By("creating a workload pod requesting a client-auth certificate")
+			// The eku annotation names a key usage, not an identity, so it is
+			// accepted under the chart defaults: no interpolation, and nothing
+			// for the identity allowlist to judge.
+			pod := createCertTestPod(certTestPod{
+				name:                   podName,
+				image:                  workloadProbeImage,
+				args:                   probeArgs(podName, report.RoleClient),
+				clusterTrustBundleName: trustBundleName,
+				userAnnotations:        map[string]string{signerName + "-eku": "client"},
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := expectIssued(pod)[0]
+
+			By("verifying the certificate is restricted to client authentication")
+			Expect(leaf.ExtKeyUsage).To(ConsistOf(x509.ExtKeyUsageClientAuth))
+
+			By("waiting for the pod to run with the projected credential")
+			expectPodRunning(pod)
+
+			By("verifying the credential authenticates as a client and is refused as a server")
+			observed := expectProbeReport(pod, report.RoleClient)
+			Expect(observed.Facts.LeafExtKeyUsage).To(ConsistOf("clientAuth"),
+				"the projected leaf must carry the same restriction as the issued one")
+		})
+	})
+}
+
+// probeArgs configures the credential probe for a pod.
+//
+// The unrelated name is built from the pod's own name under a foreign suffix
+// rather than something arbitrary: the interesting negative is not "a name from
+// another universe is rejected" but "a name that starts like mine is", which is
+// the same exact-match boundary the identity allowlist enforces on the issuing
+// side.
+func probeArgs(podName, role string) []string {
+	return []string{
+		"-role=" + role,
+		fmt.Sprintf("-expect-chain-len=%d", defaultChainLength),
+		fmt.Sprintf("-allowed-dns=%s.%s.pod.cluster.local", podName, workloadNamespace),
+		fmt.Sprintf("-unrelated-dns=%s.%s.pod.attacker.example", podName, workloadNamespace),
+		fmt.Sprintf("-bundle=%s/%s", certTestPodMountPath, defaultCredentialBundlePath),
+		fmt.Sprintf("-trust=%s/ca.crt", certTestPodMountPath),
+	}
+}
+
+// expectProbeReport waits for the probe to publish its report and asserts that
+// it ran every check for its role and passed all of them.
+//
+// The report is the failure message. A red check states what it observed - the
+// PEM block types it found, the fingerprints, the classified TLS error - so a
+// failing run needs no second run to explain itself.
+func expectProbeReport(ref podRef, role string) report.Report {
+	GinkgoHelper()
+
+	var observed report.Report
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "logs", ref.name, "-n", ref.namespace)
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred(),
+			"reading the probe log for pod %s failed; %s", ref, podStatusSummary(ref))
+
+		parsed, err := report.Parse(output)
+		g.Expect(err).NotTo(HaveOccurred(),
+			"the probe for pod %s has not reported: %v; %s; log was: %s",
+			ref, err, podStatusSummary(ref), output)
+		observed = parsed
+	}, probeTimeout).Should(Succeed())
+
+	Expect(observed.Role).To(Equal(role), "the probe reported for the wrong role")
+	Expect(observed.CheckNames()).To(Equal(report.ExpectedChecks(role)),
+		"the probe must run every check for the %s role; a short report means it stopped early\n%s",
+		role, observed)
+	Expect(observed.Failures()).To(BeEmpty(),
+		"the projected credential failed conformance checks\n%s", observed)
+
+	return observed
+}
+
+// expectPodRunning waits for the workload pod to reach Running.
+//
+// For a pod with a podCertificate projection this is an assertion about the
+// signer: kubelet does not start the container until the request is issued and
+// the credential is written, so a pod that never runs is a credential that was
+// never delivered.
+func expectPodRunning(ref podRef) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "get", "pod", ref.name, "-n", ref.namespace,
+			"-o", "jsonpath={.status.phase}")
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(output).To(Equal("Running"),
+			"pod %s must run once kubelet mounts the issued credential; %s", ref, podStatusSummary(ref))
+	}, probeTimeout).Should(Succeed())
+}
+
+// podStatusSummary renders a pod's phase and container states for a failure
+// message. It never asserts: it runs while something else is already failing.
+func podStatusSummary(ref podRef) string {
+	cmd := exec.Command("kubectl", "get", "pod", ref.name, "-n", ref.namespace,
+		"-o", "jsonpath={.status.phase}{\" \"}{.status.containerStatuses[*].state}")
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return fmt.Sprintf("pod status for %s unavailable: %v", ref, err)
+	}
+	return fmt.Sprintf("pod status: %s", strings.TrimSpace(output))
+}
+
+// getPodCertificateRequest returns the request belonging to the pod, for the
+// spec fields expectIssued does not surface.
+func getPodCertificateRequest(ref podRef) *capiv1beta1.PodCertificateRequest {
+	GinkgoHelper()
+
+	var request *capiv1beta1.PodCertificateRequest
+	Eventually(func(g Gomega) {
+		request = findPodCertificateRequest(g, ref)
+	}).Should(Succeed())
+	return request
+}
+
+// certificateFingerprints returns the SHA-256 fingerprints of a chain, in the
+// same encoding the probe reports, so the two can be compared directly.
+func certificateFingerprints(certs []*x509.Certificate) []string {
+	fingerprints := make([]string, 0, len(certs))
+	for _, cert := range certs {
+		fingerprints = append(fingerprints, fingerprint(cert))
+	}
+	return fingerprints
+}
+
+// fingerprint returns the SHA-256 fingerprint of a certificate.
+func fingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(sum[:])
+}

--- a/test/e2e/diagnostics_test.go
+++ b/test/e2e/diagnostics_test.go
@@ -251,6 +251,13 @@ func dumpDiagnostics() {
 
 	By("collecting the workload pods and their certificate requests")
 	dumpKubectl("workload pods", "get", "pods", "-n", workloadNamespace, "-o", "yaml")
+	// The credential probe reports what it saw inside the pod; for a spec that
+	// failed before parsing that report, the raw log is the only place it
+	// exists. Selecting on the suite's own label keeps this to pods these specs
+	// created. The probe publishes fingerprints and block types, never key
+	// material, and the output passes through redactSensitive regardless.
+	dumpKubectl("workload pod logs", "logs", "-l", e2eWorkloadLabel+"=true",
+		"-n", workloadNamespace, "--all-containers=true", "--prefix=true", "--tail=-1")
 	dumpKubectl("pod certificate requests", "get", "podcertificaterequests", "-n", workloadNamespace, "-o", "yaml")
 	dumpKubectl("workload namespace events", "get", "events", "-n", workloadNamespace, "--sort-by=.lastTimestamp")
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -43,6 +43,15 @@ var (
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
 	projectImage = "example.com/pcs:v0.0.1"
+
+	// workloadProbeImage is the in-cluster credential probe the
+	// credential-conformance specs run as their workload (test/credprobe).
+	//
+	// It is built from this repository and loaded into Kind for the same reason
+	// the manager image is: a third-party workload image would have to exist,
+	// and be reachable, on whatever runner executes `make test-e2e`. The value
+	// must match the Makefile's E2E_WORKLOAD_IMAGE default.
+	workloadProbeImage = "example.com/pcs-credprobe:v0.0.1"
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -86,6 +95,15 @@ var _ = BeforeSuite(func() {
 	By("loading the manager(Operator) image on Kind")
 	err = utils.LoadImageToKindClusterWithName(projectImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+
+	By("building the credential probe workload image")
+	cmd = exec.Command("make", "e2e-workload-image", fmt.Sprintf("E2E_WORKLOAD_IMAGE=%s", workloadProbeImage))
+	_, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the credential probe image")
+
+	By("loading the credential probe workload image on Kind")
+	err = utils.LoadImageToKindClusterWithName(workloadProbeImage)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the credential probe image into Kind")
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with CertManager already installed,

--- a/test/e2e/fixtures_test.go
+++ b/test/e2e/fixtures_test.go
@@ -84,7 +84,25 @@ type certTestPod struct {
 	// alongside the podCertificate one so the pod also mounts the signer's
 	// published trust anchors at ca.crt.
 	clusterTrustBundleName string
+
+	// image and args replace the default sleeper container. The
+	// credential-conformance specs point them at the in-cluster probe
+	// (test/credprobe), which is the only workload in the suite that does
+	// anything with the credential it is given; every other spec only needs a
+	// container that stays up long enough for kubelet to project one.
+	image string
+	args  []string
 }
+
+// sleeperImage is the workload container for the specs that only need a pod to
+// exist. It is not the probe: a spec that asserts on the mounted credential
+// must set image explicitly, so "the pod is up" can never be mistaken for
+// "the credential works".
+const sleeperImage = "busybox:1.37"
+
+// e2eWorkloadLabel marks the pods this suite creates, so the failure dump can
+// collect their logs without knowing which spec made them.
+const e2eWorkloadLabel = "e2e.pod-certificate-signer/workload"
 
 // withDefaults returns the fixture with every unset field filled in. The
 // defaults reproduce the pod the string-built helper created, so switching to
@@ -103,7 +121,38 @@ func (p certTestPod) withDefaults() certTestPod {
 	if p.credentialBundlePath == "" {
 		p.credentialBundlePath = defaultCredentialBundlePath
 	}
+	if p.image == "" {
+		p.image = sleeperImage
+		p.args = nil
+	}
 	return p
+}
+
+// container renders the workload container. The sleeper keeps the command it
+// has always had; anything else runs its image's entrypoint with the fixture's
+// arguments, which is how the credential probe is configured.
+func (p certTestPod) container() corev1.Container {
+	container := corev1.Container{
+		Name:  "workload",
+		Image: p.image,
+		Args:  p.args,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr(false),
+			RunAsNonRoot:             ptr(true),
+			RunAsUser:                ptr(int64(65532)),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      "x509",
+			MountPath: certTestPodMountPath,
+			ReadOnly:  true,
+		}},
+	}
+	if p.image == sleeperImage {
+		container.Command = []string{"sleep", "600"}
+	}
+	return container
 }
 
 // build renders the fixture as a typed corev1.Pod.
@@ -134,27 +183,12 @@ func (p certTestPod) build() *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.name,
 			Namespace: p.namespace,
+			Labels:    map[string]string{e2eWorkloadLabel: "true"},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,
 			ServiceAccountName: p.serviceAccountName,
-			Containers: []corev1.Container{{
-				Name:    "sleeper",
-				Image:   "busybox:1.37",
-				Command: []string{"sleep", "600"},
-				SecurityContext: &corev1.SecurityContext{
-					AllowPrivilegeEscalation: ptr(false),
-					RunAsNonRoot:             ptr(true),
-					RunAsUser:                ptr(int64(65532)),
-					Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-					SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-				},
-				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "x509",
-					MountPath: certTestPodMountPath,
-					ReadOnly:  true,
-				}},
-			}},
+			Containers:         []corev1.Container{p.container()},
 			Volumes: []corev1.Volume{{
 				Name: "x509",
 				VolumeSource: corev1.VolumeSource{

--- a/test/e2e/install_profiles_test.go
+++ b/test/e2e/install_profiles_test.go
@@ -308,11 +308,18 @@ func defineVerifiedInterpolationProfileTests() {
 // defineChartDefaultsProfileTests covers the chart exactly as it ships, with no
 // feature flag turned on.
 //
-// It exists for one assertion that no other profile can make: with
-// --enable-annotation-interpolation off, a value containing ${...} is denied
-// outright rather than resolved or issued verbatim. Running that assertion under
-// the verified-interpolation profile would pass for the wrong reason - the value would
-// be rejected by the allowlist rather than by the disabled interpolation gate.
+// It carries both halves of the shipped configuration. The negative is the
+// assertion no other profile can make: with --enable-annotation-interpolation
+// off, a value containing ${...} is denied outright rather than resolved or
+// issued verbatim. Running that assertion under the verified-interpolation
+// profile would pass for the wrong reason - the value would be rejected by the
+// allowlist rather than by the disabled interpolation gate.
+//
+// The positive is defineCredentialConformanceTests
+// (credential_conformance_test.go), which proves an unmodified install hands a
+// workload a credential it can actually use. It belongs here, inside this
+// container, so it runs against the chart defaults without a further Helm
+// upgrade.
 func defineChartDefaultsProfileTests() {
 	Context("Install profile: chart-defaults", func() {
 		BeforeAll(func() {
@@ -334,5 +341,7 @@ func defineChartDefaultsProfileTests() {
 			Expect(denial.Message).To(ContainSubstring("interpolation, which is disabled on this signer"),
 				"the denial must name the disabled flag, not the identity constraint")
 		})
+
+		defineCredentialConformanceTests()
 	})
 }


### PR DESCRIPTION
Stage 2 of the E2E coverage plan: workload credential conformance, on top of the
Stage 1 harness in #98. Test infrastructure only — no signer behaviour changes.

Every existing spec reads a `PodCertificateRequest` status from outside the
cluster. That answers whether the signer produced a certificate and nothing
about whether the workload can use the one kubelet projected for it. It also
left the shipped chart configuration proven only to *deny*: `chart-defaults` had
one spec, the interpolation-disabled denial, and nothing showed that an install
with no feature flag turned on hands a workload a credential that works. (As
elsewhere in the suite, the `chart-defaults` profile pins `replicaCount=1` and
enables the DNS SAN admission policy; neither touches issuance semantics.)

## What changed

**An in-cluster credential probe** (`test/credprobe`). A small Go binary that
runs as the workload pod, reads the projected volume as the non-root user the
container runs as, and reports what it found. Under the `chart-defaults`
profile it checks:

- `credentialbundle.pem` exists, is non-empty and is readable as uid 65532;
- the bundle is exactly one private key block, first, then the expected
  certificates and nothing else — a trailing truncated block fails it;
- the projected private key belongs to the projected leaf;
- `ca.crt` exists, is readable, carries only CA certificates, and verifies the
  leaf.

**Real TLS, not a PEM parse.** The probe completes TLS 1.3 handshakes over a
loopback socket with the projected key and the projected trust anchors:

- verification succeeds for a DNS name the certificate carries;
- verification fails for one it does not — and fails with `x509.HostnameError`
  specifically;
- a server-only certificate offered for client authentication is refused with
  `IncompatibleUsage`;
- a client-only certificate is accepted by a server that requires and verifies
  client certificates, and refused when offered as a server certificate.

The negative cases classify the x509 reason rather than accepting any error. A
handshake that failed because the probe misconfigured its own listener would
otherwise read as proof of a boundary that was never tested. TLS 1.3 is pinned
at both ends, which also moves client-certificate verification entirely to the
server side of the handshake — so every client-authentication assertion reads
the server's error, not the client's.

**The probe reports; the suite judges.** The probe writes one line of JSON
(`test/credprobe/report`, imported by both halves, so a renamed check is a
compile error rather than an unmatched string). It carries observed facts —
certificate fingerprints, PEM block types, file mode and ownership, leaf
fields — and the specs compare those against the request status and the
published ClusterTrustBundle. Neither half grades its own homework: the probe
cannot know what the status published, and the suite cannot see inside the pod.
The report is also the failure message, so a red check states what it observed
without needing a second run.

Nothing derived from the private key is ever reported. A unit test pins that the
encoded report carries no PEM block and none of the key's bytes.

**The image is built from this repository** and loaded into Kind alongside the
manager image (`make e2e-workload-image`, `E2E_WORKLOAD_IMAGE`). A third-party
workload image would have to exist, and be reachable, on whatever runner
executes `make test-e2e`. The Dockerfile shares the manager's pinned base image
digests; refresh them together.

**The probe's logic is unit tested** against synthesized material — key/leaf
mismatch, unexpected and truncated PEM blocks, a non-CA trust anchor, an
untrusted issuer, both role boundaries. Those run in `make test` in
milliseconds, so when the in-cluster probe goes red the fault is in the cluster
or the signer rather than in the probe.

**The chart-default positive case.** With no feature flags and no annotations,
the shipped chart issues a certificate whose common name is the pod name,
whose DNS SANs are exactly the two canonical pod/service forms, whose EKU is
`serverAuth` only and whose lifetime is exactly 24h — with no IP and no URI
SANs. `maxExpirationSeconds` is asserted to be the apiserver's 86400 default
rather than assumed, so if that default ever moves it says why the lifetime
changed. The chain is asserted to be the leaf plus the CA that signed it, and
the leaf's signature is checked against that CA. The interpolation-disabled
denial stays next to it as the negative case.

**Fixture and diagnostics changes.** `certTestPod` gains `image` and `args`, so
a spec that asserts on the mounted credential must name the probe explicitly and
"the pod is up" can never be mistaken for "the credential works". Fixture pods
carry a suite label, and the failure dump collects their logs — for a spec that
failed before parsing the report, the raw log is the only place it exists. It
passes through the existing `redactSensitive` backstop like every other
collector.

## Verification

- `make test-e2e`: **34 of 34 specs passed in 177.6s** (2 new; 32 before), on a
  Kind cluster the target created and tore down.
- `make test`, `make lint`, `make vet-e2e`, `make lint-e2e`: all pass. The probe
  is covered by both the tagged and untagged lint runs.

## Deliberately out of scope

- **Projection refresh atomicity.** Proving projections update with no partial
  PEM needs a refresh or a CA rotation to observe; rotation is Stage 4. The
  probe's bundle check already fails on a truncated trailing block, which is the
  assertion that stage will need.
- **The key-type matrix.** The probe takes the chain length and role as flags
  and reports the leaf's key algorithm, so ED25519/ECDSA/RSA is a table in Stage
  3 rather than another refactor. Only the ED25519 default is exercised here.

## Checklist

- [x] **Exactly one `release/*` label is set** — `release/skip`.
- [x] No `.changes/unreleased/*.yaml` fragment: this is a `release/skip` change.
- [x] The PR title is descriptive.
- [x] `make test` and `make lint` pass locally.
- [x] Tests were added/updated for new behavior.
- [x] Docs — none needed; this is test infrastructure with no user-facing surface.
- [x] No ADR needed; no decision is being made or changed here.
