### PR TITLE
fix: announce a CA reload that recovered from a failure

### DIFF
--- a/.changes/unreleased/fixed-ca-reload-recovery-visible.yaml
+++ b/.changes/unreleased/fixed-ca-reload-recovery-visible.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: A CA reload that succeeds after a failure is logged again. Correcting a mismatched certificate/key pair restores the same certificate, so the change-detection added for periodic reconciliation reported "unchanged" and the confirmation was dropped to V(1) - invisible at the default verbosity to an operator who had just fixed the CA.

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -458,6 +458,9 @@ func (ca *CertificateAuthority) watchLoop(
 			}
 
 			logger.Info("reloading CA certificate")
+			// Read before the reload: reloadWithRetry clears the streak on
+			// success.
+			wasFailing := ca.reloadFailing()
 			changed, err := ca.reloadWithRetry(ctx, logger)
 			if err != nil {
 				// The last-good CA is retained, so signing keeps working.
@@ -472,6 +475,15 @@ func (ca *CertificateAuthority) watchLoop(
 				// watched directories, events arriving after the drain window,
 				// or a tick that already picked the material up. Only the one
 				// that actually changed the CA is worth publishing.
+				//
+				// Recovery is the exception worth announcing: correcting a
+				// mismatched pair restores the same certificate, so nothing
+				// changed, but "the CA is loadable again" is exactly what an
+				// operator who just fixed it is watching for.
+				if wasFailing {
+					logger.Info("CA certificate reloaded successfully", "recovered", true)
+					continue
+				}
 				logger.V(1).Info("CA certificate on disk is unchanged, nothing to publish")
 				continue
 			}
@@ -516,6 +528,8 @@ func (ca *CertificateAuthority) drainEvents(ctx context.Context, logger logr.Log
 // also bounds the log stream: a permanently unloadable CA costs one line per
 // interval rather than the whole retry burst, forever.
 func (ca *CertificateAuthority) reconcileOnce(logger logr.Logger, notify chan<- struct{}, cause string) {
+	// Read before the reload: recordReloadResult below clears the streak.
+	wasFailing := ca.reloadFailing()
 	changed, err := ca.load()
 
 	// Recorded regardless of whether anything changed: a readable CA clears the
@@ -530,6 +544,14 @@ func (ca *CertificateAuthority) reconcileOnce(logger logr.Logger, notify chan<- 
 	case changed:
 		logger.Info("CA certificate reloaded successfully", "cause", cause)
 		notifyChanged(notify)
+	case wasFailing:
+		// Recovery is worth announcing even though nothing changed. Correcting
+		// a mismatched pair restores the *same* certificate, so `changed` is
+		// false and the V(1) line below would be the only record - invisible at
+		// the default verbosity, to an operator who has just fixed the CA and is
+		// watching for confirmation. No notify: nothing moved, so nothing needs
+		// republishing.
+		logger.Info("CA certificate reloaded successfully", "cause", cause, "recovered", true)
 	default:
 		logger.V(1).Info("CA certificate on disk is unchanged", "cause", cause)
 	}
@@ -589,6 +611,18 @@ func (ca *CertificateAuthority) reloadWithRetry(ctx context.Context, logger logr
 		case <-timer.C:
 		}
 	}
+}
+
+// reloadFailing reports whether the last reload attempt left the CA in a failed
+// state, so a caller can tell a reload that recovered from one that was routine.
+//
+// Read before the reload it describes, since recordReloadResult clears the
+// streak. Only the watch goroutine reloads, so no attempt can interleave.
+func (ca *CertificateAuthority) reloadFailing() bool {
+	ca.healthMu.Lock()
+	defer ca.healthMu.Unlock()
+
+	return ca.reloadFailures > 0
 }
 
 // recordReloadResult stores the outcome of the most recent reload attempt and

--- a/internal/kubernetes/authority/authority_recovery_log_test.go
+++ b/internal/kubernetes/authority/authority_recovery_log_test.go
@@ -1,0 +1,114 @@
+package authority
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/internal/testutil"
+)
+
+// reloadSucceededLine is the message test/e2e/ca_lifecycle_test.go greps for.
+// Keep the two in step: the e2e suite has no other observable for "the CA is
+// loadable again", so changing this string silently breaks that spec.
+const reloadSucceededLine = "CA certificate reloaded successfully"
+
+// captureLogger records messages at verbosity 0 - the production default, where
+// V(1) is dropped. Asserting against it is what makes "the operator can see
+// this" a property of the test rather than an assumption.
+func captureLogger(lines *[]string) logr.Logger {
+	return funcr.New(func(_, args string) {
+		*lines = append(*lines, args)
+	}, funcr.Options{Verbosity: 0})
+}
+
+// A reload that succeeds after a failure must announce itself even when the
+// material did not change.
+//
+// Correcting a mismatched pair restores the *same* certificate, so the
+// fingerprint gate added for periodic reconciliation reports "unchanged" and the
+// only record would be a V(1) line - dropped at the default verbosity, leaving
+// an operator who has just fixed the CA with no confirmation at all. That is
+// also the property the e2e spec "a good write after a bad one must reload on
+// its own" waits for; it timed out because this line was suppressed.
+func TestReconcileAnnouncesRecoveryWithoutChange(t *testing.T) {
+	dir := t.TempDir()
+	good := writeCA(t, dir, "good-ca.example.org", 24*time.Hour)
+
+	ca, err := New(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Break the pair: the good certificate with a foreign key. This is the
+	// case that matters, because the certificate on disk never changes - so
+	// recovery cannot be detected by comparing fingerprints.
+	foreign, err := testutil.NewCA("foreign.example.org", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("generate foreign CA: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), foreign.KeyPEM, 0o600); err != nil {
+		t.Fatalf("write foreign key: %v", err)
+	}
+
+	var lines []string
+	logger := captureLogger(&lines)
+
+	ca.reconcileOnce(logger, nil, "test")
+	if ca.failureCount() == 0 {
+		t.Fatal("the mismatched pair must record a reload failure, otherwise this test proves nothing")
+	}
+
+	// Restore the original key. The certificate is byte-identical to the one
+	// already loaded, so load() reports changed=false.
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), good.KeyPEM, 0o600); err != nil {
+		t.Fatalf("restore key: %v", err)
+	}
+
+	lines = nil
+	ca.reconcileOnce(logger, nil, "test")
+
+	if ca.failureCount() != 0 {
+		t.Errorf("failureCount = %d, want 0: a successful reload must clear the streak", ca.failureCount())
+	}
+	if !containsLine(lines, reloadSucceededLine) {
+		t.Errorf("recovery was not announced at the default verbosity; logged: %v", lines)
+	}
+}
+
+// The converse: a routine unchanged reload must stay quiet, or the recovery
+// line becomes noise on every tick and the e2e count-based assertion is
+// meaningless.
+func TestReconcileStaysQuietWhenNothingChangedAndNothingFailed(t *testing.T) {
+	dir := t.TempDir()
+	writeCA(t, dir, "good-ca.example.org", 24*time.Hour)
+
+	ca, err := New(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var lines []string
+	logger := captureLogger(&lines)
+
+	ca.reconcileOnce(logger, nil, "test")
+
+	if containsLine(lines, reloadSucceededLine) {
+		t.Errorf("an unchanged reload after no failure must not announce itself; logged: %v", lines)
+	}
+}
+
+func containsLine(lines []string, want string) bool {
+	for _, line := range lines {
+		if strings.Contains(line, want) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Fixes the red nightly tier on `main`.

## What broke

Periodic reconciliation (#102, PR #104) gates the success log on whether the material changed, comparing a fingerprint of the certificate DER. That conflates two questions: *did the CA rotate*, and *did a reload succeed after failing*.

Correcting a mismatched certificate/key pair restores the **same** certificate, so the fingerprint matches, the reload reports unchanged, and the only record is a `V(1)` line — dropped at the default verbosity. An operator who has just repaired the CA sees nothing.

`load()`'s own comment says an unchanged read still counts as a successful reload. The line that would say so was suppressed.

## The fix

`reloadFailing()`, read before each reload since `recordReloadResult` clears the streak. Both paths — the ticker and the event path — log the success line when a reload succeeds after a failure, even with nothing changed. No `notify`: nothing moved, so nothing needs republishing.

## Verification

`make test` and `make lint` pass. Both new tests assert at **verbosity 0**, the production default, so visibility is a property of the test rather than an assumption. **Verified to fail without the fix** — the captured log is empty.

The converse is pinned too: a routine unchanged reload stays quiet, or the line becomes noise on every tick and the e2e count assertion means nothing.

## Why the nightly went red

`test/e2e/ca_lifecycle_test.go` — *"a good write after a bad one must reload on its own"* — waits for that log line. Nightly has been red on `main` since #104 merged; the last green run predates it. Confirmed on two independent machines and by a dispatched run on `main` (32164394549), which rules out PR #112, whose specs run after the failing one and were being skipped.

## Note for review

The e2e suite has **no machine-readable observable** for CA reload state — it greps controller logs in five places. That is why a log-level change turned the tier red. A metrics surface is being designed separately; this PR deliberately does not attempt it.