### PR TITLE
feat(x509): assert basicConstraints with cA:FALSE on issued leaves

### DIFF
--- a/.changes/unreleased/security-leaf-basic-constraints.yaml
+++ b/.changes/unreleased/security-leaf-basic-constraints.yaml
@@ -1,0 +1,2 @@
+kind: Security
+body: Issued certificates now assert the basicConstraints extension with cA:FALSE, instead of omitting the extension and leaving each verifier to infer end-entity status from its absence. This grants no new capability and removes none - a conforming verifier already refused to treat these leaves as CAs (RFC 5280 6.1.4) - but the signer cannot enumerate the TLS stacks that verify its output, and lenient path validation around a missing basicConstraints has a long history of implementation bugs. No pathLenConstraint is set. See ADR-0003.

--- a/docs/adr/0003-leaf-basic-constraints-ca-false.md
+++ b/docs/adr/0003-leaf-basic-constraints-ca-false.md
@@ -1,0 +1,195 @@
+---
+status: proposed
+date: 2026-08-18
+decision-makers: RafPe
+---
+
+# Assert `basicConstraints` with `cA:FALSE` on issued leaf certificates
+
+## Context and Problem Statement
+
+The signing template in `internal/kubernetes/authority/authority.go` (`Sign`) set
+neither `BasicConstraintsValid` nor `IsCA`:
+
+```go
+template := &x509.Certificate{
+    SerialNumber: serialNumber,
+    Subject:      pkix.Name{CommonName: pcConfig.CommonName},
+    DNSNames:     pcConfig.DNSNames,
+    // ... no BasicConstraintsValid, no IsCA
+}
+```
+
+`crypto/x509.CreateCertificate` emits the basicConstraints extension only when
+`BasicConstraintsValid` is true, so **issued leaves carried no basicConstraints
+extension at all**. This surfaced in the Stage 3 e2e work, which set out to
+assert `cA:FALSE` on every leaf and found there was nothing to assert; the
+assertion it settled on pinned the *absence*
+(`test/e2e/key_semantics_test.go`, `expectConformantLeaf`).
+
+**This is not a vulnerability, and this record is not a fix for one.** The
+absence is standards-conformant:
+
+- RFC 5280 4.2.1.9 states the extension **MAY** appear in end-entity
+  certificates. Only CA certificates **MUST** carry it.
+- RFC 5280 6.1.4 path validation refuses to treat a certificate as a CA unless
+  basicConstraints is present with `cA:TRUE`. Go's verifier implements exactly
+  that, and it is the verifier the signer's own e2e chain checks run through.
+  A leaf issued by this signer therefore cannot be used to sign further
+  certificates when validated by a conforming implementation.
+- Current CA/Browser Forum Baseline Requirements treat basicConstraints as
+  **optional** for subscriber certificates rather than mandatory. An earlier
+  internal note claimed the BRs require it; that overstated the position and is
+  corrected here so the overstatement does not get cited back.
+
+The argument for asserting it anyway is that "conforming implementation" is a
+weaker guarantee inside a Kubernetes cluster than it looks on paper. The signer
+issues credentials consumed by whatever TLS stack a workload happens to link:
+Go, OpenSSL, BoringSSL, Java, Python, Rust, and vendored copies of all of them,
+at whatever version the workload image pins. Path-validation leniency around a
+missing basicConstraints has a long history of implementation bugs. The signer
+cannot enumerate its verifiers, so it should not rely on all of them being
+strict.
+
+The certificate profile is also read by people. A leaf that states its
+end-entity status is auditable in one `openssl x509 -text`; a leaf that omits
+the extension requires the reader to know RFC 5280 6.1.4 before they can
+conclude anything from what is not there.
+
+## Decision
+
+**Set `BasicConstraintsValid: true` on the leaf template and leave `IsCA` at its
+zero value**, so every issued certificate carries a basicConstraints extension
+asserting `cA:FALSE`.
+
+**No `pathLenConstraint`.** It is meaningful only when `cA` is true, and some
+verifiers treat the combination with `cA:FALSE` as malformed.
+
+**The extension is emitted critical**, which is what `crypto/x509` does
+unconditionally for basicConstraints — the criticality is not a separate
+decision the template can express. It is also the right encoding, for reasons
+recorded under Alternatives Considered.
+
+Worth knowing before someone "corrects" the test: DER omits a field encoded at
+its DEFAULT, and `cA` is `BOOLEAN DEFAULT FALSE` with `pathLenConstraint`
+`OPTIONAL`. The emitted extension value is therefore an **empty SEQUENCE**
+(`30 00`). There is no explicit `FALSE` byte to find; `openssl x509 -text`
+still prints `CA:FALSE`, and that empty SEQUENCE is the strongest single thing
+to assert on, because it pins both the value and the absent `pathLenConstraint`
+without depending on any parser's sentinel for "unset".
+
+**Non-goals.** Nothing here touches the identity model, the verified-identity
+allowlist, key usage, extended key usage, SANs, or lifetimes. This record
+governs only how an issued certificate describes its own end-entity status. It
+does not supersede [ADR-0001](0001-verified-identity-allowlist-boundary.md).
+
+**Release classification: patch, `Security`.** The classification records
+hardening, not a fixed vulnerability. No capability is granted and none is
+removed.
+
+## Consequences
+
+* Good, because issued certificates state their end-entity status explicitly
+  instead of relying on every verifier to infer it from an absence. A verifier
+  with a lenient or buggy path-validation implementation can no longer be
+  induced to treat a workload credential as a CA.
+* Good, because the profile becomes self-describing and therefore auditable
+  without a spec lookup.
+* Neutral, because a conforming verifier — Go's included — already refused to
+  treat these leaves as CAs. For that population nothing changes at all, which
+  is precisely why this is not classified as a fix.
+* Bad, because every issued certificate changes shape. The extension is a
+  handful of bytes and universally understood, so the compatibility risk is
+  low, but it is not zero: a consumer pinning an exact certificate fingerprint
+  or DER length sees a change on the next issuance. Certificates are
+  short-lived (24h default) and rotate constantly, so such a consumer is
+  already broken by rotation; this only makes the breakage arrive sooner.
+* Bad, because the e2e assertion that pinned the absence had to be inverted in
+  the same change or the suite goes red. That coupling is the point of the
+  assertion existing — it is what caught the profile change — but it does mean
+  the record and the test must move together.
+
+## Implementation Plan
+
+* **Affected paths**:
+  * `internal/kubernetes/authority/authority.go` — `BasicConstraintsValid: true`
+    on the `Sign` template. `IsCA` is deliberately *not* written: the pair of a
+    present extension and a false `cA` is what produces `cA:FALSE`, and a
+    comment at the field says so, with the `ADR-0003` reference.
+  * `internal/kubernetes/authority/authority_test.go` —
+    `TestSignAssertsBasicConstraintsCAFalse`.
+  * `test/e2e/key_semantics_test.go` — `expectConformantLeaf`, the assertion
+    that pinned the absence.
+* **Dependencies**: none. This does not rest on the allowlist boundary or on
+  any flag.
+* **Patterns to follow**: assert on the certificate parsed back from DER, never
+  on the template. The template is the request; the DER is the artifact the
+  workload is handed, and only one of the two is evidence.
+* **Patterns to avoid**: do not add `MaxPathLen` / `MaxPathLenZero` to the
+  template to "complete" the extension. Do not reach for `ExtraExtensions` to
+  hand-encode the extension — the template field is sufficient and the
+  hand-rolled DER would have to be maintained against the same spec Go already
+  implements.
+
+### Verification
+
+- [x] A freshly issued leaf, parsed from DER, has `BasicConstraintsValid` true
+      and `IsCA` false (`TestSignAssertsBasicConstraintsCAFalse`).
+- [x] `pathLenConstraint` is absent: `MaxPathLen` is `-1` and `MaxPathLenZero`
+      is false (same test). Go's parser reports `-1`, not `0`, for an absent
+      constraint — the assertion was written against the observed value.
+- [x] The extension with OID 2.5.29.19 is present, critical, and carries an
+      empty SEQUENCE (same test, walking `cert.Extensions` — `x509.Certificate`
+      exposes no typed field for basicConstraints criticality).
+- [ ] The e2e conformance helper requires the extension's presence on every
+      issued leaf across the key-type matrix
+      (`test/e2e/key_semantics_test.go`, `expectConformantLeaf`).
+
+## Alternatives Considered
+
+* **Leave it absent.** Standards-conformant, zero risk, zero work, and it is
+  what shipped until now. Rejected because the cost of the alternative is a
+  handful of bytes and one template field, while the benefit is not depending
+  on the correctness of TLS stacks the signer does not choose and cannot
+  enumerate.
+* **Emit it non-critical.** Rejected on two counts. First, it is not
+  expressible: `crypto/x509` marks basicConstraints critical unconditionally,
+  so non-critical would mean hand-building the DER in `ExtraExtensions` and
+  bypassing the template field entirely. Second, and decisively, it would be
+  the wrong choice even if it were free — non-critical is exactly the encoding
+  a *lenient* verifier is licensed to skip, and lenient verifiers are the entire
+  population this change exists for. The usual argument for non-critical, that
+  a verifier which cannot process a critical extension rejects the certificate
+  outright, does not apply here: RFC 5280 4.2.1.9 already requires
+  basicConstraints critical on CA certificates, so any verifier able to
+  validate a chain at all must process it.
+* **Set `pathLenConstraint: 0`.** Meaningless with `cA:FALSE`, and some
+  verifiers treat the combination as malformed. Rejected.
+* **Assert it only for some requests, behind a flag.** Rejected. A certificate
+  profile that varies per request is harder to reason about than either
+  profile on its own, and there is no configuration for which the extension is
+  the wrong answer.
+
+## More Information
+
+* RFC 5280 4.2.1.9 (Basic Constraints) and 6.1.4 (path validation).
+* Found by the Stage 3 e2e work. `test/e2e/key_semantics_test.go`,
+  `expectConformantLeaf`, now requires the extension's presence; before this
+  record it pinned the absence, with a comment saying that any extension
+  appearing there must be reviewed and must carry `cA:FALSE`. This is that
+  review.
+* [ADR-0001](0001-verified-identity-allowlist-boundary.md) — the identity
+  boundary. Untouched here; listed so the two are not confused, since both
+  concern what an issued certificate may say.
+* `CONTRIBUTING.md`'s "When an ADR is required" list does not literally name
+  an unconditional change to certificate contents — its closest entry is *a
+  flag that gates what ends up in a certificate*, and this change is not
+  behind a flag. The record exists anyway because it changes what every
+  certificate the signer issues contains, and that reasoning should outlive
+  the pull request that carried it.
+
+**Revisit if**: a verifier is found that rejects a leaf carrying a critical
+basicConstraints (which would reopen the criticality question, and would be
+worth reporting upstream); or the CA/Browser Forum Baseline Requirements move
+basicConstraints from optional to required for subscriber certificates, which
+would turn this from a judgement call into a conformance obligation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ when an ADR is required and how one is reviewed.
 | --- | ----- | ------ |
 | [0001](0001-verified-identity-allowlist-boundary.md) | Bound the verified-identity allowlist to identities the signer emits, plus the service-account short DNS form and SPIFFE ID | Accepted |
 | [0002](0002-annotation-interpolation-on-by-default.md) | Ship `--enable-annotation-interpolation` on by default | Accepted |
