### PR TITLE
test(e2e): assert CA recovery and requeues on metrics, not log lines

### DIFF
--- a/test/e2e/ca_lifecycle_test.go
+++ b/test/e2e/ca_lifecycle_test.go
@@ -147,28 +147,38 @@ const maxPreviousCACerts = 2
 // signing fails with ErrCASignerUnusable.
 const shortCAValidity = 30 * time.Minute
 
-// Controller log lines the CA-lifecycle specs count.
+// Controller log lines the CA-lifecycle specs still count.
 //
 // Counting a log line is not the assertion; it is what makes the assertion
 // about the right moment. A spec that only waited for "the bundle did not
 // change" would pass against a controller that had not yet noticed the write at
 // all, which is the false pass these lines rule out.
+//
+// Two of these greps are gone, replaced by metric samples (see
+// metrics_scrape_test.go): a metric says what the controller *did*, where a log
+// line says what it *said*, and the difference turned this suite red once
+// already when a log level moved. The two below are deliberately not migrated,
+// and neither is the immutability grep in outcomes_test.go:
+//
+//   - caReloadFailedLine is asserted together with classification and detail
+//     needles that are standard-library error strings. They are unbounded and
+//     unstable, which is exactly what a metric label may never carry, so a
+//     metric could replace the count but never the claim that the controller
+//     said *why* it refused the material. Half a migration invites the belief
+//     that the migration is done.
+//   - caBootstrapLine is emitted before the manager starts, so the metrics
+//     endpoint is not listening when it happens. A gauge can show the history
+//     is non-empty, but the spec's claim is provenance - that it came from the
+//     published ClusterTrustBundle - and only the log line carries that.
 const (
 	// caReloadFailedLine is logged by authority.watchLoop once a reload has
 	// exhausted its retry budget. The error it carries names why, which is what
 	// distinguishes the invalid-material cases from each other.
 	caReloadFailedLine = "failed to reload CA certificate after retries"
 
-	// caReloadSucceededLine is logged after a reload that took.
-	caReloadSucceededLine = "CA certificate reloaded successfully"
-
 	// caBootstrapLine is logged by fetchPreviousCAs when a starting process
 	// seeds its previous-CA history from the published ClusterTrustBundle.
 	caBootstrapLine = "bootstrapped previous CA certificates from ClusterTrustBundle"
-
-	// transientRequeueLine is logged by the reconciler for an error it treats as
-	// retryable rather than terminal.
-	transientRequeueLine = "transient error; requeueing"
 )
 
 // defineCALifecycleTests is called from the top-level Manager container, after
