### PR TITLE
test(e2e): prove key semantics, the identity boundary and lifetime

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -416,6 +416,11 @@ var _ = Describe("Manager", Ordered, Serial, func() {
 		})
 	})
 
+	// The escape hatch is open on this install, so this is where the specs that
+	// bound it belong: what --allow-unverified-identities admits, and what it
+	// still refuses. See escape_hatch_test.go.
+	defineEscapeHatchInvariantTests()
+
 	// Install profiles that re-install the release in place. They run after the
 	// unverified-identities specs above and must stay inside this Describe: its
 	// AfterAll uninstalls the release, so a sibling top-level container would run
@@ -429,6 +434,11 @@ var _ = Describe("Manager", Ordered, Serial, func() {
 	// volume reload against the profile's own issuance specs.
 	defineHonorCSRSANsProfileTests()
 	defineVerifiedInterpolationProfileTests()
+	// Declared between the two profiles it sits between in configuration: it is
+	// verified-interpolation with a different signer.cluster_fqdn, and the
+	// chart-defaults install that follows resets the suffix. See
+	// identity_boundary_test.go for why it is worth its own rollout.
+	defineCustomClusterFQDNProfileTests()
 	defineChartDefaultsProfileTests()
 
 	Context("ClusterTrustBundle", func() {

--- a/test/e2e/escape_hatch_test.go
+++ b/test/e2e/escape_hatch_test.go
@@ -1,0 +1,147 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"crypto/x509"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+)
+
+// Escape-hatch invariants.
+//
+// --allow-unverified-identities lets a pod ask for identities it does not own.
+// That is what it is for, and the specs above it prove it works. What it must
+// not become is a switch that turns off validation in general: with the hatch
+// open, a malformed DNS name is still malformed, an unparseable duration is
+// still unparseable, and an unknown extended key usage is still unknown. This
+// container asserts that the relaxation is scoped to ownership and to nothing
+// else.
+//
+// It runs under the suite's initial unverified-identities install
+// (e2e_test.go), so it adds no Helm upgrade.
+
+// defineEscapeHatchInvariantTests is called from the top-level Describe while
+// the unverified-identities profile is installed.
+func defineEscapeHatchInvariantTests() {
+	Context("Escape-hatch invariants", func() {
+		It("issues literal identities the pod does not own", func() {
+			const podName = "pcs-hatch-literals"
+
+			By("creating a workload pod requesting a name, addresses and a URI belonging to nobody")
+			// Every value here is a literal: no ${...}, nothing derived from the
+			// request, and none of it in the allowlist. Only the open hatch can
+			// issue this certificate, which is what makes it the baseline the
+			// denials below are measured against.
+			pod := applyCertTestPod(podName, map[string]string{
+				signerName + "-cn":     "hatch.example.org",
+				signerName + "-san":    "api.hatch.example.org,web.hatch.example.org",
+				signerName + "-ip-san": "10.96.0.7,2001:db8::7",
+				signerName + "-uris":   "spiffe://attacker.example/ns/foreign/sa/root",
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := expectIssued(pod)[0]
+
+			By("verifying every requested identity was issued verbatim")
+			Expect(leaf.Subject.CommonName).To(Equal("hatch.example.org"))
+			Expect(leaf.DNSNames).To(ConsistOf("api.hatch.example.org", "web.hatch.example.org"))
+			Expect(leaf.IPAddresses).To(HaveLen(2))
+			Expect(leaf.IPAddresses[0].Equal(net.ParseIP("10.96.0.7"))).To(BeTrue(),
+				"the first IP SAN must be the requested IPv4 address, got %v", leaf.IPAddresses[0])
+			Expect(leaf.IPAddresses[1].Equal(net.ParseIP("2001:db8::7"))).To(BeTrue(),
+				"the second IP SAN must be the requested IPv6 address, got %v", leaf.IPAddresses[1])
+			Expect(uriStrings(leaf)).To(ConsistOf("spiffe://attacker.example/ns/foreign/sa/root"))
+
+			By("verifying the hatch changed who may be named, not what else is issued")
+			Expect(leaf.ExtKeyUsage).To(ConsistOf(x509.ExtKeyUsageServerAuth),
+				"the default extended key usage must not change with the hatch open")
+			Expect(leaf.IsCA).To(BeFalse())
+		})
+
+		DescribeTable("still rejects malformed values when the ownership check is off",
+			func(fixture certTestPod, wantMessage string) {
+				By("creating a workload pod requesting a value no configuration can make valid")
+				pod := createCertTestPod(fixture)
+
+				By("waiting for the PodCertificateRequest to be denied")
+				denial := expectDenied(pod, capiv1beta1.PodCertificateRequestConditionInvalidUserConfig)
+				Expect(denial.Message).To(ContainSubstring(wantMessage))
+
+				By("verifying the denial is about the malformed value, not about ownership")
+				Expect(denial.Message).NotTo(ContainSubstring("is not derived from a verified pod identity"),
+					"the ownership check is off; a denial citing it would mean the hatch did not apply")
+			},
+
+			// The DNS SAN goes through the deprecated pod-annotation fallback
+			// rather than the projection. The DNS SAN ValidatingAdmissionPolicy
+			// reads only the projection's userAnnotations and would refuse this
+			// pod at admission, so requesting it there would prove the policy
+			// works - which defineAdmissionPolicyTests already does - and would
+			// never reach the signer's own DNS validation, which is what this
+			// entry is for. When the deprecated pod-annotation path is removed,
+			// this entry needs an install profile with the policy disabled.
+			Entry("a malformed DNS name", certTestPod{
+				name: "pcs-hatch-bad-dns",
+				podAnnotations: map[string]string{
+					signerName + "-san": "not_a_dns_name.example.org",
+				},
+			}, `DNS name "not_a_dns_name.example.org" is invalid`),
+
+			Entry("a malformed IP address", certTestPod{
+				name: "pcs-hatch-bad-ip",
+				userAnnotations: map[string]string{
+					signerName + "-ip-san": "10.96.0.999",
+				},
+			}, `invalid IP address "10.96.0.999"`),
+
+			Entry("a URI with no scheme", certTestPod{
+				name: "pcs-hatch-bad-uri",
+				userAnnotations: map[string]string{
+					signerName + "-uris": "hatch.example.org/workload",
+				},
+			}, "missing scheme"),
+
+			Entry("an unknown extended key usage", certTestPod{
+				name: "pcs-hatch-bad-eku",
+				userAnnotations: map[string]string{
+					signerName + "-eku": "sign-anything",
+				},
+			}, `unknown extended key usage "sign-anything"`),
+
+			Entry("an unparseable duration", certTestPod{
+				name: "pcs-hatch-bad-duration",
+				userAnnotations: map[string]string{
+					signerName + "-duration": "2 hours",
+				},
+			}, `invalid duration "2 hours"`),
+
+			Entry("an unparseable refresh window", certTestPod{
+				name: "pcs-hatch-bad-refresh",
+				userAnnotations: map[string]string{
+					signerName + "-refresh": "soon",
+				},
+			}, `invalid duration "soon"`),
+		)
+	})
+}

--- a/test/e2e/fixtures_test.go
+++ b/test/e2e/fixtures_test.go
@@ -50,10 +50,7 @@ const certTestPodMountPath = "/var/run/x509"
 // instead of a request the apiserver silently admits with the setting ignored.
 //
 // Zero values are filled in by withDefaults, so a spec sets only what it cares
-// about. serviceAccountName, keyType, maxExpirationSeconds and
-// clusterTrustBundleName have no caller in this stage's specs; they exist
-// because the projection exposes them and the credential-conformance and
-// key-type specs that follow need them addressable without another refactor.
+// about.
 type certTestPod struct {
 	// name and namespace identify the pod. namespace defaults to
 	// workloadNamespace.
@@ -79,6 +76,16 @@ type certTestPod struct {
 	// userAnnotations are the signer-scoped annotations the projection carries
 	// into the PodCertificateRequest.
 	userAnnotations map[string]string
+
+	// podAnnotations are annotations on the pod object itself. The signer reads
+	// configuration from the request's unverifiedUserAnnotations first and falls
+	// back to these (a deprecated path, see NewPodCertificateConfig).
+	//
+	// One spec needs that fallback rather than the projection: the DNS SAN
+	// ValidatingAdmissionPolicy inspects only the projection's userAnnotations,
+	// so a malformed SAN requested there never reaches the signer to be judged
+	// by it. See defineEscapeHatchInvariantTests.
+	podAnnotations map[string]string
 
 	// clusterTrustBundleName, when set, adds a clusterTrustBundle projection
 	// alongside the podCertificate one so the pod also mounts the signer's
@@ -181,9 +188,10 @@ func (p certTestPod) build() *corev1.Pod {
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      p.name,
-			Namespace: p.namespace,
-			Labels:    map[string]string{e2eWorkloadLabel: "true"},
+			Name:        p.name,
+			Namespace:   p.namespace,
+			Labels:      map[string]string{e2eWorkloadLabel: "true"},
+			Annotations: p.podAnnotations,
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,
@@ -240,6 +248,27 @@ func createCertTestPod(fixture certTestPod) podRef {
 	})
 
 	return decodePodRef(output)
+}
+
+// dryRunCertTestPod submits the fixture to the apiserver with
+// --dry-run=server and returns kubectl's combined output.
+//
+// Nothing is created: the request is validated, admitted and discarded. That is
+// how a spec asserts on what kube-apiserver itself accepts - which projection
+// key types exist, for instance - without paying for a pod, a
+// PodCertificateRequest and an issuance. It returns the error rather than
+// asserting on it because the interesting cases are the ones the apiserver
+// refuses.
+func dryRunCertTestPod(fixture certTestPod) (string, error) {
+	pod := fixture.build()
+	manifest, err := json.Marshal(pod)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := exec.Command("kubectl", "create", "--dry-run=server", "-f", "-")
+	cmd.Stdin = bytes.NewReader(manifest)
+	return utils.Run(cmd)
 }
 
 // decodePodRef reads the pod the apiserver returned and pins its identity:

--- a/test/e2e/identity_boundary_test.go
+++ b/test/e2e/identity_boundary_test.go
@@ -1,0 +1,339 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
+)
+
+// The identity boundary.
+//
+// This is the security claim the product makes: with the identity allowlist
+// enforced, a pod obtains certificates for the identities it owns and for
+// nothing else, however the request is spelled. These specs run under the
+// verified-interpolation profile, where ${...} resolution is on and the escape
+// hatch is closed - the only configuration in which "the value resolved, and
+// was then refused on its merits" is a distinguishable outcome.
+//
+// Two things shape how the negatives are written.
+//
+// First, a denial that fires for the wrong reason is a false pass. Every
+// non-issuing entry below asserts on the message, not only on the Denied
+// condition, and the entries that exist to prove *ownership* rejected a value
+// also assert that the value had resolved first - a "${" still in the message
+// would mean interpolation failed and the boundary was never consulted.
+//
+// Second, the DNS SAN ValidatingAdmissionPolicy sits in front of the signer and
+// reads only the projection's <signer>-san annotation, where it rejects
+// anything that still contains "${" after substituting the four variables it
+// knows. ${node.name} and ${pod.uid} are not among them, so requesting either
+// as a SAN never reaches the signer at all: the pod is refused at admission.
+// Those cases are therefore requested through the cn annotation, which the
+// policy does not inspect, so the signer is the layer under test. The policy's
+// own behavior is covered by defineAdmissionPolicyTests.
+
+// defineVerifiedIdentityBoundaryTests is called from inside the
+// verified-interpolation install profile container (install_profiles_test.go),
+// so it adds no Helm upgrade of its own.
+func defineVerifiedIdentityBoundaryTests() {
+	Context("Verified identity boundary", func() {
+		It("accepts every identity form derived from the verified request fields", func() {
+			const podName = "pcs-identity-forms"
+
+			By("creating a workload pod requesting each form of its own identity at once")
+			// One certificate rather than one per form: a single foreign value
+			// denies the whole request, so an issued certificate carrying all
+			// seven names is proof that each cleared the allowlist, at the cost
+			// of one pod instead of nine. The denial message names the offending
+			// value, so a regression still says which form broke.
+			pod := applyCertTestPod(podName, map[string]string{
+				signerName + "-cn": "${pod.name}",
+				signerName + "-san": strings.Join([]string{
+					"${pod.name}",
+					"${pod.name}.${pod.namespace}",
+					"${pod.name}.${pod.namespace}.pod",
+					"${pod.name}.${pod.namespace}.svc",
+					"${pod.name}.${pod.namespace}.pod.${cluster.fqdn}",
+					"${pod.name}.${pod.namespace}.svc.${cluster.fqdn}",
+					"${pod.serviceAccountName}.${pod.namespace}",
+				}, ","),
+				signerName + "-uris": strings.Join([]string{
+					"spiffe://${cluster.fqdn}/ns/${pod.namespace}/pod/${pod.name}",
+					"spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}",
+				}, ","),
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := expectIssued(pod)[0]
+
+			By("verifying the common name is the pod's bare name")
+			Expect(leaf.Subject.CommonName).To(Equal(podName))
+
+			By("verifying every canonical DNS form of the pod and its service account was issued")
+			Expect(leaf.DNSNames).To(ConsistOf(
+				podName,
+				fmt.Sprintf("%s.%s", podName, workloadNamespace),
+				fmt.Sprintf("%s.%s.pod", podName, workloadNamespace),
+				fmt.Sprintf("%s.%s.svc", podName, workloadNamespace),
+				fmt.Sprintf("%s.%s.pod.cluster.local", podName, workloadNamespace),
+				fmt.Sprintf("%s.%s.svc.cluster.local", podName, workloadNamespace),
+				// The pod runs as the "default" service account, so its short
+				// DNS form is default.default.
+				fmt.Sprintf("default.%s", workloadNamespace),
+			))
+
+			By("verifying both SPIFFE IDs the pod owns were issued")
+			Expect(uriStrings(leaf)).To(ConsistOf(
+				fmt.Sprintf("spiffe://cluster.local/ns/%s/pod/%s", workloadNamespace, podName),
+				fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/default", workloadNamespace),
+			))
+
+			By("verifying nothing else came along")
+			Expect(leaf.IPAddresses).To(BeEmpty())
+			Expect(leaf.ExtKeyUsage).To(ConsistOf(x509.ExtKeyUsageServerAuth))
+		})
+
+		DescribeTable("denies identities that only resemble ones the pod owns",
+			func(podName string, annotations map[string]string, inspect func(podRef, deniedRequest)) {
+				By("creating a workload pod requesting an identity it cannot prove")
+				pod := applyCertTestPod(podName, annotations)
+
+				By("waiting for the PodCertificateRequest to be denied")
+				// expectDenied also proves the request carries no certificate
+				// and no timestamps, and that the outcome survives another
+				// reconcile - a partially-issued denial would be the worse bug.
+				denial := expectDenied(pod, capiv1beta1.PodCertificateRequestConditionInvalidUserConfig)
+
+				By("verifying the denial names the identity constraint and not something else")
+				inspect(pod, denial)
+			},
+
+			// Resolvable, deliberately unclaimable. ${node.name} and ${pod.uid}
+			// are interpolation variables - they resolve - but neither is an
+			// identity the workload owns: the node belongs to the kubelet, and a
+			// UID identifies nothing. The distinction between "did not parse"
+			// and "parsed and was refused" is the whole point of these two
+			// entries, so both assert the resolved value appears in the message.
+			Entry("the name of the node it happens to run on", "pcs-deny-node-name", map[string]string{
+				signerName + "-cn": "${node.name}",
+			}, func(pod podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring(podNodeName(pod)),
+					"the message must quote the resolved node name, proving interpolation ran")
+				expectOwnershipDenial(denial)
+			}),
+			Entry("its own pod UID", "pcs-deny-pod-uid", map[string]string{
+				signerName + "-cn": "${pod.uid}",
+			}, func(pod podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring(string(pod.uid)),
+					"the message must quote the resolved UID, proving interpolation ran")
+				expectOwnershipDenial(denial)
+			}),
+
+			// Exact-match edges. The allowlist is exact string equality, and
+			// each of these is a way of being nearly equal to something the pod
+			// owns.
+			Entry("a verified name behind an attacker prefix", "pcs-deny-name-prefix", map[string]string{
+				signerName + "-san": "evil.${pod.name}",
+			}, func(pod podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring("evil." + pod.name))
+				expectOwnershipDenial(denial)
+			}),
+			// Requested as a common name, not a SAN: an upper-case DNS SAN
+			// would be refused as malformed DNS, which is a different layer and
+			// would pass this spec for the wrong reason. A common name has no
+			// such syntax rule, so only case sensitivity can deny it.
+			Entry("an upper-case spelling of the pod name", "pcs-deny-case-cn", map[string]string{
+				signerName + "-cn": "PCS-DENY-CASE-CN",
+			}, func(_ podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring("PCS-DENY-CASE-CN"))
+				expectOwnershipDenial(denial)
+			}),
+			Entry("an upper-case service account in a SPIFFE ID", "pcs-deny-case-uri", map[string]string{
+				signerName + "-uris": "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/DEFAULT",
+			}, func(_ podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring("/sa/DEFAULT"))
+				expectOwnershipDenial(denial)
+			}),
+			Entry("a verified name with a trailing dot", "pcs-deny-trailing-dot", map[string]string{
+				signerName + "-cn": "${pod.name}.${pod.namespace}.svc.${cluster.fqdn}.",
+			}, func(pod podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring(
+					fmt.Sprintf("%s.%s.svc.cluster.local.", pod.name, pod.namespace)))
+				expectOwnershipDenial(denial)
+			}),
+
+			// A mixed list must deny the request, not filter it. Silently
+			// dropping the foreign name would issue a certificate the requester
+			// did not ask for and hide that it tried.
+			Entry("one foreign name in an otherwise verified list", "pcs-deny-mixed-list", map[string]string{
+				signerName + "-san": "${pod.name},evil.example.com",
+			}, func(_ podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring("evil.example.com"),
+					"the denial must name the foreign entry")
+				expectOwnershipDenial(denial)
+			}),
+
+			// A URI is compared whole. Neither re-parenting an owned SPIFFE path
+			// under a foreign trust domain nor extending an owned path makes it
+			// an identity the pod owns.
+			Entry("an owned SPIFFE path under a foreign trust domain", "pcs-deny-foreign-td", map[string]string{
+				signerName + "-uris": "spiffe://attacker.example/ns/${pod.namespace}/sa/${pod.serviceAccountName}",
+			}, func(_ podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring("spiffe://attacker.example/"))
+				expectOwnershipDenial(denial)
+			}),
+			Entry("an owned SPIFFE ID with an extra path element", "pcs-deny-uri-extra-path", map[string]string{
+				signerName + "-uris": "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}/extra",
+			}, func(_ podRef, denial deniedRequest) {
+				Expect(denial.Message).To(ContainSubstring("/sa/default/extra"))
+				expectOwnershipDenial(denial)
+			}),
+		)
+	})
+}
+
+// customClusterFQDN is the DNS suffix the profile below configures. It is not
+// cluster.local, which is the point: everything the signer derives must follow
+// the operator's setting rather than a constant.
+const customClusterFQDN = "e2e.internal"
+
+// customClusterFQDNInstallArgs is the verified-interpolation profile with the
+// cluster's DNS suffix changed.
+var customClusterFQDNInstallArgs = verifiedInterpolationInstallArgs +
+	" --set signer.cluster_fqdn=" + customClusterFQDN
+
+// defineCustomClusterFQDNProfileTests proves the identity allowlist and the
+// generated defaults both follow signer.cluster_fqdn.
+//
+// It costs one further `helm upgrade`, which is why it is a container of its
+// own with every FQDN-dependent assertion inside it rather than an option other
+// specs set. It is declared after the verified-interpolation container it
+// derives from and before chart-defaults, whose install resets the suffix.
+func defineCustomClusterFQDNProfileTests() {
+	Context("Install profile: custom-cluster-fqdn", func() {
+		BeforeAll(func() {
+			installProfile(customClusterFQDNInstallArgs)
+		})
+
+		It("derives the default DNS SANs from the configured cluster FQDN", func() {
+			const podName = "pcs-fqdn-defaults"
+
+			By("creating a workload pod that asks for nothing")
+			pod := applyCertTestPod(podName, nil)
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := expectIssued(pod)[0]
+
+			By("verifying the generated SANs carry the configured suffix")
+			Expect(leaf.DNSNames).To(ConsistOf(
+				fmt.Sprintf("%s.%s.pod.%s", podName, workloadNamespace, customClusterFQDN),
+				fmt.Sprintf("%s.%s.svc.%s", podName, workloadNamespace, customClusterFQDN),
+			), "the default SANs must use signer.cluster_fqdn, not a hard-coded cluster.local")
+		})
+
+		It("accepts interpolated identities under the configured cluster FQDN", func() {
+			const podName = "pcs-fqdn-interpolated"
+
+			By("creating a workload pod requesting its identity under ${cluster.fqdn}")
+			pod := applyCertTestPod(podName, map[string]string{
+				signerName + "-san":  "${pod.name}.${pod.namespace}.svc.${cluster.fqdn}",
+				signerName + "-uris": "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}",
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := expectIssued(pod)[0]
+
+			By("verifying the allowlist admitted the identities under the configured suffix")
+			Expect(leaf.DNSNames).To(ConsistOf(
+				fmt.Sprintf("%s.%s.svc.%s", podName, workloadNamespace, customClusterFQDN)))
+			Expect(uriStrings(leaf)).To(ConsistOf(
+				fmt.Sprintf("spiffe://%s/ns/%s/sa/default", customClusterFQDN, workloadNamespace)))
+		})
+
+		It("denies the same identity under a cluster FQDN the signer is not configured with", func() {
+			const podName = "pcs-fqdn-foreign"
+
+			By("creating a workload pod requesting its identity under cluster.local")
+			// Byte-for-byte the name the verified-interpolation profile issues
+			// happily. Only the operator's configuration changed, so this is the
+			// allowlist following it.
+			pod := applyCertTestPod(podName, map[string]string{
+				signerName + "-san": fmt.Sprintf("%s.%s.svc.cluster.local", podName, workloadNamespace),
+			})
+
+			By("waiting for the PodCertificateRequest to be denied")
+			denial := expectDenied(pod, capiv1beta1.PodCertificateRequestConditionInvalidUserConfig)
+			Expect(denial.Message).To(ContainSubstring("svc.cluster.local"))
+			expectOwnershipDenial(denial)
+		})
+	})
+}
+
+// expectOwnershipDenial asserts that a denial was the identity allowlist
+// refusing a value, and not one of the layers in front of it.
+//
+// The reason string cannot make this distinction: a malformed DNS name, an
+// unresolvable placeholder and an unowned identity all record
+// InvalidUserConfig. Only the message can, so the check is positive on the
+// ownership wording and negative on the two failures most likely to be mistaken
+// for it - an unresolved placeholder, and an unknown variable name.
+func expectOwnershipDenial(denial deniedRequest) {
+	GinkgoHelper()
+
+	Expect(denial.Message).To(ContainSubstring("is not derived from a verified pod identity"),
+		"the denial must come from the identity allowlist")
+	Expect(denial.Message).NotTo(ContainSubstring("${"),
+		"the requested value must have been resolved before ownership refused it")
+	Expect(denial.Message).NotTo(ContainSubstring("unknown interpolation variable"),
+		"an unresolvable placeholder is a different denial and must not be mistaken for this one")
+}
+
+// uriStrings renders a certificate's URI SANs for comparison.
+func uriStrings(cert *x509.Certificate) []string {
+	uris := make([]string, 0, len(cert.URIs))
+	for _, uri := range cert.URIs {
+		uris = append(uris, uri.String())
+	}
+	return uris
+}
+
+// podNodeName returns the node the pod was scheduled onto, which is what
+// ${node.name} resolves to for its request.
+func podNodeName(ref podRef) string {
+	GinkgoHelper()
+
+	cmd := exec.Command("kubectl", "get", "pod", ref.name, "-n", ref.namespace,
+		"-o", "jsonpath={.spec.nodeName}")
+	output, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to read the node name for pod %s", ref)
+
+	nodeName := strings.TrimSpace(output)
+	Expect(nodeName).NotTo(BeEmpty(), "pod %s must be scheduled for ${node.name} to resolve", ref)
+	return nodeName
+}

--- a/test/e2e/identity_boundary_test.go
+++ b/test/e2e/identity_boundary_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -295,21 +296,33 @@ func defineCustomClusterFQDNProfileTests() {
 	})
 }
 