+| [0003](0003-leaf-basic-constraints-ca-false.md) | Assert `basicConstraints` with `cA:FALSE` on issued leaf certificates | Proposed |

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -298,6 +298,16 @@ func (ca *CertificateAuthority) Sign(pcConfig *podcertificate.PodCertificateConf
 		ExtKeyUsage:        pcConfig.ExtKeyUsage,
 		NotBefore:          nbf,
 		NotAfter:           naf,
+		// BasicConstraintsValid is what makes Go emit the basicConstraints
+		// extension at all; IsCA stays at its zero value, so the pair asserts
+		// cA:FALSE on every leaf. DER omits a field at its DEFAULT, so the
+		// encoded extension is an empty SEQUENCE - that is cA:FALSE, not a
+		// missing value. No pathLenConstraint: it is meaningless with cA:FALSE.
+		// crypto/x509 marks the extension critical, which is what we want: RFC
+		// 5280 4.2.1.9 already requires it critical on CA certificates, so any
+		// verifier that can validate a chain processes it. Why it is asserted
+		// at all: ADR-0003.
+		BasicConstraintsValid: true,
 	}
 
 	issuedCertificate, err := x509.CreateCertificate(rand.Reader, template, ca.certificate, pcConfig.PublicKey, ca.signer)

--- a/internal/kubernetes/authority/authority_test.go
+++ b/internal/kubernetes/authority/authority_test.go
@@ -1,14 +1,18 @@
 package authority
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"errors"
 	"net"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -154,6 +158,64 @@ func TestSignIssuesCertificateChain(t *testing.T) {
 	}
 	if !pc.IsValid() {
 		t.Error("freshly issued certificate must be valid")
+	}
+}
+
+// basicConstraintsOID is id-ce-basicConstraints (RFC 5280 4.2.1.9).
+var basicConstraintsOID = asn1.ObjectIdentifier{2, 5, 29, 19}
+
+// Every issued leaf must assert basicConstraints with cA:FALSE and without a
+// pathLenConstraint (ADR-0003). The assertions run against the certificate
+// parsed back from DER rather than against the template, so they prove what
+// was emitted rather than what was requested.
+func TestSignAssertsBasicConstraintsCAFalse(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	pc, err := ca.Sign(testConfig(t))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(pc.Certificate())
+	if err != nil {
+		t.Fatalf("parse issued certificate: %v", err)
+	}
+
+	if !leaf.BasicConstraintsValid {
+		t.Error("issued leaf must carry the basicConstraints extension")
+	}
+	if leaf.IsCA {
+		t.Error("issued leaf must assert cA:FALSE")
+	}
+	if leaf.MaxPathLen != -1 || leaf.MaxPathLenZero {
+		t.Errorf("pathLenConstraint must be absent: MaxPathLen = %d, MaxPathLenZero = %t",
+			leaf.MaxPathLen, leaf.MaxPathLenZero)
+	}
+
+	// x509.Certificate exposes no typed field for the criticality of
+	// basicConstraints, so read it off the raw extension. The value is an empty
+	// SEQUENCE because DER omits a field encoded at its DEFAULT and cA is
+	// BOOLEAN DEFAULT FALSE - which pins cA:FALSE and the absent
+	// pathLenConstraint in the bytes themselves, where no parser sentinel can
+	// blur them.
+	idx := slices.IndexFunc(leaf.Extensions, func(ext pkix.Extension) bool {
+		return ext.Id.Equal(basicConstraintsOID)
+	})
+	if idx < 0 {
+		t.Fatalf("no extension with OID %s in the issued leaf", basicConstraintsOID)
+	}
+	ext := leaf.Extensions[idx]
+	if !ext.Critical {
+		t.Error("basicConstraints must be emitted critical, as crypto/x509 does")
+	}
+	if want := []byte{0x30, 0x00}; !bytes.Equal(ext.Value, want) {
+		t.Errorf("basicConstraints value = % x, want % x (empty SEQUENCE: cA:FALSE, no pathLenConstraint)",
+			ext.Value, want)
 	}
 }
 