@@ -186,6 +196,9 @@ func defineCALifecycleTests() {
 		var caA, caB *testutil.KeyPair
 
 		BeforeAll(func() {
+			By("authorizing the metrics scrapes these specs assert on")
+			authorizeMetricsScrapes()
+
 			By("rotating to a CA this container generated, so every spec below starts from a known one")
 			caA = newLifecycleCA("ca-lifecycle-a")
 			rotateCA(caA)
@@ -505,12 +518,31 @@ func defineCALifecycleTests() {
 					expectControllerStaysReady()
 
 					By("restoring loadable material and verifying recovery needs no restart")
-					reloadsBefore := controllerLogLineCount(caReloadSucceededLine)
+					// Asserted on the metrics endpoint rather than on a log
+					// line. The claim is behavioural - "a good write after a bad
+					// one reloads on its own" - but the old assertion was
+					// written against a log level and an emission condition, so
+					// changing when the controller logs turned this spec red for
+					// no behavioural reason. That is the wrong coupling.
+					//
+					// The observable is the last-success timestamp, not the
+					// changed counter: restoring the material the signer already
+					// had is a successful reload that changes nothing, which is
+					// precisely the recovery case. The streak returning to zero
+					// is the same fact from the readiness side.
+					var successBefore float64
+					Eventually(func(g Gomega) {
+						successBefore = scrapeMetricValue(g, caReloadLastSuccessGauge)
+					}, caPropagationTimeout, metricsScrapePollInterval).Should(Succeed())
+
 					applyCAMaterial(good.CertPEM, good.KeyPEM)
 					Eventually(func(g Gomega) {
-						g.Expect(controllerLogLineCount(caReloadSucceededLine)).To(BeNumerically(">", reloadsBefore),
+						body := scrapeControllerMetrics(g)
+						g.Expect(metricValue(g, body, caReloadLastSuccessGauge)).To(BeNumerically(">", successBefore),
 							"a good write after a bad one must reload on its own")
-					}, caPropagationTimeout).Should(Succeed())
+						g.Expect(metricValue(g, body, caReloadFailuresGauge)).To(BeZero(),
+							"a successful reload must clear the failure streak, so readiness recovers without a restart")
+					}, caPropagationTimeout, metricsScrapePollInterval).Should(Succeed())
 
 					By("verifying the published bundle came back unchanged")
 					// Restoring the same CA is not a rotation, so the history must
@@ -554,7 +586,18 @@ func defineCALifecycleTests() {
 				By("rotating to a CA that loads but expires before a default certificate would")
 				short, err := testutil.NewCA("ca-lifecycle-short", shortCAValidity)
 				Expect(err).NotTo(HaveOccurred(), "Failed to generate the short-lived CA")
-				requeuesBefore := controllerLogLineCount(transientRequeueLine, "exceeds the signer CA validity")
+				// The metric collapses both ErrCASignerUnusable producers - an
+				// expired signer and a lifetime the CA cannot cover - into one
+				// series, because errors.Is is the only discrimination the
+				// reconciler makes. The old grep proved the second branch
+				// specifically. This setup guarantees which one is hit (a CA
+				// that loads but expires before a default certificate would),
+				// so the weaker assertion still tests the intended thing, but
+				// it is weaker and that is worth knowing.
+				var requeuesBefore float64
+				Eventually(func(g Gomega) {
+					requeuesBefore = scrapeMetricValue(g, caUnusableRequeueSeries)
+				}, caPropagationTimeout, metricsScrapePollInterval).Should(Succeed())
 				rotateCA(short)
 
 				By("creating a workload whose default 24-hour lifetime cannot fit inside that CA")
@@ -562,10 +605,10 @@ func defineCALifecycleTests() {
 
 				By("verifying the controller treats the unusable CA as transient and requeues")
 				Eventually(func(g Gomega) {
-					g.Expect(controllerLogLineCount(transientRequeueLine, "exceeds the signer CA validity")).
+					g.Expect(scrapeMetricValue(g, caUnusableRequeueSeries)).
 						To(BeNumerically(">", requeuesBefore),
-							"an unusable CA must be logged as a transient error, not a terminal one")
-				}, caPropagationTimeout).Should(Succeed())
+							"an unusable CA must be counted as a requeue, not as a terminal outcome")
+				}, caPropagationTimeout, metricsScrapePollInterval).Should(Succeed())
 
 				By("verifying the request records no terminal outcome")
 				// This is the contract the reconciler states at the

--- a/test/e2e/metrics_scrape_test.go
+++ b/test/e2e/metrics_scrape_test.go
@@ -1,0 +1,192 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rafpe/kubernetes-podcertificate-signer/test/utils"
+)
+
+// Repeatable scrapes of the controller's metrics endpoint.
+//
+// The suite already scrapes it once, from a one-shot pod whose logs it reads
+// (e2e_test.go). That proves the endpoint is authenticated and serving; it is
+// not something a spec can sample twice to assert a delta. These helpers are
+// the second thing: a scrape that can be taken before an action and again
+// after it.
+//
+// Three properties are deliberate.
+//
+// The scrape targets the controller **pod**, not the metrics Service. Counters
+// are per replica, so a Service that round-robins would silently mix two of
+// them and a delta would be nonsense on any multi-replica install.
+//
+// Counters reset when the process does, so a delta is only meaningful within
+// one controller lifetime. No spec using these may put a restartController()
+// between its baseline and its assertion.
+//
+// And a scrape costs a pod, so it is far too expensive for the suite's default
+// one-second poll. Every Eventually over a scrape passes an explicit, wider
+// interval.
+
+// metricsScrapeBinding authorizes the scrape pods. It is a separate
+// ClusterRoleBinding from the one the metrics spec creates and deletes within
+// its own It, so the two cannot collide on name or lifetime.
+const metricsScrapeBinding = releaseName + "-e2e-metrics-scrape"
+
+// metricsScrapePollInterval is how often an Eventually over a scrape may run.
+// Each scrape creates and waits on a pod, so a one-second poll would spend the
+// whole timeout starting containers.
+const metricsScrapePollInterval = 5 * time.Second
+
+// metricsScrapeSeq names each scrape pod uniquely: kubectl run --rm deletes on
+// exit, but a run killed mid-flight would otherwise leave the name taken.
+var metricsScrapeSeq atomic.Int64
+
+// authorizeMetricsScrapes binds the chart's metrics-reader ClusterRole to the
+// controller ServiceAccount, which the scrape pods run as, and removes the
+// binding when the calling container finishes. The secured endpoint authorizes
+// GET on the /metrics nonResourceURL via SubjectAccessReview, so without this
+// every scrape is a 403.
+func authorizeMetricsScrapes() {
+	GinkgoHelper()
+
+	cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsScrapeBinding,
+		"--clusterrole", metricsReaderClusterRole,
+		"--serviceaccount", fmt.Sprintf("%s:%s", namespace, serviceAccountName))
+	_, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to authorize the metrics scrape pods")
+
+	DeferCleanup(func() {
+		cmd := exec.Command("kubectl", "delete", "clusterrolebinding", metricsScrapeBinding, "--ignore-not-found=true")
+		_, _ = utils.Run(cmd)
+	})
+}
+
+// scrapeControllerMetrics returns the exposition body from the controller pod's
+// metrics endpoint, scraped through a short-lived pod presenting its projected
+// ServiceAccount token.
+func scrapeControllerMetrics(g Gomega) string {
+	cmd := exec.Command("kubectl", "get", "pod", controllerPodName, "-n", namespace,
+		"-o", "jsonpath={.status.podIP}")
+	podIP, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred(), "Failed to read the controller pod IP")
+	g.Expect(podIP).NotTo(BeEmpty(), "the controller pod has no IP yet")
+
+	// -k skips verification of the controller's in-memory self-signed serving
+	// certificate: the guarantee under test here is the metric value, not the
+	// serving-cert trust chain, which the metrics spec already covers.
+	script := fmt.Sprintf(
+		"curl -fsk -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s:9090/metrics",
+		podIP)
+	podName := fmt.Sprintf("pcs-metrics-scrape-%d", metricsScrapeSeq.Add(1))
+
+	cmd = exec.Command("kubectl", "run", podName,
+		"--restart=Never", "--rm", "--attach", "--quiet",
+		"--namespace", namespace,
+		"--image=curlimages/curl:latest",
+		"--overrides",
+		fmt.Sprintf(`{
+			"spec": {
+				"containers": [{
+					"name": "curl",
+					"image": "curlimages/curl:latest",
+					"command": ["/bin/sh", "-c"],
+					"args": [%q],
+					"securityContext": {
+						"readOnlyRootFilesystem": true,
+						"allowPrivilegeEscalation": false,
+						"capabilities": { "drop": ["ALL"] },
+						"runAsNonRoot": true,
+						"runAsUser": 1000,
+						"seccompProfile": { "type": "RuntimeDefault" }
+					}
+				}],
+				"serviceAccountName": %q
+			}
+		}`, script, serviceAccountName))
+	body, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred(), "Failed to scrape the controller metrics endpoint")
+	g.Expect(body).To(ContainSubstring("podcertificatesigner_"),
+		"the scrape returned no signer metrics at all: %s", body)
+
+	return body
+}
+
+// metricValue reads one sample out of a Prometheus text exposition body. series
+// is the full series identity as exposed, e.g.
+// `podcertificatesigner_ca_reload_attempts_total{result="changed"}`.
+//
+// Every series this suite reads is pre-initialised by the signer, so an absent
+// one is a failure rather than a zero: reporting it as zero would let a
+// misspelled name pass as "nothing has happened yet".
+func metricValue(g Gomega, body, series string) float64 {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		sep := strings.LastIndex(line, " ")
+		if sep < 0 || line[:sep] != series {
+			continue
+		}
+		value, err := strconv.ParseFloat(line[sep+1:], 64)
+		g.Expect(err).NotTo(HaveOccurred(), "unparseable sample for %s: %q", series, line)
+
+		return value
+	}
+
+	g.Expect(false).To(BeTrue(), "the scrape carried no sample for %s; the signer pre-initialises every series it can expose, "+
+		"so an absent one means the name is wrong or the metric was removed", series)
+
+	return 0
+}
+
+// scrapeMetricValue takes one scrape and reads a single series out of it.
+func scrapeMetricValue(g Gomega, series string) float64 {
+	return metricValue(g, scrapeControllerMetrics(g), series)
+}
+
+// Series the CA-lifecycle specs sample. Spelled out in full rather than
+// assembled, so a rename in internal/metrics shows up here as a failing scrape
+// rather than as a silently-zero assertion.
+const (
+	// caReloadFailuresGauge is the consecutive-failure streak backing readiness.
+	caReloadFailuresGauge = `podcertificatesigner_ca_reload_consecutive_failures`
+
+	// caReloadLastSuccessGauge is when the CA was last read successfully, as a
+	// Unix timestamp. It advances on every successful reload, including one
+	// that changed nothing, which is what makes it the observable for a
+	// recovery that restores the CA the signer already had.
+	caReloadLastSuccessGauge = `podcertificatesigner_ca_reload_last_success_timestamp_seconds`
+
+	// caUnusableRequeueSeries counts reconciles requeued because the CA could
+	// not cover the request.
+	caUnusableRequeueSeries = `podcertificatesigner_podcertificaterequest_requeues_total{reason="CASignerUnusable"}`
+)