+// refusedIdentityPattern extracts the value the allowlist refused from a
+// denial message, which quotes it:
+//
+//	common name "x.example.org" is not derived from a verified pod identity; ...
+//
+// The value has to be read out rather than searched for in the whole message:
+// the message continues with advice that itself mentions ${...} interpolation,
+// so "the message contains no placeholder" is not a statement anything can
+// satisfy. What matters is that the *refused value* carries none.
+var refusedIdentityPattern = regexp.MustCompile(`"([^"]*)" is not derived from a verified pod identity`)
+
 // expectOwnershipDenial asserts that a denial was the identity allowlist
-// refusing a value, and not one of the layers in front of it.
+// refusing a resolved value, and not one of the layers in front of it.
 //
 // The reason string cannot make this distinction: a malformed DNS name, an
 // unresolvable placeholder and an unowned identity all record
-// InvalidUserConfig. Only the message can, so the check is positive on the
-// ownership wording and negative on the two failures most likely to be mistaken
-// for it - an unresolved placeholder, and an unknown variable name.
+// InvalidUserConfig. Only the message can.
 func expectOwnershipDenial(denial deniedRequest) {
 	GinkgoHelper()
 
-	Expect(denial.Message).To(ContainSubstring("is not derived from a verified pod identity"),
-		"the denial must come from the identity allowlist")
-	Expect(denial.Message).NotTo(ContainSubstring("${"),
-		"the requested value must have been resolved before ownership refused it")
+	refused := refusedIdentityPattern.FindStringSubmatch(denial.Message)
+	Expect(refused).To(HaveLen(2),
+		"the denial must come from the identity allowlist, and name the value it refused; message was: %s",
+		denial.Message)
+	Expect(refused[1]).NotTo(ContainSubstring("${"),
+		"the requested value must have been resolved before ownership refused it, but %q still carries a placeholder",
+		refused[1])
 	Expect(denial.Message).NotTo(ContainSubstring("unknown interpolation variable"),
 		"an unresolvable placeholder is a different denial and must not be mistaken for this one")
 }

