### PR TITLE
test(e2e): prove interoperability with a real TLS workload

### DIFF
--- a/.github/workflows/pr-release-metadata.yml
+++ b/.github/workflows/pr-release-metadata.yml
@@ -2,9 +2,18 @@ name: PR Release Metadata
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
-    branches:
-      - main
+    # `edited` is in this list because a pull request's base branch changing is
+    # an edit, and in a stacked workflow bases change on their own: when the PR
+    # below merges, this one is retargeted onto main automatically. Without
+    # `edited` that retarget fires no event in this list and the gate would
+    # never have run against the base the PR actually merges into.
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
+    # Deliberately no `branches` filter. Restricting this to PRs targeting main
+    # checks only the bottom of a stack: every layer above it targets the layer
+    # below and would reach main unchecked, carrying no release label and no
+    # changelog fragment of its own. The job reads changed files from the PR's
+    # own base, so on a stacked PR it sees just that layer's diff - which is
+    # exactly what each layer has to account for.
 
 permissions:
   contents: read

--- a/.github/workflows/test-e2e-nightly.yml
+++ b/.github/workflows/test-e2e-nightly.yml
@@ -18,22 +18,49 @@ on:
   # workflow_dispatch is what makes it runnable on demand rather than only by
   # waiting a day.
   workflow_dispatch:
+  # Opt-in per pull request, by labelling it `run-nightly`.
+  #
+  # Without this the nightly specs are only ever exercised after they merge: the
+  # per-PR gate excludes them by label and the cron only runs from the default
+  # branch. A pull request could therefore break a nightly spec and nobody would
+  # find out until it was already on main - and in a deep stack that is a lot of
+  # blast radius to unwind.
+  #
+  # `labeled` only, deliberately, and not `synchronize`: the full tier is 20+
+  # minutes, so re-running it on every push to a labelled pull request is not
+  # affordable. To re-run after a push, use workflow_dispatch, or remove the
+  # label and add it back. That is a choice, not an oversight.
+  pull_request:
+    types: [labeled]
 
 # Least privilege: the suite only needs to read the checked-out source. It
 # builds and loads images into a local kind cluster and publishes nothing.
 permissions:
   contents: read
 
-# One nightly run at a time, and never cancelled: a half-finished run of the
+# One run at a time per ref, and never cancelled: a half-finished run of the
 # only job that covers these specs is worth less than letting it finish.
+#
+# The group is ref-scoped rather than just the workflow name. With only the
+# nightly cron a single global group was right, but now that pull requests can
+# trigger this too, a workflow-wide group would serialise every labelled pull
+# request behind every other one and behind the cron - each waiting out a
+# 20-plus-minute run before starting its own.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   test-e2e-nightly:
     name: Run the full suite on Ubuntu
     runs-on: ubuntu-latest
+    # Scheduled and manual runs always go ahead. A pull request runs only when
+    # it carries the `run-nightly` label, so labelling a pull request anything
+    # else - a release label, an area label - does not spend half an hour of
+    # runner time.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-nightly')
     # The full set adds a CA rotation's worth of kubelet propagation per
     # nightly spec on top of the per-PR suite. Generous, but bounded: a hung
     # run must not sit on the runner until GitHub's six-hour default.

--- a/test/credprobe/main.go
+++ b/test/credprobe/main.go
@@ -51,7 +51,11 @@ func main() {
 	flag.StringVar(&cfg.trustPath, "trust", "/var/run/x509/ca.crt",
 		"path of the projected ClusterTrustBundle")
 	flag.StringVar(&cfg.role, "role", report.RoleServer,
-		"extended key usage the projected certificate was issued with: server or client")
+		"what to prove about the projected credential: server, client, or peer (a request to a real HTTPS peer)")
+	flag.StringVar(&cfg.peerURL, "peer-url", "",
+		"peer role only: the HTTPS URL to request")
+	flag.StringVar(&cfg.peerMode, "peer-mode", report.PeerModeProjected,
+		"peer role only: which client credential to present - projected, none or foreign")
 	flag.IntVar(&cfg.expectChainLen, "expect-chain-len", 2,
 		"number of certificates the bundle must carry after the private key")
 	flag.StringVar(&cfg.allowedDNS, "allowed-dns", "",

--- a/test/credprobe/peer.go
+++ b/test/credprobe/peer.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+)
+
+// The peer role is the only check in this suite whose other end is software
+// this repository did not write. Everything the server and client roles do is a
+// handshake the probe configured on both sides, which proves the projected
+// credential is well-formed and internally consistent but cannot prove that an
+// independent peer *accepts* the identity the signer issued.
+//
+// It is driven one request at a time, by `kubectl exec` rather than at pod
+// start, because the interesting questions are about a pod that is already
+// running: whether the same client still authenticates after the issuing CA has
+// rotated underneath the peer, without either pod restarting. A check that only
+// ran at startup could not ask that.
+
+const (
+	// peerRequestTimeout bounds the whole request, so an exec that cannot
+	// complete fails with a report rather than hanging until the suite's own
+	// timeout fires.
+	peerRequestTimeout = 20 * time.Second
+
+	// peerBodyLimit caps how much of the response is read into the report. The
+	// peer's JSON documents are well under this; the limit is here so a
+	// misdirected request cannot paste an arbitrary page into the log.
+	peerBodyLimit = 64 << 10
+)
+
+// checkPeer performs one request against the configured peer and records what
+// happened.
+//
+// It never asserts on the outcome. The suite decides whether a 200, a 403 or a
+// TLS alert was the right answer for the mode it asked for; this records which
+// one occurred, in enough detail that a wrong answer explains itself.
+func (r *reporter) checkPeer(cfg config, projected tls.Certificate, pool *x509.CertPool) bool {
+	facts := &report.PeerFacts{URL: cfg.peerURL, Mode: cfg.peerMode}
+	r.report.Facts.Peer = facts
+
+	if cfg.peerURL == "" {
+		return r.fail(report.CheckPeerRequest, "the peer role requires -peer-url")
+	}
+
+	clientCert, err := peerClientCertificate(cfg.peerMode, projected)
+	if err != nil {
+		return r.fail(report.CheckPeerRequest,
+			"preparing the client credential for mode %q: %v", cfg.peerMode, err)
+	}
+
+	tlsConfig := &tls.Config{
+		// Pinned at both ends throughout this probe, so the observations are
+		// stable across Go releases that move the default.
+		MinVersion: tls.VersionTLS13,
+		// The projected trust anchors and nothing else: the peer's certificate
+		// has to verify against what the signer published, not against whatever
+		// the image's root store happens to carry.
+		RootCAs: pool,
+	}
+	if clientCert != nil {
+		// GetClientCertificate rather than Certificates, and this is the
+		// difference between testing the untrusted-client case and silently not
+		// testing it. Go's default certificate selection filters candidates
+		// against the acceptable-CA list the server advertises, so a foreign
+		// certificate would never be put on the wire at all - the handshake
+		// would succeed with no client certificate and the run would look like
+		// the no-certificate case while claiming to be the untrusted one.
+		tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return clientCert, nil
+		}
+	}
+
+	// The dialer records that the TCP connection was established. Without it a
+	// DNS failure, a missing Service and a peer that refused the credential are
+	// one indistinguishable error, and the negative cases would pass for the
+	// wrong reason.
+	dialer := &net.Dialer{Timeout: peerRequestTimeout}
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			conn, err := dialer.DialContext(ctx, network, address)
+			if err == nil {
+				facts.Connected = true
+			}
+			return conn, err
+		},
+		// One connection per run, never reused: a pooled connection would carry
+		// the trust decision made at its handshake, so a post-rotation request
+		// could be answered over a session established before the rotation and
+		// prove nothing about the reloaded bundle.
+		DisableKeepAlives: true,
+	}
+	defer transport.CloseIdleConnections()
+
+	client := &http.Client{Transport: transport, Timeout: peerRequestTimeout}
+
+	request, err := http.NewRequest(http.MethodGet, cfg.peerURL, nil)
+	if err != nil {
+		return r.fail(report.CheckPeerRequest, "building the request for %s: %v", cfg.peerURL, err)
+	}
+	// The peer serves a human page by default and JSON only to a client that
+	// asks for it explicitly by media type - a */* wildcard does not count.
+	request.Header.Set("Accept", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		classifyPeerError(err, facts)
+		if !facts.TLSAlert {
+			return r.fail(report.CheckPeerRequest,
+				"the request to %s reached no definite outcome (connected=%t): %v; "+
+					"a transport failure is not evidence that the peer refused the credential",
+				cfg.peerURL, facts.Connected, err)
+		}
+		return r.pass(report.CheckPeerRequest,
+			"the peer refused the %s credential during the handshake with TLS alert %q",
+			cfg.peerMode, facts.TLSAlertText)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, peerBodyLimit))
+	if err != nil {
+		facts.HTTPStatus = response.StatusCode
+		return r.fail(report.CheckPeerRequest,
+			"reading the response body from %s after HTTP %d: %v", cfg.peerURL, response.StatusCode, err)
+	}
+
+	facts.HTTPStatus = response.StatusCode
+	facts.Body = string(body)
+
+	return r.pass(report.CheckPeerRequest,
+		"the peer answered HTTP %d to a request presenting the %s credential",
+		response.StatusCode, cfg.peerMode)
+}
+
+// peerClientCertificate returns the credential the configured mode presents, or
+// nil to present none.
+func peerClientCertificate(mode string, projected tls.Certificate) (*tls.Certificate, error) {
+	switch mode {
+	case report.PeerModeProjected:
+		return &projected, nil
+	case report.PeerModeNone:
+		return nil, nil
+	case report.PeerModeForeign:
+		return foreignClientCertificate()
+	default:
+		return nil, fmt.Errorf("unknown peer mode %q", mode)
+	}
+}
+
+// foreignClientCertificate mints a self-signed client certificate that no CA in
+// the cluster ever signed.
+//
+// It is generated here, in the pod, rather than handed in by the suite: a
+// certificate that arrives over the wire or through a flag would have to be
+// carried by something, and the point of this negative is a credential with no
+// relationship to the signer at all. Self-signed is the strongest form of that -
+// it chains to nothing the peer could possibly trust.
+//
+// It deliberately carries clientAuth, so the peer's refusal is about *trust* and
+// not about key usage. A certificate that failed the extended-key-usage check
+// would be refused too, and the spec would pass without ever testing what it
+// claims to.
+func foreignClientCertificate() (*tls.Certificate, error) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating the foreign key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generating the foreign serial: %w", err)
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "credprobe-foreign-client.invalid"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, public, private)
+	if err != nil {
+		return nil, fmt.Errorf("creating the foreign certificate: %w", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parsing the foreign certificate: %w", err)
+	}
+
+	return &tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  private,
+		Leaf:        leaf,
+	}, nil
+}
+
+// remoteErrorOp is the net.OpError operation crypto/tls uses for an alert
+// *received* from the peer, as opposed to one this side raised. It is the
+// discriminator that makes "the peer rejected the credential" a structural
+// observation rather than a guess at error text.
+const remoteErrorOp = "remote error"
+
+// classifyPeerError records what kind of failure err was.
+//
+// The classification that matters is whether the peer raised a TLS alert. An
+// alert is proof that the other end examined the credential and rejected it;
+// every other failure - a refused connection, an unresolved name, a deadline -
+// is something that happened on this side or in between, and says nothing about
+// what the peer would have decided.
+//
+// It matches on a net.OpError whose Op is "remote error" and not on
+// tls.AlertError, which looks like the obvious choice and never matches. A
+// received alert is delivered as net.OpError wrapping crypto/tls's *unexported*
+// alert type; tls.AlertError is a distinct exported type used for alerts raised
+// locally, so errors.As against it silently returns false for exactly the case
+// this function exists to detect. The observed chain is
+// *url.Error -> *tls.permanentError -> *net.OpError{Op: "remote error"}.
+func classifyPeerError(err error, facts *report.PeerFacts) {
+	facts.Error = err.Error()
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == remoteErrorOp && opErr.Err != nil {
+		facts.TLSAlert = true
+		facts.TLSAlertText = opErr.Err.Error()
+	}
+}