--- a/test/e2e/metrics_scrape_test.go
+++ b/test/e2e/metrics_scrape_test.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -51,29 +50,38 @@ import (
 // one controller lifetime. No spec using these may put a restartController()
 // between its baseline and its assertion.
 //
-// And a scrape costs a pod, so it is far too expensive for the suite's default
-// one-second poll. Every Eventually over a scrape passes an explicit, wider
-// interval.
+// And the scrape runs `kubectl exec` into one long-lived pod rather than
+// creating a pod per sample. That is not only about cost. A `kubectl run --rm
+// --attach` pod that curls and exits races the attach: the container can finish
+// before kubectl is streaming, in which case the command succeeds and returns
+// an empty body - a silent wrong answer, not an error. An exec into a pod that
+// is already running has no such window.
 
-// metricsScrapeBinding authorizes the scrape pods. It is a separate
+// metricsScrapeBinding authorizes the scraper. It is a separate
 // ClusterRoleBinding from the one the metrics spec creates and deletes within
 // its own It, so the two cannot collide on name or lifetime.
 const metricsScrapeBinding = releaseName + "-e2e-metrics-scrape"
 
+// metricsScraperPod is the long-lived pod every scrape execs into. It runs as
+// the controller ServiceAccount so its projected token is the one the endpoint
+// authorizes.
+const metricsScraperPod = "pcs-metrics-scraper"
+
+// metricsScraperLifetime is how long the scraper idles before exiting. It has
+// to outlast the whole container that installs it, so it is set generously; the
+// pod is deleted on cleanup either way.
+const metricsScraperLifetime = "7200"
+
 // metricsScrapePollInterval is how often an Eventually over a scrape may run.
-// Each scrape creates and waits on a pod, so a one-second poll would spend the
-// whole timeout starting containers.
+// A scrape is an exec round trip, which is cheap but not free, and the CA
+// changes these specs wait on take tens of seconds to propagate.
 const metricsScrapePollInterval = 5 * time.Second
 
-// metricsScrapeSeq names each scrape pod uniquely: kubectl run --rm deletes on
-// exit, but a run killed mid-flight would otherwise leave the name taken.
-var metricsScrapeSeq atomic.Int64
-
 // authorizeMetricsScrapes binds the chart's metrics-reader ClusterRole to the
-// controller ServiceAccount, which the scrape pods run as, and removes the
-// binding when the calling container finishes. The secured endpoint authorizes
-// GET on the /metrics nonResourceURL via SubjectAccessReview, so without this
-// every scrape is a 403.
+// controller ServiceAccount and starts the scraper pod, removing both when the
+// calling container finishes. The secured endpoint authorizes GET on the
+// /metrics nonResourceURL via SubjectAccessReview, so without the binding every
+// scrape is a 403.
 func authorizeMetricsScrapes() {
 	GinkgoHelper()
 
@@ -81,17 +89,56 @@ func authorizeMetricsScrapes() {
 		"--clusterrole", metricsReaderClusterRole,
 		"--serviceaccount", fmt.Sprintf("%s:%s", namespace, serviceAccountName))
 	_, err := utils.Run(cmd)
-	Expect(err).NotTo(HaveOccurred(), "Failed to authorize the metrics scrape pods")
-
+	Expect(err).NotTo(HaveOccurred(), "Failed to authorize the metrics scrapes")
 	DeferCleanup(func() {
 		cmd := exec.Command("kubectl", "delete", "clusterrolebinding", metricsScrapeBinding, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 	})
+
+	cmd = exec.Command("kubectl", "run", metricsScraperPod,
+		"--restart=Never",
+		"--namespace", namespace,
+		"--image=curlimages/curl:latest",
+		"--overrides",
+		fmt.Sprintf(`{
+			"spec": {
+				"containers": [{
+					"name": "curl",
+					"image": "curlimages/curl:latest",
+					"command": ["/bin/sh", "-c"],
+					"args": ["sleep %s"],
+					"securityContext": {
+						"readOnlyRootFilesystem": true,
+						"allowPrivilegeEscalation": false,
+						"capabilities": { "drop": ["ALL"] },
+						"runAsNonRoot": true,
+						"runAsUser": 1000,
+						"seccompProfile": { "type": "RuntimeDefault" }
+					}
+				}],
+				"serviceAccountName": %q
+			}
+		}`, metricsScraperLifetime, serviceAccountName))
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create the metrics scraper pod")
+	DeferCleanup(func() {
+		cmd := exec.Command("kubectl", "delete", "pod", metricsScraperPod, "-n", namespace,
+			"--ignore-not-found=true", "--wait=false")
+		_, _ = utils.Run(cmd)
+	})
+
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "get", "pod", metricsScraperPod, "-n", namespace,
+			"-o", "jsonpath={.status.phase}")
+		phase, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(phase).To(Equal("Running"), "the metrics scraper pod is not running yet")
+	}).Should(Succeed())
 }
 
 // scrapeControllerMetrics returns the exposition body from the controller pod's