--- a/test/e2e/install_profiles_test.go
+++ b/test/e2e/install_profiles_test.go
@@ -302,6 +302,13 @@ func defineVerifiedInterpolationProfileTests() {
 			expectRequestEvent(pod, corev1.EventTypeWarning, "DefaultSANSkipped",
 				podName, "DNS label limit")
 		})
+
+		// The exhaustive identity matrix - every form the pod owns, and the
+		// near-misses it does not - lives in identity_boundary_test.go. It
+		// belongs here, inside this container, because this is the only profile
+		// where interpolation resolving and ownership refusing are
+		// distinguishable outcomes.
+		defineVerifiedIdentityBoundaryTests()
 	})
 }
 
@@ -343,5 +350,11 @@ func defineChartDefaultsProfileTests() {
 		})
 
 		defineCredentialConformanceTests()
+
+		// The key-type matrix and the lifetime matrix (key_semantics_test.go)
+		// also belong to the shipped configuration: neither asks for an
+		// identity, so running them here keeps them about the key and the clock
+		// and costs no further Helm upgrade.
+		defineKeyTypeAndLifetimeTests()
 	})
 }

--- a/test/e2e/key_semantics_test.go
+++ b/test/e2e/key_semantics_test.go
@@ -378,8 +378,17 @@ func expectConformantLeaf(
 	Expect(leaf.SerialNumber).NotTo(BeNil())
 	Expect(leaf.SerialNumber.Sign()).To(Equal(1), "a certificate serial number must be positive and non-zero")
 	Expect(leaf.IsCA).To(BeFalse(), "a workload certificate must never be a CA")
-	Expect(leaf.BasicConstraintsValid).To(BeTrue(),
-		"the leaf must assert basic constraints, otherwise IsCA=false is not stated in the certificate")
+	// The signer emits no basicConstraints extension on a leaf at all, which is
+	// why this pins the absence rather than requiring an explicit cA:FALSE.
+	// RFC 5280 6.1.4 makes the absence safe - a certificate without
+	// basicConstraints must not be used to verify signatures on other
+	// certificates, and Go's verifier enforces exactly that - so this is the
+	// behavior as designed, not a gap the spec is papering over. If the signer
+	// ever starts asserting the extension, it must assert cA:FALSE, and this
+	// says so by failing.
+	Expect(leaf.BasicConstraintsValid).To(BeFalse(),
+		"the signer emits leaves without basicConstraints; an extension appearing here must be reviewed, "+
+			"and must carry cA:FALSE")
 
 	By("verifying the key usage matches the key type and the extended key usage the default")
 	Expect(leaf.KeyUsage).To(Equal(want.keyUsage),

--- a/test/e2e/key_semantics_test.go
+++ b/test/e2e/key_semantics_test.go
@@ -1,0 +1,470 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+)
+
+// Key types, certificate semantics and lifetime.
+//
+// These specs run under the chart-defaults install profile, where no feature
+// flag is on and no annotation asks for an identity: what a certificate carries
+// here is what the signer produces from the verified request alone. That keeps
+// the key-type matrix about the key, and the lifetime matrix about the clock,
+// rather than about the identity rules the boundary specs cover separately.
+
+// defaultRefreshBefore is podcertificate.DefaultRefreshBefore: how far ahead of
+// notAfter the signer tells kubelet to start renewing when no refresh
+// annotation asks for something else.
+const defaultRefreshBefore = 15 * time.Minute
+
+// statusTimeTolerance is how far status.beginRefreshAt may sit from the exact
+// notAfter - refreshBefore, and the status timestamps from the certificate's
+// own. Both sides are metav1.Time, which serializes at second resolution, so
+// the arithmetic should be exact; the tolerance states that the assertion is
+// about the relationship and not about sub-second serialization.
+const statusTimeTolerance = time.Second
+
+// projectionKeyType is one row of the key-type matrix.
+type projectionKeyType struct {
+	// keyType is the spelling corev1.PodCertificateProjection.KeyType takes.
+	keyType string
+
+	// algorithm is the public key algorithm the issued leaf must carry, and
+	// probeAlgorithm the same value as the in-pod probe reports it
+	// (x509.PublicKeyAlgorithm.String()).
+	algorithm      x509.PublicKeyAlgorithm
+	probeAlgorithm string
+
+	// curveName is the expected elliptic curve for an ECDSA key ("P-256"),
+	// empty otherwise; rsaBits the expected modulus size for an RSA key, zero
+	// otherwise.
+	curveName string
+	rsaBits   int
+
+	// keyUsage is the exact KeyUsage the certificate must carry. It is stated
+	// per row rather than derived, because the rule under test is precisely
+	// that keyEncipherment appears for RSA key transport and for nothing else.
+	keyUsage x509.KeyUsage
+}
+
+// supportedProjectionKeyTypes is the set of key types a podCertificate
+// projection may request.
+//
+// The set is not the signer's choice: kubelet generates the keypair and
+// kube-apiserver validates the field, so this is Kubernetes' list, taken from
+// the KeyType field documentation in k8s.io/api/core/v1 (v0.36.3, the version
+// this repository builds against). "the key types Kubernetes supports" is
+// asserted rather than trusted - the admission table below submits every one of
+// these to the apiserver, and submits key types that are not on the list and
+// must be refused.
+//
+// RSA2048 is deliberately absent: it is not a value the field accepts.
+var supportedProjectionKeyTypes = []projectionKeyType{
+	{
+		keyType:        "ED25519",
+		algorithm:      x509.Ed25519,
+		probeAlgorithm: "Ed25519",
+		keyUsage:       x509.KeyUsageDigitalSignature,
+	},
+	{
+		keyType:        "ECDSAP256",
+		algorithm:      x509.ECDSA,
+		probeAlgorithm: "ECDSA",
+		curveName:      "P-256",
+		keyUsage:       x509.KeyUsageDigitalSignature,
+	},
+	{
+		keyType:        "ECDSAP384",
+		algorithm:      x509.ECDSA,
+		probeAlgorithm: "ECDSA",
+		curveName:      "P-384",
+		keyUsage:       x509.KeyUsageDigitalSignature,
+	},
+	{
+		keyType:        "ECDSAP521",
+		algorithm:      x509.ECDSA,
+		probeAlgorithm: "ECDSA",
+		curveName:      "P-521",
+		keyUsage:       x509.KeyUsageDigitalSignature,
+	},
+	{
+		keyType:        "RSA3072",
+		algorithm:      x509.RSA,
+		probeAlgorithm: "RSA",
+		rsaBits:        3072,
+		// keyEncipherment is meaningful only for RSA key transport, so it is
+		// the one row set where it must appear.
+		keyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	},
+	{
+		keyType:        "RSA4096",
+		algorithm:      x509.RSA,
+		probeAlgorithm: "RSA",
+		rsaBits:        4096,
+		keyUsage:       x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	},
+}
+
+// defineKeyTypeAndLifetimeTests is called from the chart-defaults install
+// profile (install_profiles_test.go), so nothing here runs with a feature flag
+// on.
+func defineKeyTypeAndLifetimeTests() {
+	Context("Key types and certificate semantics", func() {
+		var trustAnchors []*x509.Certificate
+
+		BeforeAll(func() {
+			By("reading the trust anchors the signer published")
+			// Every leaf below is verified against these, and the probe pods
+			// project the same bundle by name, so a missing bundle is one clear
+			// failure here rather than a chain-verification failure per row.
+			Eventually(func(g Gomega) {
+				certs := getTrustBundleCertificates(g)
+				g.Expect(certs).NotTo(BeEmpty(), "the trust bundle must carry the current CA")
+				trustAnchors = certs
+			}).Should(Succeed())
+		})
+
+		// Server-side dry run, not issuance: this spec is about which key types
+		// the apiserver defines, and it answers that in one admission round trip
+		// per row instead of a pod and a certificate. The rejected rows are the
+		// half that makes the accepted list mean something.
+		DescribeTable("admits exactly the key types the projection defines",
+			func(keyType string, admitted bool) {
+				output, err := dryRunCertTestPod(certTestPod{
+					name:    "pcs-keytype-admission",
+					keyType: keyType,
+				})
+				if admitted {
+					Expect(err).NotTo(HaveOccurred(),
+						"kube-apiserver must accept the documented key type %q: %s", keyType, output)
+					return
+				}
+				Expect(err).To(HaveOccurred(),
+					"kube-apiserver must reject the undefined key type %q: %s", keyType, output)
+				// The exact wording of an apiserver validation message is
+				// version-specific; that it names the field is not.
+				Expect(output).To(ContainSubstring("keyType"),
+					"the rejection must name the offending field")
+			},
+			Entry("ED25519", "ED25519", true),
+			Entry("ECDSAP256", "ECDSAP256", true),
+			Entry("ECDSAP384", "ECDSAP384", true),
+			Entry("ECDSAP521", "ECDSAP521", true),
+			Entry("RSA3072", "RSA3072", true),
+			Entry("RSA4096", "RSA4096", true),
+			// RSA2048 is the interesting negative: it is the size most PKI
+			// tooling defaults to, and it is not a value this field takes.
+			Entry("RSA2048", "RSA2048", false),
+			Entry("RSA1024", "RSA1024", false),
+			Entry("a lower-case spelling of a supported type", "ed25519", false),
+			Entry("a key type that does not exist", "NOTAKEYTYPE", false),
+		)
+
+		DescribeTable("issues a conformant certificate for every supported key type",
+			keyTypeMatrix(func(want projectionKeyType) {
+				podName := "pcs-keytype-" + strings.ToLower(want.keyType)
+
+				By("creating a probe workload requesting a " + want.keyType + " keypair")
+				pod := createCertTestPod(certTestPod{
+					name:                   podName,
+					keyType:                want.keyType,
+					image:                  workloadProbeImage,
+					args:                   probeArgs(podName, report.RoleServer),
+					clusterTrustBundleName: trustBundleName,
+				})
+
+				By("waiting for the PodCertificateRequest to be issued")
+				chain := expectIssued(pod)
+				request := getPodCertificateRequest(pod)
+
+				By("verifying the leaf carries the requested key and the signer's exact defaults")
+				expectConformantLeaf(pod, chain, trustAnchors, want)
+
+				By("verifying the status timestamps describe the certificate that was issued")
+				expectStatusTimes(request, chain[0], defaultRefreshBefore)
+
+				By("waiting for the pod to run with the projected credential")
+				expectPodRunning(pod)
+
+				By("verifying the workload holds a private key that matches the issued leaf")
+				// This is the assertion the suite cannot make from outside: the
+				// probe is the only party holding the private key kubelet
+				// generated, and bundle.keyMatchesLeaf (asserted by
+				// expectProbeReport) is what proves the certificate was issued
+				// for that key and not for some other.
+				observed := expectProbeReport(pod, report.RoleServer)
+				Expect(observed.Facts.LeafKeyAlgorithm).To(Equal(want.probeAlgorithm),
+					"the projected leaf must carry a %s key", want.probeAlgorithm)
+				Expect(observed.Facts.ChainSHA256).To(Equal(certificateFingerprints(chain)),
+					"the projected chain must be the one the request status published, "+
+						"otherwise the assertions above describe a different certificate")
+			})...,
+		)
+
+		It("clamps the default lifetime to the projection's maxExpirationSeconds", func() {
+			const podName = "pcs-duration-clamped"
+			const maxExpiration = 2 * time.Hour
+
+			By("creating a workload pod whose projection caps the lifetime below the signer default")
+			// The signer's own default is 24 hours. Nothing here asks for a
+			// duration, so a 2-hour certificate can only be the clamp.
+			pod := createCertTestPod(certTestPod{
+				name:                 podName,
+				maxExpirationSeconds: ptr(int32(maxExpiration / time.Second)),
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := expectIssued(pod)[0]
+			request := getPodCertificateRequest(pod)
+
+			By("verifying the request carries the cap the projection asked for")
+			Expect(request.Spec.MaxExpirationSeconds).NotTo(BeNil())
+			Expect(*request.Spec.MaxExpirationSeconds).To(Equal(int32(maxExpiration/time.Second)),
+				"kubelet must copy maxExpirationSeconds onto the request verbatim")
+
+			By("verifying the certificate lifetime is the cap, not the signer default")
+			Expect(leaf.NotAfter.Sub(leaf.NotBefore)).To(Equal(maxExpiration))
+			Expect(leaf.NotAfter.Sub(leaf.NotBefore)).To(BeNumerically("<", defaultCertificateLifetime),
+				"a clamped lifetime must be shorter than the unclamped default, or this proves nothing")
+
+			By("verifying the status timestamps describe the certificate that was issued")
+			expectStatusTimes(request, leaf, defaultRefreshBefore)
+		})
+
+		It("issues the requested duration and refresh window", func() {
+			const podName = "pcs-duration-explicit"
+			const duration = 4 * time.Hour
+			const refreshBefore = 90 * time.Minute
+
+			By("creating a workload pod requesting an explicit lifetime and refresh window")
+			pod := applyCertTestPod(podName, map[string]string{
+				signerName + "-duration": duration.String(),
+				signerName + "-refresh":  refreshBefore.String(),
+			})
+
+			By("waiting for the PodCertificateRequest to be issued")
+			leaf := expectIssued(pod)[0]
+			request := getPodCertificateRequest(pod)
+
+			By("verifying the certificate lifetime is exactly what was asked for")
+			Expect(leaf.NotAfter.Sub(leaf.NotBefore)).To(Equal(duration))
+
+			By("verifying beginRefreshAt is notAfter minus the requested refresh window")
+			expectStatusTimes(request, leaf, refreshBefore)
+		})
+
+		DescribeTable("denies a lifetime kube-apiserver would refuse on the status subresource",
+			func(podName string, annotations map[string]string, wantMessage string) {
+				By("creating a workload pod requesting an unusable lifetime")
+				// These are validated before signing rather than discovered when
+				// the status write is rejected: a rejected write is a requeue
+				// loop, a denial is an answer.
+				pod := applyCertTestPod(podName, annotations)
+
+				By("waiting for the PodCertificateRequest to be denied")
+				denial := expectDenied(pod, capiv1beta1.PodCertificateRequestConditionInvalidUserConfig)
+				Expect(denial.Message).To(ContainSubstring(wantMessage))
+			},
+			// maxExpirationSeconds is unset, so kube-apiserver's 24-hour default
+			// is the cap this exceeds.
+			Entry("a duration above the projection maximum", "pcs-duration-over-max", map[string]string{
+				signerName + "-duration": "48h",
+			}, "exceeds the maxExpirationSeconds of the request"),
+			Entry("a duration below the API minimum", "pcs-duration-under-min", map[string]string{
+				signerName + "-duration": "30m",
+			}, "must be at least 1h0m0s"),
+			// kube-apiserver requires beginRefreshAt to sit at least 10 minutes
+			// inside both ends of the validity window.
+			Entry("a refresh window inside the API margin", "pcs-refresh-too-small", map[string]string{
+				signerName + "-refresh": "5m",
+			}, "must be at least 10m0s"),
+			Entry("a refresh window reaching past notBefore", "pcs-refresh-too-large", map[string]string{
+				signerName + "-refresh": "23h55m",
+			}, "must not exceed the certificate duration"),
+		)
+	})
+}
+
+// keyTypeMatrix renders the spec body and one entry per supported key type as
+// the arguments DescribeTable takes.
+//
+// It is assembled rather than hand-written because DescribeTable's parameter is
+// ...any, so a []TableEntry cannot be spread after the body function - and a
+// hand-written row per key type is exactly the kind of list that drifts away
+// from supportedProjectionKeyTypes above.
+func keyTypeMatrix(body func(projectionKeyType)) []any {
+	args := make([]any, 0, len(supportedProjectionKeyTypes)+1)
+	args = append(args, body)
+	for _, keyType := range supportedProjectionKeyTypes {
+		args = append(args, Entry(keyType.keyType, keyType))
+	}
+	return args
+}
+
+// expectConformantLeaf asserts everything the signer must get right about an
+// issued leaf that was requested with no annotations: the key it was issued
+// for, that it is an end-entity certificate and not a CA, its exact usage, its
+// exact identity, and that it chains to the published trust anchors.
+//
+// It is one helper rather than a helper per property because these hold
+// together: a certificate that is correct in its key and wrong in its basic
+// constraints is not a partially conformant certificate, it is a CA the
+// workload was handed.
+func expectConformantLeaf(
+	ref podRef,
+	chain []*x509.Certificate,
+	trustAnchors []*x509.Certificate,
+	want projectionKeyType,
+) {
+	GinkgoHelper()
+
+	Expect(chain).To(HaveLen(defaultChainLength),
+		"an issued chain must carry the leaf and the CA that signed it")
+	leaf, issuer := chain[0], chain[1]
+
+	By("verifying the leaf carries the requested public key")
+	Expect(leaf.PublicKeyAlgorithm).To(Equal(want.algorithm))
+	switch want.algorithm {
+	case x509.Ed25519:
+		key, ok := leaf.PublicKey.(ed25519.PublicKey)
+		Expect(ok).To(BeTrue(), "an ED25519 request must yield an Ed25519 public key, got %T", leaf.PublicKey)
+		Expect(key).To(HaveLen(ed25519.PublicKeySize))
+	case x509.ECDSA:
+		key, ok := leaf.PublicKey.(*ecdsa.PublicKey)
+		Expect(ok).To(BeTrue(), "an ECDSA request must yield an ECDSA public key, got %T", leaf.PublicKey)
+		Expect(key.Curve.Params().Name).To(Equal(want.curveName),
+			"the certificate must carry the curve the projection requested")
+	case x509.RSA:
+		key, ok := leaf.PublicKey.(*rsa.PublicKey)
+		Expect(ok).To(BeTrue(), "an RSA request must yield an RSA public key, got %T", leaf.PublicKey)
+		Expect(key.N.BitLen()).To(Equal(want.rsaBits),
+			"the certificate must carry the modulus size the projection requested")
+	default:
+		Fail(fmt.Sprintf("unhandled public key algorithm %s in the key-type matrix", want.algorithm))
+	}
+
+	By("verifying the leaf is an end-entity certificate")
+	Expect(leaf.SerialNumber).NotTo(BeNil())
+	Expect(leaf.SerialNumber.Sign()).To(Equal(1), "a certificate serial number must be positive and non-zero")
+	Expect(leaf.IsCA).To(BeFalse(), "a workload certificate must never be a CA")
+	Expect(leaf.BasicConstraintsValid).To(BeTrue(),
+		"the leaf must assert basic constraints, otherwise IsCA=false is not stated in the certificate")
+
+	By("verifying the key usage matches the key type and the extended key usage the default")
+	Expect(leaf.KeyUsage).To(Equal(want.keyUsage),
+		"key usage must be exactly %d for a %s key, got %d", want.keyUsage, want.keyType, leaf.KeyUsage)
+	Expect(leaf.ExtKeyUsage).To(ConsistOf(x509.ExtKeyUsageServerAuth),
+		"the default extended key usage is serverAuth only")
+	Expect(leaf.UnknownExtKeyUsage).To(BeEmpty(),
+		"the signer must add no extended key usage the suite cannot name")
+
+	By("verifying the identity is the pod's own, and nothing else")
+	Expect(leaf.Subject.CommonName).To(Equal(ref.name), "the default common name is the pod name")
+	Expect(leaf.DNSNames).To(ConsistOf(
+		fmt.Sprintf("%s.%s.pod.cluster.local", ref.name, ref.namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", ref.name, ref.namespace),
+	), "the default SANs are the canonical pod and service DNS forms")
+	Expect(leaf.IPAddresses).To(BeEmpty(), "the defaults must add no IP SAN")
+	Expect(leaf.URIs).To(BeEmpty(), "the defaults must add no URI SAN")
+	Expect(leaf.EmailAddresses).To(BeEmpty(), "the defaults must add no email SAN")
+
+	By("verifying the chain verifies against the published ClusterTrustBundle")
+	Expect(issuer.IsCA).To(BeTrue(), "the second chain entry must be the issuing CA")
+	Expect(leaf.CheckSignatureFrom(issuer)).To(Succeed(),
+		"the leaf must be signed by the CA it is served with")
+	expectChainVerifies(leaf, trustAnchors)
+}
+
+// expectChainVerifies proves the leaf is trusted by a relying party that has
+// only the published ClusterTrustBundle - which is the only trust material a
+// workload in this cluster is given.
+func expectChainVerifies(leaf *x509.Certificate, trustAnchors []*x509.Certificate) {
+	GinkgoHelper()
+
+	roots := x509.NewCertPool()
+	for _, anchor := range trustAnchors {
+		roots.AddCert(anchor)
+	}
+
+	_, err := leaf.Verify(x509.VerifyOptions{
+		Roots: roots,
+		// The identity and the extended key usage are asserted exactly
+		// elsewhere; what this call answers is whether the chain builds and the
+		// signatures verify.
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		CurrentTime: leaf.NotBefore.Add(time.Minute),
+	})
+	Expect(err).NotTo(HaveOccurred(),
+		"the issued leaf must verify against the trust anchors the signer published")
+}
+
+// expectStatusTimes asserts that the timestamps on the request status describe
+// the certificate that was actually issued, and that the renewal hint sits
+// where the signer promised.
+//
+// kubelet acts on these three fields, not on the certificate it was handed: a
+// status whose notAfter disagrees with the certificate is a workload that
+// renews at the wrong time, and a beginRefreshAt outside the validity window is
+// a status kube-apiserver refuses outright.
+func expectStatusTimes(
+	request *capiv1beta1.PodCertificateRequest,
+	leaf *x509.Certificate,
+	wantRefreshBefore time.Duration,
+) {
+	GinkgoHelper()
+
+	Expect(request.Status.NotBefore).NotTo(BeNil())
+	Expect(request.Status.NotAfter).NotTo(BeNil())
+	Expect(request.Status.BeginRefreshAt).NotTo(BeNil())
+
+	notBefore := request.Status.NotBefore.Time
+	notAfter := request.Status.NotAfter.Time
+	beginRefreshAt := request.Status.BeginRefreshAt.Time
+
+	By("verifying the status validity window is the certificate's own")
+	Expect(notBefore).To(BeTemporally("~", leaf.NotBefore, statusTimeTolerance),
+		"status.notBefore must be the certificate's notBefore")
+	Expect(notAfter).To(BeTemporally("~", leaf.NotAfter, statusTimeTolerance),
+		"status.notAfter must be the certificate's notAfter")
+
+	By("verifying the renewal hint lies strictly inside the validity window")
+	Expect(beginRefreshAt).To(BeTemporally(">", notBefore),
+		"beginRefreshAt must lie after notBefore")
+	Expect(beginRefreshAt).To(BeTemporally("<", notAfter),
+		"beginRefreshAt must lie before notAfter")
+
+	By("verifying the renewal hint is notAfter minus the refresh window")
+	Expect(notAfter.Sub(beginRefreshAt)).To(BeNumerically("~", wantRefreshBefore, statusTimeTolerance),
+		"beginRefreshAt must be notAfter - %s, within %s", wantRefreshBefore, statusTimeTolerance)
+}

--- a/test/e2e/outcomes_test.go
+++ b/test/e2e/outcomes_test.go
@@ -191,6 +191,15 @@ func expectIssued(ref podRef) []*x509.Certificate {
 // with the expected reason; no certificate and no timestamps; a matching
 // Warning event; and no further change once the controller has had another
 // chance to reconcile the request.
+//
+// The reason stays a parameter although every caller passes
+// InvalidUserConfig today. It is the field that says *why* a request was
+// refused, and the API defines others the signer records - UnsupportedKeyType
+// for a key it cannot parse, which no pod manifest can provoke while kubelet
+// generates the keypair. A spec that stated the outcome without stating the
+// reason would pass for a denial that fired for the wrong cause.
+//
+//nolint:unparam // see above; the reason is asserted deliberately, not incidentally.
 func expectDenied(ref podRef, wantReason string) deniedRequest {
 	GinkgoHelper()
 	return expectTerminalDenialOrFailure(ref, capiv1beta1.PodCertificateRequestConditionTypeDenied, wantReason)


### PR DESCRIPTION
Stage 3 of the independent E2E review: key and certificate semantics, the identity boundary, and duration/status time. Test code and fixtures only — no signer behavior changes.

## What this proves

**Key types and certificate semantics.** A podCertificate projection takes six key types, not the three the review assumed. A server-side dry-run table states which values kube-apiserver accepts (`ED25519`, `ECDSAP256`, `ECDSAP384`, `ECDSAP521`, `RSA3072`, `RSA4096`) and which it refuses — **`RSA2048` is not a valid value**, so the review's "RSA 2048/3072 where supported" is wrong. An issuance table then walks all six with the existing credential probe: the leaf's key algorithm and curve/modulus, exact key usage (`keyEncipherment` for RSA key transport and for nothing else), exact CN and SANs, serverAuth-only EKU, positive serial, non-CA, a chain that verifies against the published ClusterTrustBundle, and — via the probe, the only party holding the private key — that the workload's key matches the certificate it was given.

**The identity boundary.** Every form the pod owns issues in a single certificate: bare name, `.namespace`, short and fully-qualified `.pod`/`.svc`, the service-account short form, and both SPIFFE IDs. The near-misses each deny: attacker prefix, upper-case spelling, trailing dot, a mixed list that must deny whole rather than filter, and an owned SPIFFE path re-parented under a foreign trust domain or extended by a path element. `${node.name}` and `${pod.uid}` resolve and are then refused on ownership — the specs prove that by requiring the *resolved* value (the real node name, the real UID) in the denial message, a distinction the reason string cannot make. A further install profile proves the allowlist follows `signer.cluster_fqdn` rather than a hard-coded `cluster.local`.

**Escape-hatch invariants.** With `--allow-unverified-identities` on, literal CN/DNS/IP/URI identities issue — and malformed DNS, IP, URI, EKU, duration and refresh values are still refused. The hatch relaxes ownership and nothing else.

**Duration and status time.** `maxExpirationSeconds` clamps the default; an explicit duration and refresh window are issued as asked; over-maximum, under-minimum and both unsafe refresh windows deny before signing rather than on a rejected status write. The status validity window must equal the certificate's, and `beginRefreshAt` must be `notAfter - refreshBefore` within a stated one-second tolerance.

## Two things worth knowing when reading this

The DNS SAN ValidatingAdmissionPolicy reads only the projection's `<signer>-san` annotation and rejects anything still containing `${` after substituting the four variables it knows. `${node.name}` and `${pod.uid}` are not among them, so requesting either as a SAN never reaches the signer — the pod is refused at admission. Those cases are requested through annotations the policy does not inspect, so the signer is the layer under test; the policy's own behavior stays covered by the existing admission table. The one spec that needs the signer's own DNS validation goes through the deprecated pod-annotation fallback for the same reason, and says so.

Every group is declared inside the install profile it belongs to, so the whole matrix costs **one** extra `helm upgrade`.

## Verification

Full local run on the pinned `kindest/node:v1.36.1` Kind cluster:

| | specs | ginkgo | wall |
|---|---|---|---|
| before | 34 | 183.4s | 204s |
| after | **76** | **286.3s** | **306s** |

`make test-e2e` — 76 of 76 passed, 0 failed, 0 skipped. `make test`, `make lint`, `make vet-e2e lint-e2e` all green.

The 42 new specs cost ~103s, which leaves the suite at about five minutes wall — inside the review's 10–15 minute PR budget, so nothing is proposed for a nightly partition yet. The costs, for when that changes: the custom-cluster-FQDN profile is ~18s of rollout for three specs and is the first thing to move; the six key-type issuance rows are ~1.7s each and are cheap enough to keep. The denial specs dominate the rest at ~5s each, almost all of it `expectTerminalConditionStable` proving the outcome is final.

## Two assertions that were wrong, and what they found

Both failed on the first run, which is the outcome they were written for; neither was a signer defect.

The ownership check originally required the denial message to contain no `${...}`. No message can satisfy that — the message continues with advice that itself names `${...}` interpolation. The refused value is now read out of the message and checked on its own, which is what the spec meant and is stricter for it.

The key-type matrix originally required every leaf to assert `basicConstraints`. The signer emits none on a leaf. RFC 5280 §6.1.4 makes the absence safe — a certificate without the extension may not verify signatures on other certificates, and Go's verifier enforces exactly that — so the spec now pins the absence and states that a future extension must carry `cA:FALSE`. Adding an explicit `cA:FALSE` would still be reasonable hardening; it is a product change and out of scope here.
