### PR TITLE
fix(#102): reload the CA on a timer, not only on filesystem events

### DIFF
--- a/.changes/unreleased/fixed-periodic-ca-reconciliation.yaml
+++ b/.changes/unreleased/fixed-periodic-ca-reconciliation.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: The signer now reloads its CA on a 60s timer as well as on filesystem events, so a reload that failed after its retries - or a rotation whose events were dropped or never delivered - converges without a pod restart. The CA is fingerprinted, so consumers are notified and the ClusterTrustBundle republished only when the material actually changed, rather than on every event of a rotation burst. The watch also reconciles once at startup, closing the window between the initial load and the watch being registered, and no longer ignores file removals.

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -46,12 +47,18 @@ type CertificateAuthority struct {
 	maxPreviousCerts     int
 	nowFunc              func() time.Time
 	backDate             time.Duration
-	mu                   sync.Mutex
+	// fingerprint is the SHA-256 of the loaded certificate's DER, used by load
+	// to tell a reload that changed the material from one that did not. It is
+	// content-based rather than file metadata, so a rotation that preserves
+	// mtime is still seen. Guarded by mu, like the fields it describes.
+	fingerprint [sha256.Size]byte
+	mu          sync.Mutex
 
 	// Watch/reload tuning. Set to sane defaults in New; overridable in tests.
-	drainWindow    time.Duration // coalesce window for a burst of fs events
-	reloadAttempts int           // bounded retries for a single reload
-	reloadBackoff  time.Duration // base delay between reload attempts
+	drainWindow       time.Duration // coalesce window for a burst of fs events
+	reloadAttempts    int           // bounded retries for a single reload
+	reloadBackoff     time.Duration // base delay between reload attempts
+	reconcileInterval time.Duration // periodic reload, independent of events
 
 	// health tracks the recent reload outcomes and whether the watcher has
 	// exited unrecoverably. It is guarded by its own mutex (separate from mu)
@@ -78,6 +85,24 @@ const (
 	// lasted, measured from its first failure, before readiness may fail.
 	reloadFailureGracePeriod = 10 * time.Minute
 )
+
+// caReconcileInterval is how often the watch loop reloads the CA without
+// waiting for a filesystem event. fsnotify is not a durable event log: watches
+// can be dropped, the kernel queue can overflow, and a watched directory that
+// is deleted and recreated leaves the watch on the stale inode, in which case
+// reloads are not failing, they are simply never attempted again. Reloading on
+// a timer is what makes convergence to the material on disk guaranteed rather
+// than best effort.
+//
+// This value has a ceiling, and it is not the obvious one. A tick makes a
+// single reload attempt, so a permanently unloadable CA needs
+// reloadFailureThreshold ticks to become eligible for a readiness failure.
+// Raising the interval past reloadFailureGracePeriod / reloadFailureThreshold
+// (3m20s) would make the threshold rather than the grace period the binding
+// constraint in Healthy, so the signer would report NotReady *later* than it
+// does today - a slower reconcile delaying the alarm rather than only the
+// repair. At 60s there is ~3.3x of margin.
+const caReconcileInterval = 60 * time.Second
 
 // WithBackDate is an [Option], which configures the [CertificateAuthority] to
 // use the given backdate when signing certificate requests.
@@ -139,6 +164,7 @@ func New(caFile, caKeyFile string, opts ...Option) (*CertificateAuthority, error
 		drainWindow:          500 * time.Millisecond,
 		reloadAttempts:       5,
 		reloadBackoff:        200 * time.Millisecond,
+		reconcileInterval:    caReconcileInterval,
 	}
 
 	// Additional configuration of the CA with the given options.
@@ -148,47 +174,61 @@ func New(caFile, caKeyFile string, opts ...Option) (*CertificateAuthority, error
 		}
 	}
 
-	if err := ca.load(); err != nil {
+	if _, err := ca.load(); err != nil {
 		return nil, err
 	}
 
 	return ca, nil
 }
 
-// load loads the certificate and key for the [CertificateAuthority].
-func (ca *CertificateAuthority) load() error {
+// load loads the certificate and key for the [CertificateAuthority]. It reports
+// whether the material on disk differs from what was already loaded, so callers
+// can gate downstream work - notifying consumers, republishing the trust bundle
+// - on a real rotation rather than on every successful read. An unchanged read
+// still counts as a successful reload: "the CA is readable" is the health
+// signal, "the CA changed" is not.
+func (ca *CertificateAuthority) load() (bool, error) {
 	caCert, err := tls.LoadX509KeyPair(ca.certFile, ca.privKeyFile)
 	if err != nil {
-		return fmt.Errorf("failed to load key pair: %w", err)
+		return false, fmt.Errorf("failed to load key pair: %w", err)
 	}
 
 	caX509Cert, err := x509.ParseCertificate(caCert.Certificate[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse certificate: %w", err)
+		return false, fmt.Errorf("failed to parse certificate: %w", err)
 	}
 
 	// Validate: CA
 	if !caX509Cert.BasicConstraintsValid || !caX509Cert.IsCA {
-		return errors.New("certificate is not a valid CA certificate")
+		return false, errors.New("certificate is not a valid CA certificate")
 	}
 
 	// Validate: key usage
 	if (caX509Cert.KeyUsage & x509.KeyUsageCertSign) == 0 {
-		return errors.New("CA certificate cannot sign certificates")
+		return false, errors.New("CA certificate cannot sign certificates")
 	}
 
 	// Validate: not expired
 	if time.Now().After(caX509Cert.NotAfter) {
-		return errors.New("CA certificate has expired")
+		return false, errors.New("CA certificate has expired")
 	}
 
 	signer, ok := caCert.PrivateKey.(crypto.Signer)
 	if !ok {
-		return errors.New("private key does not implement crypto.Signer interface")
+		return false, errors.New("private key does not implement crypto.Signer interface")
 	}
+
+	fingerprint := sha256.Sum256(caCert.Certificate[0])
 
 	ca.mu.Lock()
 	defer ca.mu.Unlock()
+
+	// Unchanged material: return before touching the certificate, the signer or
+	// the history. The comparison belongs inside the critical section, since
+	// ca.fingerprint is written below under the same lock.
+	if ca.certificate != nil && ca.fingerprint == fingerprint {
+		return false, nil
+	}
 
 	// Rotate: push current certificate into the history if it changed
 	if ca.certificate != nil && !ca.certificate.Equal(caX509Cert) {
@@ -205,6 +245,7 @@ func (ca *CertificateAuthority) load() error {
 	// Set new cert and signer
 	ca.certificate = caX509Cert
 	ca.signer = signer
+	ca.fingerprint = fingerprint
 
 	// Remove the current cert from the previous CA certs, in order to avoid
 	// duplicate entries in the trust bundle.
@@ -212,7 +253,7 @@ func (ca *CertificateAuthority) load() error {
 		return item.Equal(ca.certificate)
 	})
 
-	return nil
+	return true, nil
 }
 
 // Sign is responsible for signing our certificate request configuration.
@@ -356,14 +397,22 @@ func (ca *CertificateAuthority) Watch(ctx context.Context, notify chan<- struct{
 		}
 	}
 
+	// Reconcile once now that the watches are registered: a rotation landing
+	// between New's initial load and this point produces no observable event,
+	// so without this pass it would go unnoticed until the first tick.
+	logger.Info("reloading the CA periodically as well as on events", "interval", ca.reconcileInterval)
+	ca.reconcileOnce(logger, notify, "watch startup")
+
 	return ca.watchLoop(ctx, logger, watcher.Events, watcher.Errors, notify)
 }
 
 // watchLoop consumes filesystem events until ctx is canceled, reloading the CA
-// (with bounded retry) whenever the mounted files change. It returns nil on a
-// clean shutdown (ctx canceled) and a non-nil error if fsnotify closes a
-// channel, so the caller can fail fast and be restarted rather than spinning on
-// zero values read from a closed channel.
+// (with bounded retry) whenever the mounted files change, and reloading it
+// unconditionally every reconcileInterval so a rotation the event path never
+// saw, or failed to load, still converges. It returns nil on a clean shutdown
+// (ctx canceled) and a non-nil error if fsnotify closes a channel, so the caller
+// can fail fast and be restarted rather than spinning on zero values read from a
+// closed channel.
 func (ca *CertificateAuthority) watchLoop(
 	ctx context.Context,
 	logger logr.Logger,
@@ -371,15 +420,28 @@ func (ca *CertificateAuthority) watchLoop(
 	errs <-chan error,
 	notify chan<- struct{},
 ) error {
+	ticker := time.NewTicker(ca.reconcileInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-ticker.C:
+			// Reconcile on every tick, not only while reloads are failing: the
+			// silent routes (dropped events, a stale inode after the watched
+			// directory is recreated) leave the CA in a *successful* state, so
+			// a failure-gated pass would never run in exactly those cases.
+			ca.reconcileOnce(logger, notify, "periodic reconciliation")
 		case event, ok := <-events:
 			if !ok {
 				return ca.failWatcher(errWatchChannelClosed)
 			}
-			if !event.Has(fsnotify.Create) && !event.Has(fsnotify.Write) && !event.Has(fsnotify.Rename) {
+			// Remove is included because a kubelet-style atomic swap replaces
+			// the timestamped directory behind ..data, and a plain deletion of
+			// the material must be observed rather than silently ignored.
+			if !event.Has(fsnotify.Create) && !event.Has(fsnotify.Write) &&
+				!event.Has(fsnotify.Rename) && !event.Has(fsnotify.Remove) {
 				continue
 			}
 
@@ -396,23 +458,25 @@ func (ca *CertificateAuthority) watchLoop(
 			}
 
 			logger.Info("reloading CA certificate")
-			if err := ca.reloadWithRetry(ctx, logger); err != nil {
+			changed, err := ca.reloadWithRetry(ctx, logger)
+			if err != nil {
 				// The last-good CA is retained, so signing keeps working.
-				// Stay watching so a later good write recovers; readiness is
-				// only affected once the failures persist (see Healthy).
+				// Stay watching so a later good write - or the next tick -
+				// recovers; readiness is only affected once the failures
+				// persist (see Healthy).
 				logger.Error(err, "failed to reload CA certificate after retries")
 				continue
 			}
-			logger.Info("CA certificate reloaded successfully")
-
-			// Don't block here, so that reloading the CA can proceed as
-			// usual, even if we have slow consumers.
-			if notify != nil {
-				select {
-				case notify <- struct{}{}:
-				default:
-				}
+			if !changed {
+				// A single rotation can drive more than one reload: two
+				// watched directories, events arriving after the drain window,
+				// or a tick that already picked the material up. Only the one
+				// that actually changed the CA is worth publishing.
+				logger.V(1).Info("CA certificate on disk is unchanged, nothing to publish")
+				continue
 			}
+			logger.Info("CA certificate reloaded successfully")
+			notifyChanged(notify)
 		case err, ok := <-errs:
 			if !ok {
 				return ca.failWatcher(errWatchChannelClosed)
@@ -444,21 +508,64 @@ func (ca *CertificateAuthority) drainEvents(ctx context.Context, logger logr.Log
 	}
 }
 
+// reconcileOnce reloads the CA once, without retrying, and notifies callers
+// when the material actually changed. The retry budget in reloadWithRetry
+// exists to ride out the torn state a rotation briefly leaves on disk, which is
+// event-adjacent; a pass that is not correlated with a write has nothing to ride
+// out, and the next pass is itself the retry. Keeping it to a single attempt
+// also bounds the log stream: a permanently unloadable CA costs one line per
+// interval rather than the whole retry burst, forever.
+func (ca *CertificateAuthority) reconcileOnce(logger logr.Logger, notify chan<- struct{}, cause string) {
+	changed, err := ca.load()
+
+	// Recorded regardless of whether anything changed: a readable CA clears the
+	// failure streak (so a replica recovers readiness without a restart), and an
+	// unreadable one accumulates towards the readiness threshold even though no
+	// filesystem event ever arrived.
+	ca.recordReloadResult(err)
+
+	switch {
+	case err != nil:
+		logger.Error(err, "failed to reload CA certificate; retaining the last-good CA", "cause", cause)
+	case changed:
+		logger.Info("CA certificate reloaded successfully", "cause", cause)
+		notifyChanged(notify)
+	default:
+		logger.V(1).Info("CA certificate on disk is unchanged", "cause", cause)
+	}
+}
+
+// notifyChanged performs a non-blocking send on notify, so reloading the CA can
+// proceed as usual even if we have slow consumers. A nil channel means the
+// caller did not ask for notifications.
+func notifyChanged(notify chan<- struct{}) {
+	if notify == nil {
+		return
+	}
+	select {
+	case notify <- struct{}{}:
+	default:
+	}
+}
+
 // reloadWithRetry attempts to reload the CA, retrying on a bounded linear
 // backoff. A failed attempt leaves the last-good CA in place (see load), so
 // callers keep signing with the previous material until a good reload succeeds.
 // Every attempt is recorded for the readiness probe (see Healthy).
-// It returns nil on the first successful reload, ctx.Err() if ctx is canceled,
-// or the final error once the attempt budget is exhausted.
-func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr.Logger) error {
+// It reports whether the reload changed the CA material, so callers only
+// republish on a real rotation. It returns nil on the first successful reload,
+// ctx.Err() if ctx is canceled, or the final error once the attempt budget is
+// exhausted.
+func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr.Logger) (bool, error) {
 	const maxBackoff = 5 * time.Second
 
 	var err error
 	for attempt := 1; ; attempt++ {
-		if err = ca.load(); err == nil {
+		var changed bool
+		if changed, err = ca.load(); err == nil {
 			ca.recordReloadResult(nil)
 
-			return nil
+			return changed, nil
 		}
 
 		// Record each failed attempt rather than only the exhausted burst:
@@ -467,7 +574,7 @@ func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr
 		// without one.
 		failures := ca.recordReloadResult(err)
 		if attempt >= ca.reloadAttempts {
-			return fmt.Errorf("reload failed after %d attempt(s), %d consecutive failure(s): %w",
+			return false, fmt.Errorf("reload failed after %d attempt(s), %d consecutive failure(s): %w",
 				attempt, failures, err)
 		}
 		logger.Error(err, "failed to reload CA certificate, retrying",
@@ -478,7 +585,7 @@ func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return ctx.Err()
+			return false, ctx.Err()
 		case <-timer.C:
 		}
 	}

--- a/internal/kubernetes/authority/authority_readiness_test.go
+++ b/internal/kubernetes/authority/authority_readiness_test.go
@@ -155,7 +155,7 @@ func TestPersistentlyUnloadableCAEventuallyFailsReadiness(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := ca.reloadWithRetry(ctx, log.FromContext(ctx)); err == nil {
+	if _, err := ca.reloadWithRetry(ctx, log.FromContext(ctx)); err == nil {
 		t.Fatal("reloadWithRetry() = nil, want error for a permanently unloadable CA")
 	}
 

--- a/internal/kubernetes/authority/authority_reconcile_test.go
+++ b/internal/kubernetes/authority/authority_reconcile_test.go
@@ -1,0 +1,313 @@
+package authority
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/testutil"
+)
+
+// failureCount reads the reload failure streak under the health mutex, so tests
+// can poll it without racing the watch loop.
+func (ca *CertificateAuthority) failureCount() int {
+	ca.healthMu.Lock()
+	defer ca.healthMu.Unlock()
+
+	return ca.reloadFailures
+}
+
+// startWatchLoop runs the watch loop with channels that never fire, which
+// isolates the periodic reconciliation completely: nothing but the ticker can
+// start a reload. It returns the notification channel and a stop function that
+// cancels the loop and waits for it to return.
+func startWatchLoop(t *testing.T, ca *CertificateAuthority) (chan struct{}, chan error, func()) {
+	t.Helper()
+
+	events := make(chan fsnotify.Event) // open, never sends
+	errs := make(chan error)            // open, never sends
+	notify := make(chan struct{}, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- ca.watchLoop(ctx, log.FromContext(ctx), events, errs, notify) }()
+
+	return notify, errs, func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("watchLoop() = %v, want nil on context cancellation", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("watchLoop did not return after context cancellation")
+		}
+	}
+}
+
+// The reload burst a rotation produces is consumed before the retries run, so
+// when those retries are exhausted no further filesystem event is coming: the
+// CA is stuck on the old material until the process restarts. The periodic
+// reconciliation is what recovers it. This is the direct regression test for
+// the defect, and it can only be written at the watchLoop seam, because writing
+// a good CA to disk is itself an event everywhere else.
+func TestReconcileTickRecoversAFailedReloadWithoutAnEvent(t *testing.T) {
+	clock := newFakeClock()
+	ca, dir := newTestCA(t, clock)
+	ca.reloadAttempts = 3
+	ca.reloadBackoff = time.Millisecond
+	ca.reconcileInterval = 20 * time.Millisecond
+
+	// Spend the whole retry budget on unloadable material, exactly as the event
+	// path would have, and let the failure streak cross into NotReady.
+	nonCA, err := testutil.NewNonCA("not-a-ca.example.org", time.Hour)
+	if err != nil {
+		t.Fatalf("generate non-CA: %v", err)
+	}
+	if _, _, err := nonCA.WriteFiles(dir); err != nil {
+		t.Fatalf("write non-CA files: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := ca.reloadWithRetry(ctx, log.FromContext(ctx)); err == nil {
+		t.Fatal("reloadWithRetry() = nil, want error for a permanently unloadable CA")
+	}
+	clock.advance(reloadFailureGracePeriod)
+	if err := ca.Healthy(); err == nil {
+		t.Fatal("Healthy() = nil after an exhausted retry budget past the grace period, want an error")
+	}
+
+	// Good material lands on disk before the loop starts, so no event of any
+	// kind is delivered for it.
+	rotated := writeCA(t, dir, "recovered-ca.example.org", 24*time.Hour)
+
+	notify, _, stop := startWatchLoop(t, ca)
+	defer stop()
+
+	select {
+	case <-notify:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the periodic reconciliation to reload the CA")
+	}
+
+	if got := parseChain(t, ca.TrustBundlePEM()); !got[0].Equal(rotated.Cert) {
+		t.Error("the current CA must be the recovered certificate after a reconcile tick")
+	}
+	// The streak is cleared by a successful reload, so the replica rejoins the
+	// Service without needing a restart. The clock is still well past the grace
+	// period, so this can only be the streak resetting.
+	if err := ca.Healthy(); err != nil {
+		t.Errorf("Healthy() after a successful reconcile tick = %v, want nil", err)
+	}
+}
+
+// A tick must notify consumers when, and only when, the CA material actually
+// changed: an unchanged tick that notified would republish the
+// ClusterTrustBundle every interval for nothing, and a changed tick that stayed
+// quiet would leave pods trusting a bundle without the signing CA.
+func TestReconcileTickNotifiesOnlyWhenTheCAChanges(t *testing.T) {
+	clock := newFakeClock()
+	ca, dir := newTestCA(t, clock)
+	ca.reconcileInterval = 20 * time.Millisecond
+
+	notify, _, stop := startWatchLoop(t, ca)
+	defer stop()
+
+	// Several intervals over unchanged material must produce nothing.
+	select {
+	case <-notify:
+		t.Fatal("a reconcile tick over unchanged CA material must not notify")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	// Rotating the material must produce exactly one notification. This also
+	// proves the ticker was live throughout the quiet period above, rather than
+	// silent because it had stopped.
+	rotated := writeCA(t, dir, "ca-2.example.org", 24*time.Hour)
+	select {
+	case <-notify:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the reconcile tick to notify on a changed CA")
+	}
+	if got := parseChain(t, ca.TrustBundlePEM()); !got[0].Equal(rotated.Cert) {
+		t.Fatal("the current CA must be the rotated certificate after a reconcile tick")
+	}
+
+	// Every later tick re-reads the same material, and must stay quiet.
+	select {
+	case <-notify:
+		t.Fatal("a reconcile tick must not notify again once the CA has settled")
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// An fsnotify error (an inotify queue overflow, say) is exactly the case where
+// events are being dropped, so the ticker must keep running after one rather
+// than the loop being wedged by it.
+func TestReconcileTickSurvivesAWatcherError(t *testing.T) {
+	clock := newFakeClock()
+	ca, dir := newTestCA(t, clock)
+	ca.reconcileInterval = 20 * time.Millisecond
+
+	notify, errs, stop := startWatchLoop(t, ca)
+	defer stop()
+
+	select {
+	case errs <- errors.New("inotify: queue or buffer overflow"):
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watch loop did not consume the watcher error")
+	}
+
+	rotated := writeCA(t, dir, "ca-2.example.org", 24*time.Hour)
+	select {
+	case <-notify:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the reconcile tick stopped running after a watcher error")
+	}
+	if got := parseChain(t, ca.TrustBundlePEM()); !got[0].Equal(rotated.Cert) {
+		t.Error("the current CA must be the rotated certificate after a reconcile tick")
+	}
+}
+
+// The ticker must not outlive the loop: cancelling the context has to return
+// promptly and stop reloading.
+func TestWatchLoopStopsTheReconcileTickerOnContextCancel(t *testing.T) {
+	clock := newFakeClock()
+	ca, _ := newTestCA(t, clock)
+	ca.reconcileInterval = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan fsnotify.Event) // open, never sends
+	errs := make(chan error)            // open, never sends
+
+	done := make(chan error, 1)
+	go func() { done <- ca.watchLoop(ctx, log.FromContext(ctx), events, errs, nil) }()
+
+	// Let at least one tick land, so cancellation races a running ticker rather
+	// than a loop that has not started yet.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("watchLoop() = %v, want nil on context cancellation", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchLoop did not return promptly after context cancellation")
+	}
+}
+
+// A tick makes a single reload attempt, not a full retry burst: retries exist to
+// ride out the torn state a rotation briefly leaves on disk, which a tick is not
+// correlated with, and the next tick is itself the retry. Pinning it keeps the
+// failure accounting honest (one tick, one failure) and bounds the log stream on
+// a permanently bad CA.
+func TestReconcileOnceRecordsASingleFailure(t *testing.T) {
+	clock := newFakeClock()
+	ca, dir := newTestCA(t, clock)
+	if ca.reloadAttempts < 2 {
+		t.Fatalf("reloadAttempts = %d, the test needs a retry budget greater than one", ca.reloadAttempts)
+	}
+
+	nonCA, err := testutil.NewNonCA("not-a-ca.example.org", time.Hour)
+	if err != nil {
+		t.Fatalf("generate non-CA: %v", err)
+	}
+	if _, _, err := nonCA.WriteFiles(dir); err != nil {
+		t.Fatalf("write non-CA files: %v", err)
+	}
+
+	ctx := context.Background()
+	ca.reconcileOnce(log.FromContext(ctx), nil, "test")
+
+	if got := ca.failureCount(); got != 1 {
+		t.Errorf("reload failures after one reconcile pass = %d, want 1 (a single attempt, not a retry burst)", got)
+	}
+}
+
+// The readiness contract must hold on tick-only failures too: a CA that stays
+// unloadable with no filesystem event ever arriving must still cross the
+// threshold and fail readiness once the grace period elapses.
+func TestTickOnlyFailuresCrossTheReadinessThreshold(t *testing.T) {
+	clock := newFakeClock()
+	ca, dir := newTestCA(t, clock)
+	ca.reconcileInterval = 20 * time.Millisecond
+
+	nonCA, err := testutil.NewNonCA("not-a-ca.example.org", time.Hour)
+	if err != nil {
+		t.Fatalf("generate non-CA: %v", err)
+	}
+	if _, _, err := nonCA.WriteFiles(dir); err != nil {
+		t.Fatalf("write non-CA files: %v", err)
+	}
+
+	_, _, stop := startWatchLoop(t, ca)
+	defer stop()
+
+	deadline := time.After(10 * time.Second)
+	for ca.failureCount() < reloadFailureThreshold {
+		select {
+		case <-deadline:
+			t.Fatalf("reload failures reached %d on ticks alone, want at least %d",
+				ca.failureCount(), reloadFailureThreshold)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	// Inside the grace period the last-good CA keeps signing, so the replica
+	// stays ready; past it, readiness must fail.
+	if err := ca.Healthy(); err != nil {
+		t.Errorf("Healthy() inside the grace period = %v, want nil", err)
+	}
+	clock.advance(reloadFailureGracePeriod)
+	if err := ca.Healthy(); err == nil {
+		t.Error("Healthy() = nil after tick-only failures past the grace period, want an error")
+	}
+}
+
+// A rotation landing between New's initial load and the watch being registered
+// produces no observable event, so Watch reconciles once on startup. Without it
+// the stale CA would persist until the first tick.
+func TestWatchReconcilesOnStartup(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "ca-1.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Rotate before the watcher exists, so no event can ever be delivered for
+	// it, and leave the reconcile interval at its production value so only the
+	// startup pass can observe the change.
+	rotated := writeCA(t, dir, "ca-2.example.org", 24*time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	notify := make(chan struct{}, 1)
+	watchDone := make(chan error, 1)
+	go func() { watchDone <- ca.Watch(ctx, notify) }()
+
+	select {
+	case <-notify:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the startup reconciliation to reload the CA")
+	}
+	if got := parseChain(t, ca.TrustBundlePEM()); !got[0].Equal(rotated.Cert) {
+		t.Error("the current CA must be the rotated certificate after the startup reconciliation")
+	}
+
+	cancel()
+	select {
+	case err := <-watchDone:
+		if err != nil {
+			t.Fatalf("Watch returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Watch did not return after context cancellation")
+	}
+}

--- a/internal/kubernetes/authority/authority_recovery_test.go
+++ b/internal/kubernetes/authority/authority_recovery_test.go
@@ -33,7 +33,7 @@ func TestReloadRetainsLastGoodCAOnFailure(t *testing.T) {
 		t.Fatalf("write non-CA files: %v", err)
 	}
 
-	if err := ca.load(); err == nil {
+	if _, err := ca.load(); err == nil {
 		t.Fatal("want error reloading a non-CA certificate")
 	}
 	if got := parseChain(t, ca.TrustBundlePEM()); len(got) == 0 || !got[0].Equal(good.Cert) {
@@ -42,7 +42,7 @@ func TestReloadRetainsLastGoodCAOnFailure(t *testing.T) {
 
 	// A subsequent good write must reload.
 	good2 := writeCA(t, dir, "good-ca-2.example.org", 24*time.Hour)
-	if err := ca.load(); err != nil {
+	if _, err := ca.load(); err != nil {
 		t.Fatalf("reload after good write: %v", err)
 	}
 	if got := parseChain(t, ca.TrustBundlePEM()); !got[0].Equal(good2.Cert) {
@@ -79,7 +79,7 @@ func TestReloadWithRetryRecoversFromTransientBadPair(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "tls.key"), b.KeyPEM, 0o600); err != nil {
 		t.Fatalf("write key: %v", err)
 	}
-	if err := ca.load(); err == nil {
+	if _, err := ca.load(); err == nil {
 		t.Fatal("want error for mismatched key pair")
 	}
 
@@ -95,7 +95,7 @@ func TestReloadWithRetryRecoversFromTransientBadPair(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	if err := ca.reloadWithRetry(ctx, log.FromContext(ctx)); err != nil {
+	if _, err := ca.reloadWithRetry(ctx, log.FromContext(ctx)); err != nil {
 		t.Fatalf("reloadWithRetry did not recover from a transient bad pair: %v", err)
 	}
 	if got := parseChain(t, ca.TrustBundlePEM()); !got[0].Equal(rotated.Cert) {
@@ -128,7 +128,10 @@ func TestReloadWithRetryHonorsContextCancellation(t *testing.T) {
 	defer cancel()
 
 	done := make(chan error, 1)
-	go func() { done <- ca.reloadWithRetry(ctx, log.FromContext(ctx)) }()
+	go func() {
+		_, err := ca.reloadWithRetry(ctx, log.FromContext(ctx))
+		done <- err
+	}()
 	select {
 	case err := <-done:
 		if err == nil {

--- a/internal/kubernetes/authority/authority_test.go
+++ b/internal/kubernetes/authority/authority_test.go
@@ -250,26 +250,26 @@ func TestTrustBundleRotation(t *testing.T) {
 	assertBundle(ca1)
 
 	// Reloading the same CA must not create history entries.
-	if err := ca.load(); err != nil {
+	if _, err := ca.load(); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
 	assertBundle(ca1)
 
 	ca2 := writeCA(t, dir, "ca-2.example.org", 24*time.Hour)
-	if err := ca.load(); err != nil {
+	if _, err := ca.load(); err != nil {
 		t.Fatalf("reload after rotation: %v", err)
 	}
 	assertBundle(ca2, ca1)
 
 	ca3 := writeCA(t, dir, "ca-3.example.org", 24*time.Hour)
-	if err := ca.load(); err != nil {
+	if _, err := ca.load(); err != nil {
 		t.Fatalf("reload after rotation: %v", err)
 	}
 	assertBundle(ca3, ca1, ca2)
 
 	// A fourth CA must evict the oldest previous certificate (window of 2).
 	ca4 := writeCA(t, dir, "ca-4.example.org", 24*time.Hour)
-	if err := ca.load(); err != nil {
+	if _, err := ca.load(); err != nil {
 		t.Fatalf("reload after rotation: %v", err)
 	}
 	assertBundle(ca4, ca2, ca3)


### PR DESCRIPTION
Closes #102.

## The defect

`watchLoop` only reloads on fsnotify events. `drainEvents` consumes the burst, `reloadWithRetry` gets ~2s across 5 attempts, and if those fail nothing tries again until the next event — which may never come, because the rotation already happened. A slow CSI mount or an NFS blip leaves the signer on old material until the pod restarts.

Two other routes end up the same: a dropped inotify queue, and a watched directory deleted and recreated, leaving the watch on a stale inode. The last one is silent — reloads keep succeeding against an inode nobody writes to, so `Healthy()` stays green while the CA is frozen.

## What changed

- `load()` fingerprints the cert DER (SHA-256) and reports whether anything moved. Compared inside the existing `ca.mu` section.
- `watchLoop` gains a 60s ticker.
- Both paths gate `notify` — and so the ClusterTrustBundle republish — on the changed flag.
- `Watch` reconciles once after registering the watches.
- The event filter accepts `fsnotify.Remove`.

## Decisions

**Tick does one `load()`, not `reloadWithRetry`.** Retries exist for the torn state a rotation leaves on disk. A tick isn't correlated with a write, and the next tick is the retry. On a permanently bad CA that's ~1 log line per minute instead of ~6.

**Second ticker, not the `ctbDriftRepairInterval` loop.** `ctbPublisher` is leader-elected; `caWatchRunnable` deliberately isn't, so standbys keep their CA current. Reusing the leader-gated loop would leave every standby unreconciled.

**Unconditional, not gated on failure.** The dropped-event and stale-inode routes leave the CA in a *successful* state, so a failure-gated pass would never run in the cases that need it most.

## Review notes

**The interval has a ceiling, documented on the constant.** Three single-attempt ticks must fit inside `reloadFailureGracePeriod / reloadFailureThreshold` (≈3m20s). Above that the threshold becomes binding and NotReady arrives *later* than today. 60s has ~3.3x margin.

**`fsnotify.Remove` changes one outcome.** Deleting the CA material was silent and green; it now fails a reload and eventually goes NotReady. Intended, but it is a behaviour change beyond recovery.

**`Healthy()` is untouched** and red still arrives at the same moment. What's new is that a successful tick clears the streak, so a replica recovers without a restart.

## Out of scope

A→B→A CA flapping spends a `max_previous_ca_certs` slot on a cert that is no longer an anchor. Confirmed, present today with events alone, unchanged here. Needs its own issue.

No e2e spec: writing a good CA file *is* an event, so a cluster test can only show recovery happened, never that it happened without one. The `watchLoop` seam proves the counterfactual instead — five of the new unit tests were checked to fail with the ticker and startup pass removed.