--- a/test/credprobe/peer_test.go
+++ b/test/credprobe/peer_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+)
+
+// These tests stand a local HTTPS server up with the same TLS settings the
+// in-cluster peer uses - TLS 1.3 and tls.VerifyClientCertIfGiven over a trust
+// bundle of CA certificates - and drive the peer role against it.
+//
+// They exist because the three peer modes fail in three different places, and
+// two of those are easy to get silently wrong:
+//
+//   - Presenting a foreign certificate at all requires overriding Go's default
+//     client-certificate selection, which filters candidates against the
+//     acceptable-CA list the server advertises. Without the override the
+//     handshake succeeds carrying no certificate and the untrusted-client case
+//     quietly becomes the no-certificate case - passing, while testing nothing.
+//   - A refusal must be distinguishable from a failure to reach the peer at all.
+//
+// Proving both here means the e2e spec that asserts them is debugging the
+// cluster, not the probe.
+
+// verifyClientCertIfGivenServer starts a TLS server mirroring the in-cluster
+// peer: it serves leaf, trusts clientCAs for client certificates, and requires
+// none.
+func verifyClientCertIfGivenServer(t *testing.T, leaf tls.Certificate, clientCAs *x509.CertPool) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mirrors the peer's own rule: identity comes from the verified chain,
+		// never from the presented certificates.
+		if r.TLS == nil || len(r.TLS.VerifiedChains) == 0 {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"authenticated":false,"reason":"no client certificate presented"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"authenticated":true}`))
+	}))
+	server.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{leaf},
+		ClientAuth:   tls.VerifyClientCertIfGiven,
+		ClientCAs:    clientCAs,
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// issueLoopbackServerLeaf signs a serverAuth certificate valid for 127.0.0.1,
+// which is the address httptest listens on.
+func issueLoopbackServerLeaf(t *testing.T, f fixture) tls.Certificate {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "credprobe-peer-under-test"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(testLeafLifetime),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, f.ca.Cert, pub, f.ca.Key)
+	if err != nil {
+		t.Fatalf("sign server leaf: %v", err)
+	}
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv}
+}
+
+// newPeerFixture builds a peer-role fixture pointed at a live local peer.
+func newPeerFixture(t *testing.T, mode string) (fixture, *httptest.Server) {
+	t.Helper()
+
+	f := newFixture(t, report.RolePeer)
+
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(f.ca.Cert)
+	server := verifyClientCertIfGivenServer(t, issueLoopbackServerLeaf(t, f), clientCAs)
+
+	f.cfg.peerURL = server.URL + "/whoami.json"
+	f.cfg.peerMode = mode
+	return f, server
+}
+
+// requirePeerFacts fails unless the report ran every peer check, passed them,
+// and recorded peer facts.
+func requirePeerFacts(t *testing.T, got report.Report) report.PeerFacts {
+	t.Helper()
+
+	requireAllPassed(t, got)
+	if got.Facts.Peer == nil {
+		t.Fatalf("the peer role must record peer facts\n%s", got)
+	}
+	return *got.Facts.Peer
+}
+
+func TestPeerProjectedCredentialIsAccepted(t *testing.T) {
+	f, _ := newPeerFixture(t, report.PeerModeProjected)
+
+	facts := requirePeerFacts(t, probe(f.cfg))
+
+	if !facts.Connected {
+		t.Errorf("connected = false, want true")
+	}
+	if facts.HTTPStatus != http.StatusOK {
+		t.Errorf("httpStatus = %d, want %d; error was %q", facts.HTTPStatus, http.StatusOK, facts.Error)
+	}
+	if facts.Body != `{"authenticated":true}` {
+		t.Errorf("body = %q, want the authenticated document", facts.Body)
+	}
+	if facts.TLSAlert {
+		t.Errorf("tlsAlert = true for a credential the peer trusts")
+	}
+}
+
+func TestPeerWithoutCertificateIsRefusedAsHTTP(t *testing.T) {
+	f, _ := newPeerFixture(t, report.PeerModeNone)
+
+	facts := requirePeerFacts(t, probe(f.cfg))
+
+	// The handshake completes: VerifyClientCertIfGiven permits a client that
+	// offers nothing, so the refusal is the peer's application-level answer and
+	// not a TLS failure. This is what makes it a different assertion from the
+	// foreign-certificate case below, rather than a differently worded one.
+	if facts.HTTPStatus != http.StatusForbidden {
+		t.Errorf("httpStatus = %d, want %d; error was %q", facts.HTTPStatus, http.StatusForbidden, facts.Error)
+	}
+	if facts.TLSAlert {
+		t.Errorf("tlsAlert = true; presenting no certificate must not fail the handshake")
+	}
+}
+
+func TestPeerWithForeignCertificateIsRefusedInHandshake(t *testing.T) {
+	f, _ := newPeerFixture(t, report.PeerModeForeign)
+
+	facts := requirePeerFacts(t, probe(f.cfg))
+
+	if !facts.Connected {
+		t.Errorf("connected = false; the refusal must come from the peer, not from the network")
+	}
+	if facts.HTTPStatus != 0 {
+		t.Errorf("httpStatus = %d, want no response at all: the peer must reject the certificate "+
+			"during the handshake, before any handler runs", facts.HTTPStatus)
+	}
+	if !facts.TLSAlert {
+		t.Fatalf("tlsAlert = false, want a TLS alert; error was %q.\n"+
+			"A foreign certificate that produces no alert most likely was never sent - see the "+
+			"GetClientCertificate note in checkPeer", facts.Error)
+	}
+	// A Go peer sends unknown_certificate_authority for a chain it cannot build;
+	// bad_certificate is the other refusal a peer may reasonably choose. Both
+	// name the certificate itself, which is the claim. Admitting either keeps
+	// the assertion about the rejection rather than about the peer's choice of
+	// alert, which is not ours to fix.
+	if !strings.Contains(facts.TLSAlertText, "unknown certificate authority") &&
+		!strings.Contains(facts.TLSAlertText, "bad certificate") {
+		t.Errorf("tlsAlertText = %q, want an alert naming the certificate; error was %q",
+			facts.TLSAlertText, facts.Error)
+	}
+}
+
+func TestPeerUnreachableIsNotARefusal(t *testing.T) {
+	f, server := newPeerFixture(t, report.PeerModeProjected)
+	// Closing the peer makes the request fail without the peer ever judging the
+	// credential. The check must go red: a suite that accepted this as a
+	// refusal would report a passing negative for a peer that was never there.
+	server.Close()
+
+	got := probe(f.cfg)
+
+	failures := got.Failures()
+	if len(failures) != 1 || failures[0].Name != report.CheckPeerRequest {
+		t.Fatalf("want exactly the %s check to fail\n%s", report.CheckPeerRequest, got)
+	}
+	if got.Facts.Peer == nil || got.Facts.Peer.TLSAlert {
+		t.Errorf("an unreachable peer must not be classified as a TLS refusal\n%s", got)
+	}
+}
+
+func TestPeerRoleRequiresURL(t *testing.T) {
+	f := newFixture(t, report.RolePeer)
+	f.cfg.peerMode = report.PeerModeProjected
+
+	got := probe(f.cfg)
+
+	if len(got.Failures()) != 1 {
+		t.Fatalf("a peer run with no -peer-url must fail exactly one check\n%s", got)
+	}
+}

--- a/test/credprobe/probe.go
+++ b/test/credprobe/probe.go
@@ -56,6 +56,12 @@ type config struct {
 	allowedDNS   string
 	unrelatedDNS string
 
+	// peerURL and peerMode configure the peer role: which HTTPS endpoint in
+	// another pod to call, and which client credential to present to it. See
+	// report.RolePeer and the modes beside it.
+	peerURL  string
+	peerMode string
+
 	hold time.Duration
 }
 
@@ -104,11 +110,23 @@ func probe(cfg config) report.Report {
 		return r.report
 	}
 
-	r.checkTLS(cfg, tls.Certificate{
+	projected := tls.Certificate{
 		Certificate: rawChain(chain),
 		PrivateKey:  key,
 		Leaf:        chain[0],
-	}, pool)
+	}
+
+	// The peer role branches here rather than at the top of probe, so it runs
+	// the identical preamble the other roles do: the credential it is about to
+	// present to a real peer has already been proven well-formed, key-matched
+	// and chained to the projected anchors. A peer request that then fails is a
+	// statement about the peer's decision and not about the material.
+	if cfg.role == report.RolePeer {
+		r.checkPeer(cfg, projected, pool)
+		return r.report
+	}
+
+	r.checkTLS(cfg, projected, pool)
 
 	return r.report
 }

--- a/test/credprobe/probe_test.go
+++ b/test/credprobe/probe_test.go
@@ -167,8 +167,10 @@ func newFixture(t *testing.T, role string) fixture {
 		t.Fatalf("generate CA: %v", err)
 	}
 
+	// The peer role authenticates to a real peer, so its credential is a client
+	// credential like RoleClient's; only what it does with it differs.
 	eku := x509.ExtKeyUsageServerAuth
-	if role == report.RoleClient {
+	if role == report.RoleClient || role == report.RolePeer {
 		eku = x509.ExtKeyUsageClientAuth
 	}
 	key, leaf := issueLeaf(t, ca, []x509.ExtKeyUsage{eku}, []string{testAllowedDNS})

--- a/test/credprobe/report/report.go
+++ b/test/credprobe/report/report.go
@@ -46,6 +46,36 @@ const Prefix = "CREDPROBE-REPORT "
 const (
 	RoleServer = "server"
 	RoleClient = "client"
+
+	// RolePeer drives one request against a real HTTPS peer in another pod,
+	// rather than against a loopback listener the probe configured itself.
+	//
+	// The other two roles prove the projected credential is internally usable:
+	// the probe is both ends of the handshake, so a passing check says the
+	// material is well-formed and the key works. What they cannot say is that a
+	// peer the suite did not write accepts the identity the signer issued. This
+	// role answers that, and it is the only one whose verdict depends on
+	// software outside this repository.
+	RolePeer = "peer"
+)
+
+// Peer modes select what client credential the peer role presents. They are the
+// three cases that produce different outcomes at a server doing
+// tls.VerifyClientCertIfGiven, and naming them keeps the negative cases from
+// collapsing into each other.
+const (
+	// PeerModeProjected presents the pod's own projected credential.
+	PeerModeProjected = "projected"
+
+	// PeerModeNone presents no client certificate at all. The peer's handshake
+	// succeeds and the refusal arrives as an HTTP status.
+	PeerModeNone = "none"
+
+	// PeerModeForeign presents a self-signed certificate the peer's trust
+	// bundle cannot chain. The peer refuses during the handshake, so there is
+	// no HTTP response at all - which is why the two negatives cannot be
+	// asserted the same way.
+	PeerModeForeign = "foreign"
 )
 
 // Check names. The suite asserts on the exact set for a role, so a check that
@@ -97,6 +127,18 @@ const (
 	// CheckTLSServerRoleRejected proves a clientAuth-only certificate is
 	// refused when presented as a server certificate.
 	CheckTLSServerRoleRejected = "tls.server.rejectsClientOnlyCert"
+
+	// CheckPeerRequest covers one request against a real HTTPS peer.
+	//
+	// It passes when the attempt reached a *definite* outcome - an HTTP
+	// response, or a TLS alert raised by the peer - and fails when it did not.
+	// That distinction is the whole value of the check: a refused connection, an
+	// unresolvable name or a timeout are all "the request did not succeed", and
+	// treating them as proof that a peer rejected a credential would turn a
+	// broken fixture into a passing negative. The outcome itself is recorded in
+	// PeerFacts for the suite to judge; this check only asserts that there is an
+	// outcome to judge.
+	CheckPeerRequest = "peer.request"
 )
 
 // ExpectedChecks returns the checks a report for the given role must contain,
@@ -109,6 +151,9 @@ func ExpectedChecks(role string) []string {
 		CheckTrustFile,
 		CheckTrustOnlyCAs,
 		CheckTrustVerifiesLeaf,
+	}
+	if role == RolePeer {
+		return append(common, CheckPeerRequest)
 	}
 	if role == RoleClient {
 		return append(common, CheckTLSClientAuthAccepted, CheckTLSServerRoleRejected)
@@ -170,6 +215,53 @@ type Facts struct {
 	// LeafKeyAlgorithm is the public key algorithm of the projected leaf, e.g.
 	// Ed25519.
 	LeafKeyAlgorithm string `json:"leafKeyAlgorithm"`
+
+	// Peer is what the peer role observed, and is nil for the other roles.
+	Peer *PeerFacts `json:"peer,omitempty"`
+}
+
+// PeerFacts is what one request against a real HTTPS peer observed.
+//
+// The suite is the judge here as everywhere else: the probe records the status
+// code, the response body and the classified failure, and asserts none of them.
+// A spec then states which of the three outcomes it expected.
+type PeerFacts struct {
+	URL  string `json:"url"`
+	Mode string `json:"mode"`
+
+	// Connected reports whether the TCP connection was established. It is what
+	// separates "the peer refused this credential" from "the peer was never
+	// reached", which are the same error to a caller that only checks for nil.
+	Connected bool `json:"connected"`
+
+	// HTTPStatus is the status code, or zero when no response was received.
+	HTTPStatus int `json:"httpStatus"`
+
+	// Body is the response body verbatim. The peer's endpoints publish
+	// certificate metadata only - subjects, fingerprints, SANs - so this carries
+	// nothing that is not already public.
+	Body string `json:"body"`
+
+	// Error is the request error, verbatim, and is empty on success.
+	Error string `json:"error"`
+
+	// TLSAlert reports whether the peer raised a TLS alert - that is, whether it
+	// examined the credential and rejected it at the TLS layer. It is the
+	// load-bearing half of the classification: every other way a request can
+	// fail happened on this side or in between, and says nothing about what the
+	// peer decided.
+	TLSAlert bool `json:"tlsAlert"`
+
+	// TLSAlertText is the alert's description, e.g. "tls: unknown certificate
+	// authority". It says *which* refusal, where TLSAlert says only that there
+	// was one.
+	//
+	// It is the description and not the numeric code deliberately. crypto/tls
+	// delivers a received alert as a net.OpError wrapping its unexported alert
+	// type, so the number is only reachable by reflecting into a type the
+	// standard library does not export - cleverness that would break silently on
+	// a Go release. The description is that type's Error() string and is stable.
+	TLSAlertText string `json:"tlsAlertText"`
 }
 
 // Report is the probe's whole output.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -516,6 +516,13 @@ var _ = Describe("Manager", Ordered, Serial, func() {
 	// ValidatingAdmissionPolicy, so they neither reach the signer nor care what
 	// state the CA was left in.
 	defineAdmissionPolicyTests()
+
+	// Interoperability with a real TLS workload goes last of everything. It
+	// installs its own profile and rotates the CA, and the previous-CA retention
+	// spec above asserts an exact rotation history that any rotation before it
+	// would invalidate. Declared here, nothing follows that it can disturb. See
+	// goweb_interop_test.go.
+	defineGowebInteropTests()
 })
 
 // getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.

--- a/test/e2e/fixtures_test.go
+++ b/test/e2e/fixtures_test.go
@@ -101,6 +101,35 @@ type certTestPod struct {
 	image string
 	args  []string
 
+	// env are environment variables for the workload container. The goweb
+	// interop specs configure their server entirely this way (see
+	// goweb_interop_test.go); nothing else in the suite needs any.
+	env []corev1.EnvVar
+
+	// labels are added to the pod on top of e2eWorkloadLabel.
+	//
+	// They exist so a Service can select one specific pod. e2eWorkloadLabel is
+	// on every pod the suite creates, so a selector using it would match all of
+	// them. A per-pod label cannot simply be derived from the pod name either:
+	// a label value is capped at 63 characters and one spec deliberately uses a
+	// 64-character name, so deriving one automatically would fail that spec on
+	// admission.
+	labels map[string]string
+
+	// observerSidecar adds a second container that mounts the same projected
+	// volume and does nothing but stay up.
+	//
+	// It is what makes the projected files readable by `kubectl exec` when the
+	// workload image cannot be exec'd into - the goweb server is distroless and
+	// carries no shell and no cat. Reading the file from a sidecar is reading
+	// the same projection: the volume is the pod's, not the container's, so
+	// kubelet updates it once for both.
+	//
+	// It is a bool rather than a general "extra containers" field on purpose. A
+	// list would make this fixture a way to smuggle arbitrary containers into
+	// the suite, and every spec that needed one would invent its own shape.
+	observerSidecar bool
+
 	// holdSeconds is how long the sleeper container stays up. Defaults to
 	// defaultHoldSeconds, which is ample for a spec that only needs a pod to
 	// exist while its request is issued.
@@ -158,9 +187,10 @@ func (p certTestPod) withDefaults() certTestPod {
 // arguments, which is how the credential probe is configured.
 func (p certTestPod) container() corev1.Container {
 	container := corev1.Container{
-		Name:  "workload",
+		Name:  workloadContainerName,
 		Image: p.image,
 		Args:  p.args,
+		Env:   p.env,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr(false),
 			RunAsNonRoot:             ptr(true),
@@ -178,6 +208,39 @@ func (p certTestPod) container() corev1.Container {
 		container.Command = []string{"sleep", strconv.Itoa(p.holdSeconds)}
 	}
 	return container
+}
+
+// workloadContainerName is the container every fixture's workload runs in, and
+// observerContainerName the optional sidecar beside it. They are named
+// constants because `kubectl exec` and `kubectl logs` have to name a container
+// once a pod has two.
+const (
+	workloadContainerName = "workload"
+	observerContainerName = "observer"
+)
+
+// observer renders the sidecar described on observerSidecar: a shell that mounts
+// the same projected volume and stays up for as long as the workload does.
+func (p certTestPod) observer() corev1.Container {
+	return corev1.Container{
+		Name:    observerContainerName,
+		Image:   sleeperImage,
+		Command: []string{"sleep", strconv.Itoa(p.holdSeconds)},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr(false),
+			RunAsNonRoot:             ptr(true),
+			// The same unprivileged uid the workload runs as, so what this
+			// container can read is what the workload can read.
+			RunAsUser:      ptr(int64(65532)),
+			Capabilities:   &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      "x509",
+			MountPath: certTestPodMountPath,
+			ReadOnly:  true,
+		}},
+	}
 }
 
 // build renders the fixture as a typed corev1.Pod.
@@ -203,18 +266,28 @@ func (p certTestPod) build() *corev1.Pod {
 		})
 	}
 
+	labels := map[string]string{e2eWorkloadLabel: "true"}
+	for key, value := range p.labels {
+		labels[key] = value
+	}
+
+	containers := []corev1.Container{p.container()}
+	if p.observerSidecar {
+		containers = append(containers, p.observer())
+	}
+
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        p.name,
 			Namespace:   p.namespace,
-			Labels:      map[string]string{e2eWorkloadLabel: "true"},
+			Labels:      labels,
 			Annotations: p.podAnnotations,
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,
 			ServiceAccountName: p.serviceAccountName,
-			Containers:         []corev1.Container{p.container()},
+			Containers:         containers,
 			Volumes: []corev1.Volume{{
 				Name: "x509",
 				VolumeSource: corev1.VolumeSource{

--- a/test/e2e/goweb_interop_test.go
+++ b/test/e2e/goweb_interop_test.go
@@ -1,0 +1,888 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/credprobe/report"
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
+)
+
+// Interoperability with a real TLS workload.
+//
+// Every other spec in this suite judges the signer against itself. The request
+// status is read from outside the cluster, and the credential-conformance specs
+// close half the remaining gap by having the workload use its own credential -
+// but the probe is both ends of that handshake, so what it proves is that the
+// material is well-formed and internally consistent. Nothing so far shows that
+// an independent peer *accepts* an identity this signer issued.
+//
+// These specs close that. The server is goweb-https, software from another
+// repository that knows nothing about this one: it serves HTTPS from the
+// projected credential bundle, verifies client certificates against the
+// projected ClusterTrustBundle, and publishes what it loaded and when. The
+// clients are credprobe pods in the peer role. Every verdict below is goweb's,
+// read out of its own diagnostic endpoints and judged here against the
+// PodCertificateRequest status - so, as everywhere else in this suite, neither
+// half grades its own homework.
+//
+// The spec that justifies the whole file is the rotation one. ca_lifecycle_test.go
+// already proves transitional trust *structurally*, by comparing fingerprint
+// sets across a rotation. This proves it *functionally*: a client holding a
+// certificate issued under the new CA authenticates to a server that was
+// started before the rotation, a client holding one from the previous CA still
+// authenticates, and neither pod restarts.
+//
+// Placement. This container is declared last, after every other container in
+// the Manager Describe, and that is not a matter of taste. It rotates the CA,
+// and the previous-CA retention spec in ca_lifecycle_test.go asserts an exact
+// rotation history - after A -> B -> C -> D with a bound of two, the published
+// bundle must be [D, B, C]. A rotation inserted anywhere before it changes that
+// arithmetic and fails a spec that has nothing to do with this file. Declared
+// last, nothing follows that a rotation here can disturb.
+//
+// Cost. Every spec carries Label(nightlyLabel): the container pays a Helm
+// rollout, several issuances and - in the rotation spec - one full
+// mountedTrustUpdateTimeout window, which is minutes of wall time that the
+// per-PR tier has no room for.
+
+// gowebImage is the TLS workload these specs run.
+//
+// Pinned by digest, not by tag. A tag makes the suite non-reproducible and hands
+// an unrelated repository's release the ability to turn this one red: the image
+// behind :latest can change between the run that passed and the run that did
+// not, with nothing in this repository's history to explain the difference.
+//
+// This is the multi-architecture index digest, so it resolves to the right
+// manifest on an arm64 laptop and an amd64 CI runner alike; pinning a
+// per-platform manifest digest would break one of the two.
+//
+// To refresh it:
+//
+//	docker buildx imagetools inspect ghcr.io/rafpe/goweb-https/server:latest
+//
+// and take the top-level "Digest:" line. Re-read the environment variables and
+// the /status.json and /whoami.json field names below when you do - they are
+// that image's contract, and this file is a consumer of it.
+const gowebImage = "ghcr.io/rafpe/goweb-https/server@sha256:9173587079415499d100659a18b4fcfc58014a38a55ce74432a34cf6db6b2e60"
+
+// The goweb server's identity. The Service is named after the pod deliberately:
+// the signer's default SANs are <pod>.<namespace>.pod.cluster.local and
+// <pod>.<namespace>.svc.cluster.local, and only the second is resolvable - and
+// only if a Service of that name selects the pod. Naming them alike is what lets
+// a client dial a name the certificate actually carries, rather than dialling a
+// pod IP and turning off the hostname check that is half the point of TLS.
+const (
+	gowebServerPodName = "pcs-goweb-server"
+	gowebClientPodName = "pcs-goweb-client"
+	gowebRotatedClient = "pcs-goweb-client-rotated"
+
+	// gowebPort is the port goweb listens on; it is goweb's own default, set
+	// explicitly so the fixture and the URL cannot drift apart.
+	gowebPort = 8443
+
+	// gowebSelectorLabel carries the pod name, so the Service selects exactly
+	// this pod and not every workload the suite has created.
+	gowebSelectorLabel = "e2e.pod-certificate-signer/goweb"
+
+	// gowebClientServiceAccount is the identity the client pods run as.
+	//
+	// It exists so the client's SPIFFE ID differs from the server's. Both would
+	// otherwise run as "default" and resolve to the same URI, and a spec
+	// asserting that goweb reported the client's identity would be satisfied by
+	// a server echoing its own.
+	gowebClientServiceAccount = "pcs-goweb-client"
+)
+
+// goweb's reload knobs, set far below their defaults.
+//
+// This is what makes the reload-latency spec able to say anything. goweb's
+// observed convergence after a rotation is two independent terms added
+// together - kubelet propagating the new ClusterTrustBundle into the projected
+// volume, then goweb noticing the file changed and re-reading it - and with the
+// stock 30-second reconcile interval the second term is large enough to be
+// mistaken for the first. Turned down to seconds, goweb's own contribution is
+// bounded by configuration, and what remains is kubelet's.
+const (
+	gowebReloadDebounce = "200ms"
+	gowebReloadInterval = "2s"
+)
+
+// gowebOwnReloadBudget bounds the term this file attributes to goweb: the time
+// from the projected file changing to goweb serving the new anchors.
+//
+// The configured worst case is the debounce plus one reconcile interval, 2.2
+// seconds. The rest of this budget is measurement overhead and nothing to do
+// with goweb: the file change is observed by polling `cat` through `kubectl
+// exec`, and the reload by polling /status.json through another, so each
+// endpoint of the interval is quantised by a poll period and a round trip.
+//
+// It is emphatically *not* a bound on kubelet, which is measured separately and
+// is minutes rather than seconds. See the rotation spec.
+const gowebOwnReloadBudget = 20 * time.Second
+
+// gowebObserverHold is how long the sidecar and the client probes stay up.
+//
+// It has to outlive the whole container, not just one spec: the client created
+// in BeforeAll is re-exec'd by the last spec, after a rotation and a full
+// mountedTrustUpdateTimeout window. A container that exits early is worse than
+// a timeout - the pod stops being Ready, drops out of the Service's endpoints,
+// and the failure surfaces as unresolvable DNS with nothing to say why.
+const gowebObserverHold = 3600
+
+// gowebServeTimeout bounds the wait for goweb to answer its first request. It
+// covers pulling the image, which - unlike every other image in this suite - is
+// pulled from a registry by the node rather than loaded into Kind.
+const gowebServeTimeout = 5 * time.Minute
+
+// gowebSpiffeURI is the SPIFFE ID template both pods request. Under the
+// verified-interpolation profile the resolved value still has to clear the
+// verified-identity allowlist, so an issued certificate carrying it is itself an
+// assertion (see ADR-0001).
+const gowebSpiffeURI = "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}"
+
+// defineGowebInteropTests is called last from the Manager Describe. See the
+// placement note above before moving it.
+func defineGowebInteropTests() {
+	Context("Interoperability with a real TLS workload", Label(nightlyLabel), func() {
+		var (
+			// serverLeaf is the certificate goweb serves, as the request status
+			// published it. Every assertion about what goweb reports is made
+			// against this rather than against goweb's own account of itself.
+			serverLeaf *x509.Certificate
+
+			// baselineCA is the CA current while the server and the first client
+			// were issued. The rotation spec needs it to state which clients
+			// hold pre-rotation certificates.
+			baselineCA *x509.Certificate
+
+			server, client podRef
+		)
+
+		BeforeAll(func() {
+			By("installing the profile these specs describe")
+			// Interpolation on with the identity constraints still enforced.
+			// This is the only profile in which every spec below is expressible
+			// at once: the default DNS SANs a server needs, the eku=client
+			// opt-in a client needs, and a SPIFFE URI that has to clear the
+			// verified-identity allowlist on its own merits. Using one profile
+			// costs one rollout instead of three.
+			installProfile(verifiedInterpolationInstallArgs)
+
+			By("waiting for the signer to publish its ClusterTrustBundle")
+			var anchors []*x509.Certificate
+			Eventually(func(g Gomega) {
+				anchors = getTrustBundleCertificates(g)
+				g.Expect(anchors).NotTo(BeEmpty(), "the trust bundle must carry the current CA")
+			}).Should(Succeed())
+			baselineCA = anchors[0]
+
+			By("verifying every published anchor is one goweb can load as a client CA")
+			// A precondition, not a claim about the signer, and it is here to
+			// convert one specific mystery into a diagnosis. goweb validates
+			// every anchor in its client CA file at startup and refuses to start
+			// if any one of them fails - so a single unusable certificate left in
+			// the bundle by a preceding container reaches this file as a pod
+			// stuck in CrashLoopBackOff, minutes into a nightly run, looking for
+			// all the world like an image-pull problem.
+			expectAnchorsUsableAsClientCAs(anchors)
+
+			By("creating the service account the client pods run as")
+			createGowebClientServiceAccount()
+
+			By("starting the goweb server with the projected credential and trust bundle")
+			server = createGowebServer()
+
+			By("waiting for the server's PodCertificateRequest to be issued")
+			serverChain := expectIssued(server)
+			Expect(serverChain).To(HaveLen(defaultChainLength))
+			serverLeaf = serverChain[0]
+			Expect(serverChain[1].Equal(baselineCA)).To(BeTrue(),
+				"the server's certificate must be issued under the CA the bundle currently leads with")
+
+			By("publishing a Service so the server is reachable at a name its certificate carries")
+			createGowebService()
+
+			By("starting a client whose certificate carries a SPIFFE identity")
+			client = createGowebClient(gowebClientPodName)
+			expectIssued(client)
+
+			By("waiting for both pods to run with their projected credentials")
+			expectPodRunning(server)
+			expectPodRunning(client)
+
+			By("waiting for the server to answer over TLS")
+			// Deliberately the first real request rather than a readiness probe
+			// on the pod. goweb has no probe configured, so it is Ready as soon
+			// as its container starts and its Service endpoint appears
+			// immediately; an HTTPS probe would add a failure surface that
+			// manifests as unresolvable DNS. Waiting on an actual answer here
+			// proves DNS, routing, the listener and the trust chain in one, and
+			// does it once instead of in every spec.
+			Eventually(func(g Gomega) {
+				gowebStatus(g, client)
+			}, gowebServeTimeout).Should(Succeed())
+		})
+
+		It("serves real TLS to another pod, with the certificate the signer issued", func() {
+			By("reading the server's own account of the certificate it is serving")
+			var status gowebStatusDocument
+			Eventually(func(g Gomega) {
+				status = gowebStatus(g, client)
+			}).Should(Succeed())
+
+			Expect(status.Certificate).NotTo(BeNil(),
+				"the server must report the certificate it is serving")
+
+			By("verifying it is byte-for-byte the leaf the request status published")
+			// The fingerprint is the whole claim. A subject or a SAN could match
+			// while the served certificate was some other one carrying the same
+			// fields; the fingerprint cannot.
+			Expect(status.Certificate.FingerprintSHA256).To(Equal(fingerprint(serverLeaf)),
+				"goweb must be serving exactly the certificate the PodCertificateRequest published")
+
+			By("verifying the names it serves are the ones the signer put in the certificate")
+			Expect(status.Certificate.DNSNames).To(ConsistOf(serverLeaf.DNSNames))
+			Expect(status.Certificate.DNSNames).To(ContainElement(gowebServerDNSName()),
+				"the client reached the server at this name, so the certificate must carry it")
+			Expect(status.Certificate.URIs).To(ConsistOf(certificateURIs(serverLeaf)))
+			Expect(status.Certificate.Validity).To(Equal("valid"),
+				"the served certificate must be within its validity window")
+
+			// The client verified that certificate against the projected anchors
+			// and nothing else: the peer probe sets RootCAs to the projected
+			// ca.crt alone, so a decoded status document at all means the chain
+			// built and the hostname matched. gowebStatus already requires the
+			// 200 that proves it, which is why there is no further assertion
+			// here - one restating it would read as a check and test nothing.
+		})
+
+		It("authenticates a client by the SPIFFE identity the signer issued it", func() {
+			By("verifying the client holds the SPIFFE identity this spec is about")
+			clientLeaf := expectIssued(client)[0]
+			Expect(clientLeaf.URIs).To(HaveLen(1))
+			wantURI := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/%s",
+				workloadNamespace, gowebClientServiceAccount)
+			Expect(clientLeaf.URIs[0].String()).To(Equal(wantURI))
+
+			By("asking the server who the client is")
+			var whoami gowebWhoamiDocument
+			Eventually(func(g Gomega) {
+				whoami = gowebWhoami(g, client, report.PeerModeProjected, http200)
+			}).Should(Succeed())
+
+			By("verifying the server accepted the identity rather than merely receiving it")
+			// This is the assertion nothing else in the suite makes. Every other
+			// spec proves an identity was *issued*; this proves a peer that has
+			// never heard of this signer verified it, chained it to the published
+			// trust anchors and reported it back.
+			Expect(whoami.Authenticated).To(BeTrue(),
+				"the server must authenticate a client whose certificate chains to the published anchors")
+			Expect(whoami.Client).NotTo(BeNil())
+			Expect(whoami.Client.URIs).To(ConsistOf(wantURI),
+				"the server must report the SPIFFE ID the signer issued, not one of its own")
+			Expect(whoami.Client.FingerprintSHA256).To(Equal(fingerprint(clientLeaf)),
+				"the authenticated certificate must be the one the request status published")
+			Expect(whoami.Client.Chain).NotTo(BeEmpty(),
+				"an authenticated client must have a verified chain")
+		})
+
+		It("refuses an unauthenticated client and an untrusted one, differently", func() {
+			// The two negatives fail in different places and must be asserted
+			// differently. goweb verifies client certificates with
+			// tls.VerifyClientCertIfGiven: a client offering nothing completes
+			// the handshake and is refused by the application, while a client
+			// offering a certificate that does not chain is refused during the
+			// handshake and never reaches a handler at all. Asserting both as
+			// "the request did not succeed" would pass for a server that was
+			// simply unreachable, which is the false pass this spec exists to
+			// rule out.
+
+			By("presenting no client certificate at all")
+			var whoami gowebWhoamiDocument
+			Eventually(func(g Gomega) {
+				whoami = gowebWhoami(g, client, report.PeerModeNone, http403)
+			}).Should(Succeed())
+
+			Expect(whoami.Authenticated).To(BeFalse())
+			Expect(whoami.Reason).To(Equal("no client certificate presented"),
+				"the refusal must name why, so it cannot be confused with any other 403")
+
+			By("presenting a certificate no CA in this cluster ever signed")
+			var facts report.PeerFacts
+			Eventually(func(g Gomega) {
+				facts = gowebPeerRequest(g, client, report.PeerModeForeign, gowebWhoamiURL())
+			}).Should(Succeed())
+
+			By("verifying the server rejected it in the handshake, and did not merely fail to answer")
+			Expect(facts.Connected).To(BeTrue(),
+				"the connection must have been established, or this proves nothing about the server's decision")
+			Expect(facts.HTTPStatus).To(BeZero(),
+				"an untrusted certificate must be refused before any handler runs, so there is no response")
+			Expect(facts.TLSAlert).To(BeTrue(),
+				"the refusal must be a TLS alert from the server: %s", facts.Error)
+			// A Go peer sends unknown_certificate_authority for a chain it cannot
+			// build. bad_certificate is the other refusal a server may
+			// reasonably choose, so both are admitted - the claim is that the
+			// certificate was rejected, not which alert says so.
+			Expect(facts.TLSAlertText).To(SatisfyAny(
+				ContainSubstring("unknown certificate authority"),
+				ContainSubstring("bad certificate"),
+			), "the alert must name the certificate as the reason: %s", facts.Error)
+		})
+
+		It("keeps authenticating across a CA rotation, hot-reloading trust without a restart", func() {
+			// The spec this file exists for. ca_lifecycle_test.go proves the
+			// published bundle carries both CAs across a rotation; this proves
+			// what that is *for* - that a running server picks the new anchors up
+			// from a file changing underneath it, starts accepting clients issued
+			// under the new CA, and keeps accepting the ones issued under the
+			// old, all without either process being restarted.
+
+			By("recording what the server looked like before the rotation")
+			var before gowebStatusDocument
+			Eventually(func(g Gomega) {
+				before = gowebStatus(g, client)
+			}).Should(Succeed())
+			Expect(before.TrustBundle).NotTo(BeNil(),
+				"the server must report the trust bundle it enforces")
+			Expect(before.TrustBundle.Anchors).NotTo(BeEmpty())
+			Expect(anchorFingerprints(before)).To(ContainElement(fingerprint(baselineCA)),
+				"the server must start out trusting the CA its client was issued under")
+
+			By("verifying the pre-rotation client authenticates today")
+			// The baseline for the "still authenticates" claim below. Without it
+			// a client that never worked would look like one that survived.
+			Eventually(func(g Gomega) {
+				g.Expect(gowebWhoami(g, client, report.PeerModeProjected, http200).Authenticated).To(BeTrue())
+			}).Should(Succeed())
+
+			By("rotating the issuing CA")
+			rotationStarted := time.Now()
+			rotated := newLifecycleCA("goweb-interop-rotated")
+			rotateCA(rotated)
+			Expect(rotated.Cert.Equal(baselineCA)).To(BeFalse(),
+				"the rotation must change the CA, or nothing below proves anything")
+
+			By("waiting for kubelet to write the new anchors into the server's projected volume")
+			// Term one of the latency, and the large one. This is kubelet
+			// propagating a changed ClusterTrustBundle into a mounted projected
+			// volume, which goes through a normalization cache with a hard-coded
+			// five-minute TTL plus a pod sync - see mountedTrustUpdateTimeout.
+			// None of it is goweb's, and none of it is this signer's.
+			//
+			// It is read out of the sidecar because the goweb image is distroless
+			// and has no cat. The sidecar mounts the same volume, so this is the
+			// same projection the server is reading.
+			var fileChanged time.Time
+			Eventually(func(g Gomega) {
+				mounted := certificateFingerprints(observerTrustAnchors(g, server))
+				g.Expect(mounted).To(ContainElement(fingerprint(rotated.Cert)),
+					"the projected trust anchors must catch up with the published bundle")
+				fileChanged = time.Now()
+			}, mountedTrustUpdateTimeout, 5*time.Second).Should(Succeed())
+
+			By("waiting for the server to reload the trust bundle it enforces")
+			// Term two, and the only one that is goweb's. Measured from the file
+			// changing rather than from the rotation, which is the whole point:
+			// attributing the wait above to goweb would report a reload latency
+			// of minutes for software that reconciles every two seconds.
+			var after gowebStatusDocument
+			var reloaded time.Time
+			Eventually(func(g Gomega) {
+				after = gowebStatus(g, client)
+				g.Expect(after.TrustBundle).NotTo(BeNil())
+				g.Expect(anchorFingerprints(after)).To(ContainElement(fingerprint(rotated.Cert)),
+					"the server must enforce the rotated CA once its file carries it")
+				// Set equality, not just containment. A server that only ever
+				// added anchors would satisfy the check above forever and would
+				// never apply a removal - and removing a CA from the published
+				// bundle is how this signer expresses revocation. Converging on
+				// exactly the published set is the property that makes the
+				// overlap window bounded rather than permanent.
+				g.Expect(anchorFingerprints(after)).To(
+					ConsistOf(certificateFingerprints(getTrustBundleCertificates(g))),
+					"the server must enforce exactly the anchors the signer publishes")
+				reloaded = time.Now()
+			}, gowebOwnReloadBudget+time.Minute, time.Second).Should(Succeed())
+
+			gowebTerm := reloaded.Sub(fileChanged)
+			kubeletTerm := fileChanged.Sub(rotationStarted)
+			AddReportEntry("trust propagation split", fmt.Sprintf(
+				"kubelet %s, goweb %s (goweb configured for debounce %s + interval %s)",
+				kubeletTerm.Round(time.Second), gowebTerm.Round(time.Second),
+				gowebReloadDebounce, gowebReloadInterval))
+
+			By("verifying the server's own reload was quick, whatever kubelet took")
+			// A non-positive value is normal and not an error: both endpoints are
+			// polled, so goweb can be observed serving the new anchors before the
+			// poll that notices the file changed. The assertion is an upper bound
+			// on goweb's term only.
+			Expect(gowebTerm).To(BeNumerically("<=", gowebOwnReloadBudget),
+				"the server's own reload must be bounded by its configured debounce and interval; "+
+					"kubelet's propagation took %s and is not part of this", kubeletTerm)
+
+			By("verifying the reload is visible as a fresh load, not a stale cache")
+			Expect(after.TrustBundle.LoadedAt).To(BeTemporally(">", before.TrustBundle.LoadedAt),
+				"a rotation must advance the time the enforced bundle was loaded")
+			Expect(after.TrustBundle.LastError).To(BeEmpty(),
+				"the reload must have succeeded, not been retained after a failure")
+			Expect(after.TrustBundle.StaleSeconds).To(BeNumerically("<=", int64(gowebOwnReloadBudget.Seconds())),
+				"the server must be reading its trust bundle continuously, or LoadedAt says little")
+
+			By("verifying neither process restarted")
+			// The claim is about hot reload, so a restart anywhere invalidates
+			// it. started_at is the load-bearing half: a container can be
+			// restarted and still report restartCount 0 in a race, but a new
+			// process cannot report the old start time.
+			Expect(after.Server.StartedAt).To(BeTemporally("==", before.Server.StartedAt),
+				"the server process must be the one that was running before the rotation")
+			expectNoRestarts(server)
+			expectNoRestarts(client)
+
+			By("verifying a client issued under the new CA authenticates")
+			rotatedClient := createGowebClient(gowebRotatedClient)
+			rotatedLeaf := expectIssued(rotatedClient)[0]
+			Expect(rotatedLeaf.CheckSignatureFrom(rotated.Cert)).To(Succeed(),
+				"the new client's certificate must actually be signed by the rotated CA")
+			expectPodRunning(rotatedClient)
+
+			Eventually(func(g Gomega) {
+				identified := gowebWhoami(g, rotatedClient, report.PeerModeProjected, http200)
+				g.Expect(identified.Authenticated).To(BeTrue(),
+					"a client issued under the rotated CA must authenticate to a server that never restarted")
+				g.Expect(identified.Client.FingerprintSHA256).To(Equal(fingerprint(rotatedLeaf)))
+			}, gowebServeTimeout).Should(Succeed())
+
+			By("verifying the client issued under the previous CA still authenticates")
+			// The other half of transitional trust, and the half that makes
+			// rotation survivable: the previous CA stays in the overlap bundle,
+			// so certificates issued under it keep working until they expire.
+			Eventually(func(g Gomega) {
+				surviving := gowebWhoami(g, client, report.PeerModeProjected, http200)
+				g.Expect(surviving.Authenticated).To(BeTrue(),
+					"a certificate issued before the rotation must keep authenticating "+
+						"while its CA remains in the published bundle")
+			}).Should(Succeed())
+
+			By("verifying the server trusts both CAs at once, which is why both clients work")
+			Expect(anchorFingerprints(after)).To(ContainElement(fingerprint(rotated.Cert)))
+			Expect(anchorFingerprints(after)).To(ContainElement(fingerprint(baselineCA)))
+
+			By("verifying neither process restarted while all of that happened")
+			expectNoRestarts(server)
+			expectNoRestarts(client)
+		})
+	})
+}
+
+// The two HTTP outcomes these specs expect from /whoami.json. Named so a call
+// site states which one it is asserting rather than passing a bare integer.
+const (
+	http200 = 200
+	http403 = 403
+)
+
+// gowebStatusDocument is the part of goweb's /status.json this suite reads.
+//
+// It is a local, partial mirror of goweb's own type rather than an import: the
+// image is pinned by digest and its JSON is a wire contract, so decoding only
+// the fields asserted on keeps a field added upstream from being a compile
+// error here. Refresh it alongside gowebImage.
+type gowebStatusDocument struct {
+	Server struct {
+		StartedAt time.Time `json:"started_at"`
+	} `json:"server"`
+
+	Certificate *struct {
+		FingerprintSHA256 string   `json:"fingerprint_sha256"`
+		Subject           string   `json:"subject"`
+		Issuer            string   `json:"issuer"`
+		DNSNames          []string `json:"dns_names"`
+		URIs              []string `json:"uris"`
+		Validity          string   `json:"validity"`
+	} `json:"certificate"`
+
+	TrustBundle *struct {
+		Anchors []struct {
+			Subject           string `json:"subject"`
+			FingerprintSHA256 string `json:"fingerprint_sha256"`
+		} `json:"anchors"`
+		LoadedAt     time.Time `json:"loaded_at"`
+		LastSuccess  time.Time `json:"last_success"`
+		StaleSeconds int64     `json:"stale_seconds"`
+		LastError    string    `json:"last_error"`
+	} `json:"trust_bundle"`
+}
+
+// gowebWhoamiDocument is the part of goweb's /whoami.json this suite reads.
+type gowebWhoamiDocument struct {
+	Authenticated bool   `json:"authenticated"`
+	Reason        string `json:"reason"`
+
+	Client *struct {
+		Subject           string   `json:"subject"`
+		Issuer            string   `json:"issuer"`
+		FingerprintSHA256 string   `json:"fingerprint_sha256"`
+		DNSNames          []string `json:"dns_names"`
+		URIs              []string `json:"uris"`
+		Chain             []string `json:"chain"`
+	} `json:"client"`
+}
+
+// anchorFingerprints returns the SHA-256 fingerprints of the trust anchors the
+// server reports enforcing, in the same encoding certificateFingerprints
+// produces so the two can be compared directly.
+func anchorFingerprints(status gowebStatusDocument) []string {
+	if status.TrustBundle == nil {
+		return nil
+	}
+	fingerprints := make([]string, 0, len(status.TrustBundle.Anchors))
+	for _, anchor := range status.TrustBundle.Anchors {
+		fingerprints = append(fingerprints, anchor.FingerprintSHA256)
+	}
+	return fingerprints
+}
+
+// certificateURIs renders a certificate's URI SANs as strings, the form goweb
+// reports them in.
+func certificateURIs(cert *x509.Certificate) []string {
+	uris := make([]string, 0, len(cert.URIs))
+	for _, uri := range cert.URIs {
+		uris = append(uris, uri.String())
+	}
+	return uris
+}
+
+// gowebServerDNSName is the name clients dial the server by: the Service DNS
+// form, which is one of the two SANs the signer issues by default and the only
+// one the cluster resolves.
+func gowebServerDNSName() string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local", gowebServerPodName, workloadNamespace)
+}
+
+func gowebStatusURL() string {
+	return fmt.Sprintf("https://%s:%d/status.json", gowebServerDNSName(), gowebPort)
+}
+
+func gowebWhoamiURL() string {
+	return fmt.Sprintf("https://%s:%d/whoami.json", gowebServerDNSName(), gowebPort)
+}
+
+// gowebStatus fetches and decodes the server's status document, presenting the
+// caller pod's projected credential.
+func gowebStatus(g Gomega, from podRef) gowebStatusDocument {
+	facts := gowebPeerRequest(g, from, report.PeerModeProjected, gowebStatusURL())
+	g.Expect(facts.HTTPStatus).To(Equal(http200),
+		"the server must serve its status document; error was %q", facts.Error)
+
+	var status gowebStatusDocument
+	g.Expect(json.Unmarshal([]byte(facts.Body), &status)).To(Succeed(),
+		"decoding the server's status document: %s", facts.Body)
+	return status
+}
+
+// gowebWhoami fetches and decodes the server's account of the caller's identity,
+// requiring the given HTTP status.
+//
+// The status is a parameter rather than always 200 because the refusal is as
+// much a result as the acceptance: /whoami.json answers 403 with a populated
+// document when no certificate was presented, and a helper that insisted on 200
+// could not express the negative at all.
+func gowebWhoami(g Gomega, from podRef, mode string, wantStatus int) gowebWhoamiDocument {
+	facts := gowebPeerRequest(g, from, mode, gowebWhoamiURL())
+	g.Expect(facts.HTTPStatus).To(Equal(wantStatus),
+		"the server must answer HTTP %d to a %s credential; error was %q", wantStatus, mode, facts.Error)
+
+	var whoami gowebWhoamiDocument
+	g.Expect(json.Unmarshal([]byte(facts.Body), &whoami)).To(Succeed(),
+		"decoding the server's whoami document: %s", facts.Body)
+	return whoami
+}
+
+// gowebPeerRequest runs one credential-probe request from a client pod and
+// returns what it observed.
+//
+// It goes through `kubectl exec` rather than reading the pod's log, and that is
+// what the rotation spec needs: the pod's startup report describes the world as
+// it was when the container began, and the question here is what a pod that has
+// been running for ten minutes can do *now*. Exec'ing also makes each request
+// retryable, so a transient failure is retried by the caller's Eventually
+// instead of requiring a new pod.
+func gowebPeerRequest(g Gomega, from podRef, mode, url string) report.PeerFacts {
+	cmd := exec.Command("kubectl", "exec", from.name, "-n", from.namespace,
+		"-c", workloadContainerName, "--",
+		"/credprobe",
+		"-role="+report.RolePeer,
+		"-peer-mode="+mode,
+		"-peer-url="+url,
+		// Report and exit: this is a one-shot run inside a pod that is already
+		// held open by its own long-lived process.
+		"-hold=0",
+		fmt.Sprintf("-expect-chain-len=%d", defaultChainLength),
+		fmt.Sprintf("-bundle=%s/%s", certTestPodMountPath, defaultCredentialBundlePath),
+		fmt.Sprintf("-trust=%s/ca.crt", certTestPodMountPath))
+	output, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred(),
+		"running the peer probe in pod %s failed; %s; output was: %s", from, podStatusSummary(from), output)
+
+	parsed, err := report.Parse(output)
+	g.Expect(err).NotTo(HaveOccurred(),
+		"the peer probe in pod %s did not report: %v; output was: %s", from, err, output)
+
+	g.Expect(parsed.CheckNames()).To(Equal(report.ExpectedChecks(report.RolePeer)),
+		"the peer probe must run every check; a short report means it stopped early\n%s", parsed)
+	g.Expect(parsed.Failures()).To(BeEmpty(),
+		"the peer probe reached no definite outcome\n%s", parsed)
+	g.Expect(parsed.Facts.Peer).NotTo(BeNil(), "the peer role must record peer facts\n%s", parsed)
+
+	return *parsed.Facts.Peer
+}
+
+// observerTrustAnchors reads the projected trust anchors out of a pod's observer
+// sidecar.
+//
+// It is mountedTrustAnchors for a pod whose workload container cannot be exec'd
+// into: goweb is distroless and has neither a shell nor cat. The volume is the
+// pod's, so the sidecar sees the identical projection at the identical moment -
+// this is not a proxy for what the server can read, it is the same file.
+func observerTrustAnchors(g Gomega, ref podRef) []*x509.Certificate {
+	cmd := exec.Command("kubectl", "exec", ref.name, "-n", ref.namespace,
+		"-c", observerContainerName, "--",
+		"cat", certTestPodMountPath+"/ca.crt")
+	output, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred(),
+		"Failed to read the projected trust anchors from pod %s; %s", ref, podStatusSummary(ref))
+	return parseCertificateChain(g, output)
+}
+
+// expectAnchorsUsableAsClientCAs asserts every published anchor satisfies what
+// goweb requires of a client CA.
+//
+// The conditions are goweb's, restated here because it enforces them at startup
+// and fails the whole load on one bad anchor: basic constraints present and
+// asserting CA, the certSign key usage explicitly set, and the certificate
+// currently within its validity window. RFC 5280 permits a CA to omit the key
+// usage extension; goweb does not, and that is the condition most likely to be
+// surprising.
+func expectAnchorsUsableAsClientCAs(anchors []*x509.Certificate) {
+	GinkgoHelper()
+
+	now := time.Now()
+	for _, anchor := range anchors {
+		subject := anchor.Subject.CommonName
+		Expect(anchor.BasicConstraintsValid).To(BeTrue(),
+			"anchor %q has no valid basic constraints; the TLS workload refuses to start on it", subject)
+		Expect(anchor.IsCA).To(BeTrue(),
+			"anchor %q is not a CA; the TLS workload refuses to start on it", subject)
+		Expect(anchor.KeyUsage&x509.KeyUsageCertSign).NotTo(BeZero(),
+			"anchor %q does not assert the certSign key usage; the TLS workload requires it explicitly", subject)
+		Expect(now).To(BeTemporally(">=", anchor.NotBefore),
+			"anchor %q is not yet valid; the TLS workload refuses to start on it", subject)
+		Expect(now).To(BeTemporally("<", anchor.NotAfter),
+			"anchor %q has expired; the TLS workload refuses to start on it. A preceding container "+
+				"rotates through a deliberately short-lived CA - if that one is still in the published "+
+				"window, this is why", subject)
+	}
+}
+
+// expectNoRestarts asserts every container in the pod is still on its first run.
+//
+// A restart would give a container a fresh process with a freshly loaded trust
+// bundle, which is precisely the thing the rotation spec claims did not have to
+// happen. The container statuses are decoded rather than string-matched so an
+// empty list - a pod whose statuses have not been published yet - fails instead
+// of passing vacuously.
+func expectNoRestarts(ref podRef) {
+	GinkgoHelper()
+
+	cmd := exec.Command("kubectl", "get", "pod", ref.name, "-n", ref.namespace, "-o", "json")
+	output, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to read pod %s", ref)
+
+	var pod corev1.Pod
+	Expect(json.Unmarshal([]byte(trimToJSON(output)), &pod)).To(Succeed(),
+		"Failed to decode pod %s", ref)
+
+	Expect(pod.Status.ContainerStatuses).NotTo(BeEmpty(),
+		"pod %s reported no container statuses, so 'no restarts' would prove nothing", ref)
+	for _, status := range pod.Status.ContainerStatuses {
+		Expect(status.RestartCount).To(BeZero(),
+			"container %s of pod %s restarted %d time(s); the hot-reload claim requires the "+
+				"original process to still be running", status.Name, ref, status.RestartCount)
+	}
+}
+
+// createGowebServer creates the TLS workload.
+//
+// Everything it needs is configuration: the credential bundle it serves and the
+// client CA file it verifies against are the two files kubelet already projects,
+// named through goweb's own environment variables. Nothing about the image knows
+// this signer exists, which is what makes its verdict worth having.
+func createGowebServer() podRef {
+	GinkgoHelper()
+
+	bundlePath := fmt.Sprintf("%s/%s", certTestPodMountPath, defaultCredentialBundlePath)
+	trustPath := certTestPodMountPath + "/ca.crt"
+
+	return createCertTestPod(certTestPod{
+		name:                   gowebServerPodName,
+		image:                  gowebImage,
+		clusterTrustBundleName: trustBundleName,
+		labels:                 map[string]string{gowebSelectorLabel: gowebServerPodName},
+		observerSidecar:        true,
+		holdSeconds:            gowebObserverHold,
+		userAnnotations: map[string]string{
+			signerName + "-uris": gowebSpiffeURI,
+		},
+		env: []corev1.EnvVar{
+			// One file holding the key and the chain: exactly the layout kubelet
+			// writes, which is why no adaptation is needed between the signer's
+			// output and this server's input.
+			{Name: "GOWEB_X509_BUNDLE", Value: bundlePath},
+			// Setting this is what turns client-certificate verification on;
+			// there is no separate boolean.
+			{Name: "GOWEB_MTLS_CLIENT_CA", Value: trustPath},
+			{Name: "GOWEB_PORT", Value: fmt.Sprintf("%d", gowebPort)},
+			{Name: "GOWEB_RELOAD_DEBOUNCE", Value: gowebReloadDebounce},
+			{Name: "GOWEB_RELOAD_INTERVAL", Value: gowebReloadInterval},
+		},
+	})
+}
+
+// createGowebClient creates a credential-probe pod that can authenticate to the
+// server.
+//
+// It runs in the client role at startup, which proves its own credential before
+// any peer is involved, and then holds so the specs can exec peer requests
+// through it for as long as the container lives.
+func createGowebClient(podName string) podRef {
+	GinkgoHelper()
+
+	return createCertTestPod(certTestPod{
+		name:                   podName,
+		image:                  workloadProbeImage,
+		serviceAccountName:     gowebClientServiceAccount,
+		clusterTrustBundleName: trustBundleName,
+		userAnnotations: map[string]string{
+			// clientAuth is required, not cosmetic: Go's TLS server rejects a
+			// client certificate without it for incompatible key usage, and the
+			// spec would then be asserting an EKU boundary rather than trust.
+			signerName + "-eku":  "client",
+			signerName + "-uris": gowebSpiffeURI,
+		},
+		args: []string{
+			"-role=" + report.RoleClient,
+			fmt.Sprintf("-expect-chain-len=%d", defaultChainLength),
+			fmt.Sprintf("-allowed-dns=%s.%s.pod.cluster.local", podName, workloadNamespace),
+			fmt.Sprintf("-unrelated-dns=%s.%s.pod.attacker.example", podName, workloadNamespace),
+			fmt.Sprintf("-bundle=%s/%s", certTestPodMountPath, defaultCredentialBundlePath),
+			fmt.Sprintf("-trust=%s/ca.crt", certTestPodMountPath),
+			// Long enough to outlive the whole container; see gowebObserverHold.
+			fmt.Sprintf("-hold=%ds", gowebObserverHold),
+		},
+	})
+}
+
+// createGowebClientServiceAccount creates the identity the client pods run as,
+// so their SPIFFE ID differs from the server's.
+func createGowebClientServiceAccount() {
+	GinkgoHelper()
+
+	account := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gowebClientServiceAccount,
+			Namespace: workloadNamespace,
+		},
+	}
+	applyObject(account, "service account "+gowebClientServiceAccount)
+
+	DeferCleanup(func() {
+		cmd := exec.Command("kubectl", "delete", "serviceaccount", gowebClientServiceAccount,
+			"-n", workloadNamespace, "--ignore-not-found=true")
+		_, _ = utils.Run(cmd)
+	})
+}
+
+// createGowebService publishes the server under a name its certificate carries.
+//
+// It is headless on purpose. A ClusterIP would put kube-proxy between the two
+// pods and the handshake would terminate against a virtual address; with no
+// cluster IP, the name resolves straight to the pod and the TLS session is
+// genuinely pod to pod, which is the claim these specs are making.
+func createGowebService() {
+	GinkgoHelper()
+
+	service := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gowebServerPodName,
+			Namespace: workloadNamespace,
+			Labels:    map[string]string{e2eWorkloadLabel: "true"},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
+			Selector:  map[string]string{gowebSelectorLabel: gowebServerPodName},
+			Ports: []corev1.ServicePort{{
+				Name:       "https",
+				Port:       gowebPort,
+				TargetPort: intstr.FromInt32(gowebPort),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	}
+	applyObject(service, "service "+gowebServerPodName)
+
+	DeferCleanup(func() {
+		cmd := exec.Command("kubectl", "delete", "service", gowebServerPodName,
+			"-n", workloadNamespace, "--ignore-not-found=true")
+		_, _ = utils.Run(cmd)
+	})
+}
+
+// applyObject creates a typed object through kubectl, over stdin.
+//
+// Typed rather than a YAML string for the same reason createCertTestPod builds a
+// typed Pod: a field the API renames becomes a compile error here instead of a
+// setting the apiserver silently ignores.
+func applyObject(object any, description string) {
+	GinkgoHelper()
+
+	manifest, err := json.Marshal(object)
+	Expect(err).NotTo(HaveOccurred(), "Failed to marshal %s", description)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = bytes.NewReader(manifest)
+	output, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to apply %s: %s", description, output)
+}


### PR DESCRIPTION
Adds four end-to-end specs that exercise the issued credential against [goweb-https](https://github.com/RafPe/goweb-https), a real HTTPS workload, rather than a synthetic in-process handshake. All four are `nightly`-labelled; the PR tier is unchanged.

## What the specs prove

1. **Real cross-pod TLS.** goweb serves from the projected bundle; a client pod verifies using the projected `ca.crt` alone. `/status.json`'s `certificate.fingerprint_sha256`, `dns_names` and `uris` match the leaf in PodCertificateRequest status. This is the suite's first proof that two pods can actually talk — everything prior was loopback inside one process.
2. **An issued identity is *accepted*, not merely present.** A client whose certificate carries a SPIFFE URI authenticates; `/whoami.json` reports `authenticated:true` with the expected URI. Clients run as their own service account, so a server echoing its own identity cannot satisfy the assertion.
3. **Transitional trust, functionally.** Previously asserted structurally, by comparing fingerprint sets. Now: after a rotation, a client issued under the **new** CA authenticates to a server started **before** it, and a client issued under the **previous** CA still authenticates — with neither pod restarting (`restartCount` plus an unchanged `server.started_at`, which is what proves the process survived rather than the container). Enforced anchors must **equal** the published bundle as a set, not merely contain the new CA; containment alone would pass forever for a server that accumulates anchors and never drops one, i.e. a revocation silently not taking effect.
4. **Negatives, classified and distinct.** An untrusted client certificate and a missing one are different outcomes, not two spellings of one — goweb uses `tls.VerifyClientCertIfGiven`, so a foreign certificate aborts the handshake and no handler runs.

## Latency decomposition

The rotation spec reports both terms separately. Measured twice: **kubelet 5m13s / 5m26s, goweb 0s**.

The `0s` is the instrument floor (~5s polling granularity), not a measured instant reload; goweb's configured worst case is 2.2s, and the fixture sets debounce and reconcile interval low precisely so its term is bounded by configuration. The remainder is kubelet's ClusterTrustBundle normalization cache TTL plus pod sync. Reporting a single number would attribute five minutes of kubelet latency to the workload.

## CI changes

- **`run-nightly` opt-in trigger.** Nightly specs are excluded from the PR gate and otherwise run only from `main` by cron, so a PR could break one and nobody would learn until after it merged. A PR carrying the `run-nightly` label now runs the full tier. `labeled` only, not `synchronize` — the tier is 40 minutes; re-runs go through `workflow_dispatch`. Concurrency is ref-scoped so PR runs do not serialise behind each other or the cron.
- **Release-metadata scope fix.** The "exactly one `release/*` label" gate was scoped `branches: [main]`, so stacked PRs were never checked, and a base auto-retarget is an `edited` event that was not in its trigger list — meaning a stacked PR could reach `main` without the gate ever running. Filter removed, `edited` added. The job reads changed files from the PR's own API endpoint, so it is base-relative and correct for any base.

## Results

| | result | duration |
| --- | --- | --- |
| PR tier | 78 passed, 0 failed | 900.97s |
| Nightly tier | **91 passed, 0 failed, 0 skipped** | 2440.14s |

40m40s sits well inside the 60m ginkgo budget and the 90m job ceiling; no timeout was changed.

## Notes

The image is pinned by multi-arch **index** digest (`sha256:9173587079…`) so it resolves on both arm64 and amd64; a per-platform manifest digest would break one. The refresh command is recorded alongside it.

Two crypto/tls contract details are pinned by millisecond unit tests because both fail silently: `errors.As(err, &tls.AlertError{})` never matches a *received* alert (it arrives as `*net.OpError{Op:"remote error"}` wrapping an unexported type), and presenting an untrusted client certificate requires `GetClientCertificate` — with `Certificates`, Go filters the candidate against the server's acceptable-CA list and the untrusted case quietly becomes the no-certificate case.

`ca_lifecycle_test.go`'s existing observer is deliberately untouched.