### PR TITLE
fix(#87): make the workload example issue under the identity constraints

### DIFF
--- a/.changes/unreleased/fixed-workload-pod-example.yaml
+++ b/.changes/unreleased/fixed-workload-pod-example.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: "The example workload manifest (`examples/workload-pod.yaml`) now issues under the identity constraints as they ship. It requested `<sa>.<ns>.svc` and a literal IP SAN, neither of which the signer grants, so copying it verbatim produced a denial unless `--allow-unverified-identities` was set. It now requests the service-account short DNS form and the service-account SPIFFE ID, uses `${cluster.fqdn}` instead of a hardcoded `cluster.local`, and carries the IP SAN as a commented escape-hatch block."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,6 +116,9 @@ in [`examples/workload-pod.yaml`](https://github.com/rafpe/pod-certificate-signe
 > With controller defaults the certificate is issued for the pod's own verified
 > identity. To set a custom common name, SANs, duration, EKU or SPIFFE URIs, use
 > the annotation contract in [Configuration](./configuration.md#certificate-configuration-annotations).
+> Every value the example requests resolves to an identity the pod owns, so it
+> issues under the [identity constraints](./configuration.md#identity-constraints)
+> as they ship — no `--allow-unverified-identities` needed.
 
 ## Next steps
 

--- a/examples/workload-pod.yaml
+++ b/examples/workload-pod.yaml
@@ -6,6 +6,13 @@
 # placeholders require the controller to run with
 # --enable-annotation-interpolation.
 #
+# Every value below resolves to an identity this pod owns - one the signer
+# derives from the apiserver-verified fields of the PodCertificateRequest - so
+# the manifest issues under the controller's identity constraints as they ship,
+# with no --allow-unverified-identities. Anything the pod cannot prove (a
+# literal name, an IP address) needs that escape hatch; the commented ip-san
+# below is the example of one.
+#
 # The signer's ClusterTrustBundle is mounted alongside the credential bundle,
 # so the pod ends up with:
 #   /var/run/x509/credentialbundle.pem - private key + issued certificate chain
@@ -45,9 +52,25 @@ spec:
           signerName: example.org/signer
           credentialBundlePath: credentialbundle.pem
           userAnnotations:
-            example.org/signer-cn: "${pod.name}.${pod.namespace}.svc.cluster.local"
-            example.org/signer-san: "${pod.name}.${pod.namespace}.svc,${pod.serviceAccountName}.${pod.namespace}.svc"
-            example.org/signer-ip-san: "10.96.0.99"
+            # The pod's own canonical Service DNS name. ${cluster.fqdn} rather
+            # than a hardcoded cluster.local, so the example is also correct on
+            # a cluster installed with a different --cluster-fqdn.
+            example.org/signer-cn: "${pod.name}.${pod.namespace}.svc.${cluster.fqdn}"
+            # The pod's canonical service form plus the short service-account
+            # form <sa>.<ns>. The service-account Service DNS form
+            # <sa>.<ns>.svc is deliberately not in the verified-identity
+            # allowlist and would be denied - see
+            # docs/adr/0001-verified-identity-allowlist-boundary.md.
+            example.org/signer-san: "${pod.name}.${pod.namespace}.svc,${pod.serviceAccountName}.${pod.namespace}"
+            # The SPIFFE ID of the service account this pod runs as: the
+            # blessed spelling of the service-account identity (ADR-0001).
+            example.org/signer-uris: "spiffe://${cluster.fqdn}/ns/${pod.namespace}/sa/${pod.serviceAccountName}"
+            # Escape hatch only, left commented on purpose. An IP address has no
+            # verified derivation from the request, so an ip-san is denied
+            # unless the controller runs with --allow-unverified-identities
+            # (Helm: signer.allow_unverified_identities=true). Uncomment only
+            # against a signer deployed with that flag:
+            # example.org/signer-ip-san: "10.96.0.99"
       - clusterTrustBundle:
           signerName: example.org/signer
           labelSelector: {}

--- a/internal/hygiene/workload_example_test.go
+++ b/internal/hygiene/workload_example_test.go
@@ -1,0 +1,165 @@
+package hygiene
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	capiv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/kubernetes/podcertificate"
+)
+
+// exampleWorkloadPod is the flagship example manifest: operators copy it
+// verbatim and the e2e suite applies it as-is.
+const exampleWorkloadPod = "workload-pod.yaml"
+
+// TestWorkloadPodExampleIssuesUnderIdentityConstraints guards the flagship
+// example against the failure it shipped with until issue #87: it requested
+// <sa>.<ns>.svc and a literal IP SAN, neither of which the signer grants, so
+// the manifest could not issue unless the operator opened the
+// --allow-unverified-identities escape hatch. Everything the live manifest
+// requests must resolve to an identity the signer derives from the
+// apiserver-verified request fields; a value that needs the escape hatch
+// belongs in a commented block, not in the manifest.
+//
+// This is one half of the guarantee that the example issues on a default
+// install. The other half is
+// TestAnnotationInterpolationEnabledByDefault in cmd/podcertificate-signer,
+// which proves ${...} interpolation is what the binary and the chart ship.
+// This test fixes EnableInterpolation itself, so it cannot see a regression of
+// that default, and that test says nothing about the example. Neither is
+// meaningful alone - do not remove or simplify one without the other.
+func TestWorkloadPodExampleIssuesUnderIdentityConstraints(t *testing.T) {
+	path := filepath.Join("..", "..", "examples", exampleWorkloadPod)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) = %v, want the workload example to exist", path, err)
+	}
+
+	var pod *unstructured.Unstructured
+	for _, doc := range decodeDocuments(t, path, data) {
+		if doc.GetKind() == "Pod" {
+			pod = doc
+			break
+		}
+	}
+	if pod == nil {
+		t.Fatalf("%s contains no Pod document", path)
+	}
+
+	// The service account is read from the manifest rather than assumed. The
+	// fallback mirrors both Kubernetes and the chart's DNS-SAN admission
+	// policy, which substitutes the literal "default" when
+	// spec.serviceAccountName is unset.
+	serviceAccountName, _, err := unstructured.NestedString(pod.Object, "spec", "serviceAccountName")
+	if err != nil {
+		t.Fatalf("%s: spec.serviceAccountName not readable: %v", path, err)
+	}
+	if serviceAccountName == "" {
+		serviceAccountName = "default"
+	}
+
+	requests := podCertificateRequests(t, path, pod)
+	if len(requests) == 0 {
+		t.Fatalf("%s: found no podCertificate projected volume source; the example was restructured "+
+			"out from under this test", path)
+	}
+
+	for _, request := range requests {
+		t.Run(request.signerName, func(t *testing.T) {
+			pcr := &capiv1beta1.PodCertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "pcr", Namespace: pod.GetNamespace()},
+				Spec: capiv1beta1.PodCertificateRequestSpec{
+					SignerName:                request.signerName,
+					PodName:                   pod.GetName(),
+					PodUID:                    types.UID("11111111-2222-3333-4444-555555555555"),
+					ServiceAccountName:        serviceAccountName,
+					NodeName:                  types.NodeName("node-1"),
+					UnverifiedUserAnnotations: request.userAnnotations,
+				},
+			}
+			workload := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: pod.GetName(), Namespace: pod.GetNamespace()},
+			}
+
+			// AllowUnverifiedIdentities is deliberately left false: that is the
+			// property under test. EnableInterpolation is on because the
+			// example is written in ${...}; the chart shipping it on is what
+			// the cmd-side test named above asserts.
+			config, err := podcertificate.NewPodCertificateConfig(pcr, workload,
+				podcertificate.Options{EnableInterpolation: true}, nil, 0)
+			if err != nil {
+				t.Fatalf("%s requests an identity the signer does not grant: %v\n"+
+					"every live value must resolve to a verified pod identity; move anything needing "+
+					"--allow-unverified-identities into a commented block", path, err)
+			}
+			if err := config.Validate(); err != nil {
+				t.Fatalf("%s resolves to an invalid certificate configuration: %v", path, err)
+			}
+		})
+	}
+}
+
+// certificateRequest is one podCertificate projected volume source of the
+// example: the signer it names and the annotations it asks that signer for.
+type certificateRequest struct {
+	signerName      string
+	userAnnotations map[string]string
+}
+
+// podCertificateRequests collects every podCertificate projected volume source
+// declared by the pod.
+func podCertificateRequests(t *testing.T, path string, pod *unstructured.Unstructured) []certificateRequest {
+	t.Helper()
+
+	volumes, found, err := unstructured.NestedSlice(pod.Object, "spec", "volumes")
+	if err != nil || !found {
+		t.Fatalf("%s: spec.volumes not readable (found=%t): %v", path, found, err)
+	}
+
+	var requests []certificateRequest
+	for i, v := range volumes {
+		volume, ok := v.(map[string]any)
+		if !ok {
+			t.Fatalf("%s: spec.volumes[%d] is %T, want a mapping", path, i, v)
+		}
+		sources, found, err := unstructured.NestedSlice(volume, "projected", "sources")
+		if err != nil {
+			t.Fatalf("%s: spec.volumes[%d].projected.sources not readable: %v", path, i, err)
+		}
+		if !found {
+			continue
+		}
+		for j, s := range sources {
+			source, ok := s.(map[string]any)
+			if !ok {
+				t.Fatalf("%s: spec.volumes[%d].projected.sources[%d] is %T, want a mapping", path, i, j, s)
+			}
+			certificate, found, err := unstructured.NestedMap(source, "podCertificate")
+			if err != nil {
+				t.Fatalf("%s: podCertificate source not readable: %v", path, err)
+			}
+			if !found {
+				continue
+			}
+			signerName, _, err := unstructured.NestedString(certificate, "signerName")
+			if err != nil {
+				t.Fatalf("%s: podCertificate.signerName not readable: %v", path, err)
+			}
+			userAnnotations, _, err := unstructured.NestedStringMap(certificate, "userAnnotations")
+			if err != nil {
+				t.Fatalf("%s: podCertificate.userAnnotations not readable: %v", path, err)
+			}
+			requests = append(requests, certificateRequest{
+				signerName:      signerName,
+				userAnnotations: userAnnotations,
+			})
+		}
+	}
+	return requests
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -337,11 +337,18 @@ var _ = Describe("Manager", Ordered, Serial, func() {
 				"common name must be interpolated from the pod identity")
 			Expect(leaf.DNSNames).To(ConsistOf(
 				fmt.Sprintf("%s.%s.svc", workloadPodName, workloadNamespace),
-				fmt.Sprintf("default.%s.svc", workloadNamespace), // ${pod.serviceAccountName} = default
+				// The short service-account form. ${pod.serviceAccountName} is
+				// "default", and <sa>.<ns> - not <sa>.<ns>.svc - is what the
+				// verified-identity allowlist grants (ADR-0001).
+				fmt.Sprintf("default.%s", workloadNamespace),
 			), "SANs must be interpolated from the pod identity")
-			Expect(leaf.IPAddresses).To(HaveLen(1), "the ip-san annotation must yield one IP SAN")
-			Expect(leaf.IPAddresses[0].Equal(net.ParseIP("10.96.0.99"))).To(BeTrue(),
-				"IP SAN must match the ip-san annotation in examples/workload-pod.yaml")
+			Expect(leaf.URIs).To(HaveLen(1), "the uris annotation must yield the service-account SPIFFE ID")
+			Expect(leaf.URIs[0].String()).To(Equal(
+				fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/default", workloadNamespace)),
+				"SPIFFE ID must match the uris annotation in examples/workload-pod.yaml")
+			Expect(leaf.IPAddresses).To(BeEmpty(),
+				"the example's ip-san is commented out: an IP SAN has no verified derivation and "+
+					"would need --allow-unverified-identities")
 
 			By("waiting for the pod to run with the projected certificate")
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
Its part one of #87. Base: `main`. **Merge this before #106 (the flip), which is stacked on it.**

## Problem

`examples/workload-pod.yaml` is the flagship example: `docs/getting-started.md` points operators at it and the e2e suite applies it verbatim with `kubectl create -f`. It could not issue.

| Annotation | Resolves to | Verdict on a default install |
| --- | --- | --- |
| `-cn` | `pcs-example-workload.default.svc.cluster.local` | allowed |
| `-san` #1 | `pcs-example-workload.default.svc` | allowed |
| `-san` #2 | `default.default.svc` | **denied** — `<sa>.<ns>.svc` is not in the allowlist |
| `-ip-san` | `10.96.0.99` | **denied** — an IP has no verified derivation |

The e2e suite never caught it because it installed with `--set signer.allow_unverified_identities=true`, which masks exactly this denial.

[ADR-0001](https://github.com/RafPe/pod-certificate-signer/blob/main/docs/adr/0001-verified-identity-allowlist-boundary.md) settles which side gives: the service-account Service DNS forms stay out of the allowlist, because granting `<sa>.<ns>.svc` would let a pod running as ServiceAccount `kubernetes` in `default` present a certificate for `kubernetes.default.svc` — the exact case the constraint exists to deny. So the example changes, not the identity model. Nothing in this PR touches `verifiedIdentities`.

## What changed

- **`examples/workload-pod.yaml`** — the `san` asks for the short service-account form `<sa>.<ns>` instead of `<sa>.<ns>.svc`, and gains `-uris` with the service-account SPIFFE ID, the blessed spelling of that identity per ADR-0001 and the form #87 actually asked for. The `cn` uses `${cluster.fqdn}` rather than a hardcoded `cluster.local`, so the example is also correct on a cluster installed with a different `--cluster-fqdn`. The `ip-san` moves into a commented escape-hatch block naming the flag it needs.
- **`internal/hygiene/workload_example_test.go`** (new) — parses the manifest, walks every `podCertificate` projected volume source it declares, builds a `PodCertificateRequest` from it and asserts the configuration resolves and validates with `AllowUnverifiedIdentities: false`. The service account is read from `spec.serviceAccountName` (falling back to `default`, mirroring both Kubernetes and the chart's DNS-SAN policy) rather than hardcoded. It fails the test if it finds no `podCertificate` source at all, which catches the example being restructured out from under it.
- **`test/e2e/e2e_test.go`** — the issuance spec asserted on the old values, so it changes atomically with the manifest: the second DNS SAN is now `default.default`, the SPIFFE URI is asserted, and `IPAddresses` must be empty.
- **`docs/getting-started.md`** — the note about the example now says it issues under the identity constraints with no escape hatch.

## Verification

`internal/hygiene/workload_example_test.go` was written RED. Against the unmodified manifest it fails with the signer's own message:

```
../../examples/workload-pod.yaml requests an identity the signer does not grant:
DNS name "default.default.svc" is not derived from a verified pod identity
```

**Admission policy clearance**, checked against the CEL rather than the docs — the e2e suite installs with `admissionPolicies.dnsSANValidation.enabled=true`, `failurePolicy: Fail`, and a binding whose `namespaceSelector` is `{}`, so a denial here would stop the example pod being admitted at all:

- The policy guards **only** `<signer>-san` (`variables.sanKey in source.podCertificate.userAnnotations`). `-cn`, `-uris` and `-ip-san` are not inspected — so the new `spiffe://…` URI is never run through `format.dns1123Subdomain()`, which it would fail.
- The new `-san` uses only `${pod.name}`, `${pod.namespace}`, `${pod.serviceAccountName}` and `${cluster.fqdn}`, all four of which the policy substitutes, so the "unsupported `${...}`" branch does not fire.
- It expands to `pcs-example-workload.default.svc` and `default.default`: both DNS-1123 subdomains, every label well under 63, total under 253.

The resolved CN is 46 characters, under the 64-character RFC 5280 limit `Validate()` enforces.

`make test`, `make vet-e2e lint-e2e` pass. The e2e suite was **not** run — the `pcs-e2e` cluster is in use.

## Release metadata

`release/patch`, `kind: Fixed`. A user-facing artifact operators copy verbatim was broken; no behaviour change in the controller.