-// metrics endpoint, scraped through a short-lived pod presenting its projected
-// ServiceAccount token.
+// metrics endpoint, read through the scraper pod's projected ServiceAccount
+// token.
 func scrapeControllerMetrics(g Gomega) string {
 	cmd := exec.Command("kubectl", "get", "pod", controllerPodName, "-n", namespace,
 		"-o", "jsonpath={.status.podIP}")
@@ -105,32 +152,7 @@ func scrapeControllerMetrics(g Gomega) string {
 	script := fmt.Sprintf(
 		"curl -fsk -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s:9090/metrics",
 		podIP)
-	podName := fmt.Sprintf("pcs-metrics-scrape-%d", metricsScrapeSeq.Add(1))
-
-	cmd = exec.Command("kubectl", "run", podName,
-		"--restart=Never", "--rm", "--attach", "--quiet",
-		"--namespace", namespace,
-		"--image=curlimages/curl:latest",
-		"--overrides",
-		fmt.Sprintf(`{
-			"spec": {
-				"containers": [{
-					"name": "curl",
-					"image": "curlimages/curl:latest",
-					"command": ["/bin/sh", "-c"],
-					"args": [%q],
-					"securityContext": {
-						"readOnlyRootFilesystem": true,
-						"allowPrivilegeEscalation": false,
-						"capabilities": { "drop": ["ALL"] },
-						"runAsNonRoot": true,
-						"runAsUser": 1000,
-						"seccompProfile": { "type": "RuntimeDefault" }
-					}
-				}],
-				"serviceAccountName": %q
-			}
-		}`, script, serviceAccountName))
+	cmd = exec.Command("kubectl", "exec", metricsScraperPod, "-n", namespace, "--", "/bin/sh", "-c", script)
 	body, err := utils.Run(cmd)
 	g.Expect(err).NotTo(HaveOccurred(), "Failed to scrape the controller metrics endpoint")
 	g.Expect(body).To(ContainSubstring("podcertificatesigner_"),


### PR DESCRIPTION
Step 4 of 4 implementing [ADR-0005](https://github.com/RafPe/pod-certificate-signer/blob/main/docs/adr/0005-bounded-metrics-surface.md): replacing the two log greps a metric covers cleanly.

Stacked on #117. `release/skip`, no changelog fragment — this changes no shipped behaviour.

## What moves

Two CA-lifecycle specs made behavioural claims — *"a good write after a bad one reloads on its own"*, *"an unusable CA requeues rather than failing the request"* — and asserted them by counting log lines. That coupling has already cost a red nightly tier once: #104 changed the emission condition of one line and a behavioural test went red for no behavioural reason.

**`caReloadSucceededLine` → the last-success timestamp and the failure streak.** Deliberately not the `{result="changed"}` counter, which is what the design work proposed: restoring the material the signer already had is a successful reload that *changes nothing*, so `changed` never moves. That case is exactly why 3aef22e added the `recovered=true` log line, and the last-success gauge is the observable that covers it. The streak returning to zero is the same fact from the readiness side, and asserting both from one scrape costs nothing extra.

**`transientRequeueLine` → `podcertificaterequest_requeues_total{reason="CASignerUnusable"}`**, with the precision loss recorded in a comment. The metric collapses both `ErrCASignerUnusable` producers — an expired signer, and a lifetime the CA cannot cover — because `errors.Is` is all the reconciler distinguishes. The old grep proved the second branch specifically. This spec's setup guarantees which branch is hit, so the weaker assertion still tests the intended thing, but it is weaker and the comment says so.

## The plumbing that did not exist

`getMetricsOutput()` reads a one-shot curl pod — fine for proving the endpoint is authenticated and serving, useless for a delta. `test/e2e/metrics_scrape_test.go` adds a repeatable scrape, and three of its properties are deliberate:

- It targets the controller **pod**, not the metrics Service. Counters are per replica, so a Service that round-robins would silently mix two of them.
- Counters reset when the process does, so a delta is only meaningful within one controller lifetime. Neither migrated assertion has a `restartController()` between its baseline and its `Eventually` — checked, not assumed; the two restarts in this file are both in earlier specs.
- A scrape costs a pod, so every `Eventually` over one passes an explicit five-second interval rather than inheriting the suite's one-second default.

## What deliberately stays a grep

The constant block now says why, rather than leaving three greps looking like debt:

- **`caReloadFailedLine`** is asserted with classification and detail needles that are standard-library error strings — unbounded and unstable across Go releases, which is precisely what a metric label may never carry. A metric can replace the count but never the claim that the controller *said why* it refused the material, and half a migration invites the belief that the migration is done.
- **`caBootstrapLine`** is emitted before `mgr.Start`, so the metrics server is not listening when it happens. A gauge shows the history is non-empty; the spec's claim is *provenance*.
- **`"PodCertificateRequest is immutable"`** (`outcomes_test.go`) keys on the request name, the exact unbounded value ADR-0005 forbids as a label. This is a legitimate use of a log grep.

## The mechanism this went through two nightly runs to get right

The first cut created a pod per sample with `kubectl run --rm --attach`. The nightly run showed why that is wrong: the container curls and exits in milliseconds, so it can finish before kubectl is streaming, and when it does **the command succeeds and returns an empty body** — a silent wrong answer, not an error. It only surfaced because the helper asserts the body contains the signer's prefix, and once the node was warm the race was lost consistently rather than occasionally.

The second commit replaces it with one long-lived scraper pod, exec'd into per sample. An exec into a pod that is already running has no such window, and it is also markedly faster — the two heaviest migrated specs dropped from 391s and 231s to 127s and 143s.

## Verification

`make vet-e2e` and `make lint-e2e`: clean, 0 issues.

The two migrated specs are both `nightly`-labelled, so `make test-e2e` does not cover them. Against this branch, in an isolated cluster:

```
make test-e2e-nightly KIND_CLUSTER_E2E=pcs-metrics
Ran 91 of 91 Specs in 2364.804 seconds
SUCCESS! -- 91 Passed | 0 Failed | 0 Pending | 0 Skipped
```

(An earlier run failed on an unrelated shared-kubeconfig collision — another cluster stole the current context mid-run — which is why the verification run pins `KUBECONFIG` to a file of its own.)