--- a/test/e2e/key_semantics_test.go
+++ b/test/e2e/key_semantics_test.go
@@ -378,17 +378,15 @@ func expectConformantLeaf(
 	Expect(leaf.SerialNumber).NotTo(BeNil())
 	Expect(leaf.SerialNumber.Sign()).To(Equal(1), "a certificate serial number must be positive and non-zero")
 	Expect(leaf.IsCA).To(BeFalse(), "a workload certificate must never be a CA")
-	// The signer emits no basicConstraints extension on a leaf at all, which is
-	// why this pins the absence rather than requiring an explicit cA:FALSE.
-	// RFC 5280 6.1.4 makes the absence safe - a certificate without
-	// basicConstraints must not be used to verify signatures on other
-	// certificates, and Go's verifier enforces exactly that - so this is the
-	// behavior as designed, not a gap the spec is papering over. If the signer
-	// ever starts asserting the extension, it must assert cA:FALSE, and this
-	// says so by failing.
-	Expect(leaf.BasicConstraintsValid).To(BeFalse(),
-		"the signer emits leaves without basicConstraints; an extension appearing here must be reviewed, "+
-			"and must carry cA:FALSE")
+	// The signer asserts basicConstraints with cA:FALSE rather than leaving the
+	// extension out (ADR-0003). RFC 5280 6.1.4 already makes the absence safe
+	// for a conforming verifier, but the signer cannot enumerate the TLS stacks
+	// that will verify its output, so it says end-entity explicitly instead of
+	// relying on the verifier to infer it. BasicConstraintsValid is Go's report
+	// that the extension was present in the DER, so this pins presence; IsCA
+	// above pins the value.
+	Expect(leaf.BasicConstraintsValid).To(BeTrue(),
+		"every issued leaf must carry a basicConstraints extension asserting cA:FALSE")
 
 	By("verifying the key usage matches the key type and the extended key usage the default")
 	Expect(leaf.KeyUsage).To(Equal(want.keyUsage),


### PR DESCRIPTION
## What

Issued leaf certificates now carry the `basicConstraints` extension asserting `cA:FALSE`. One field on the signing template (`internal/kubernetes/authority/authority.go`, `Sign`): `BasicConstraintsValid: true`, with `IsCA` left at its zero value.

Before this, the template set neither field, and `crypto/x509.CreateCertificate` emits the extension only when `BasicConstraintsValid` is true — so **issued leaves carried no `basicConstraints` extension at all**. The Stage 3 e2e work found this when it set out to assert `cA:FALSE` and discovered there was nothing to assert.

## What this is not

**This is not a vulnerability fix, and the changelog entry says so.**

- RFC 5280 §4.2.1.9: the extension **MAY** appear in end-entity certificates. Only CA certificates **MUST** carry it.
- RFC 5280 §6.1.4 path validation refuses to treat a certificate as a CA without `basicConstraints` present and `cA:TRUE`. Go's verifier implements exactly that, so these leaves already could not sign further certificates under a conforming verifier.
- Current CA/Browser Forum Baseline Requirements treat `basicConstraints` as **optional** for subscriber certificates. An earlier internal note claimed the BRs require it; that overstated the position, and ADR-0003 corrects it rather than repeating it.

## Why do it anyway

"Conforming implementation" is a weaker guarantee in a cluster than it looks on paper. The signer issues credentials consumed by whatever TLS stack a workload happens to link — Go, OpenSSL, BoringSSL, Java, Python, Rust, and vendored copies of all of them, at whatever version the workload image pins. Path-validation leniency around a missing `basicConstraints` has a long history of implementation bugs. The signer cannot enumerate its verifiers, so it should not rely on all of them being strict. Defence in depth, plus a profile that is auditable in one `openssl x509 -text` instead of requiring the reader to know §6.1.4.

## Two encoding decisions

**No `pathLenConstraint`.** Meaningless with `cA:FALSE`, and some verifiers treat the combination as malformed.

**The extension is critical.** `crypto/x509` marks `basicConstraints` critical unconditionally — criticality is not something the template field can express, and non-critical would mean hand-building the DER in `ExtraExtensions`. It is also the right encoding independently of that constraint: RFC 5280 §4.2.1.9 already requires `basicConstraints` critical on CA certificates, so any verifier able to validate a chain must process it, and there is no population that accepts it critical one level up but rejects a leaf for carrying it. Meanwhile non-critical is precisely the encoding a *lenient* verifier is licensed to skip — which would exempt the exact population this change exists for. ADR-0003 records both reasons under Alternatives Considered.

Note for anyone reading the bytes: DER omits a field encoded at its DEFAULT, and `cA` is `BOOLEAN DEFAULT FALSE`. The extension value is an **empty SEQUENCE** (`30 00`). That is `cA:FALSE` with no `pathLenConstraint`, and `openssl x509 -text` prints `CA:FALSE`.

## Tests

`TestSignAssertsBasicConstraintsCAFalse` in `internal/kubernetes/authority/` asserts on a freshly issued leaf **parsed back from DER**, not read off the template — the template is the request, the DER is what the workload is handed:

- `BasicConstraintsValid` true, `IsCA` false
- `MaxPathLen == -1` and `MaxPathLenZero` false (Go's parser reports `-1`, not `0`, for an absent constraint; the assertion was written against the observed value)
- the extension with OID 2.5.29.19 is present, critical, and its value is exactly `30 00` — one assertion that pins both `cA:FALSE` and the absent `pathLenConstraint` without depending on any parser sentinel

`test/e2e/key_semantics_test.go` (`expectConformantLeaf`) pinned the *absence* of the extension, with a comment saying that anything appearing there must be reviewed and must carry `cA:FALSE`. This is that review: the assertion is flipped to require presence, and the comment rewritten. It had to flip here or the suite goes red.

## Checks

- `make test` — all 7 packages pass; `internal/kubernetes/authority` at 86.6% coverage
- `make lint` — 0 issues
- `make vet-e2e lint-e2e` — clean

The kind e2e suite was not run locally; `test-e2e.yml` runs it on this PR, and the unit test proves on a parsed leaf exactly what the e2e helper asserts on a parsed leaf.

## ADR

`docs/adr/0003-leaf-basic-constraints-ca-false.md`, status `proposed`, indexed in `docs/adr/README.md`. Numbered 0003 — 0002 is the merged interpolation-default record.

One honest note in the ADR's *More Information*: `CONTRIBUTING.md`'s "When an ADR is required" list does not literally cover an unconditional change to certificate contents. Its closest entry is *a flag that gates what ends up in a certificate*, and this change is not behind a flag. The record exists anyway, because it changes what every certificate the signer issues contains and that reasoning should outlive the PR — but the ADR says that plainly rather than claiming a requirement that is not there.

Per `CONTRIBUTING.md`, an ADR needs one approving maintainer review before it merges as `accepted`; this one merges as `proposed` and binds nothing until then.
