### PR TITLE
ci: fix the release PR

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,6 +5,9 @@ on:
 
 permissions:
   contents: write
+  # Labels are an issues-scoped resource; read-only, so this job still cannot
+  # create the label it checks for - only report that it is missing.
+  issues: read
   pull-requests: write
 
 concurrency:
@@ -33,6 +36,16 @@ jobs:
           test -n "${VERSION}" || { echo "::error::release-drafter produced no version"; exit 1; }
           mapfile -d '' fragments < <(find .changes/unreleased -maxdepth 1 -name '*.yaml' -print0 | sort -z)
           test "${#fragments[@]}" -gt 0 || { echo "::notice::No releasable changelog fragments"; exit 0; }
+          # Checked before anything is pushed: gh resolves label names before it
+          # creates a pull request, so a missing label aborts the create with no
+          # PR - after release/next has already been force-pushed.
+          if ! label=$(gh api "repos/${GITHUB_REPOSITORY}/labels/autorelease%3A%20pending" 2>&1); then
+            case "${label}" in
+              *"Not Found"*) echo "::error::repository lacks the 'autorelease: pending' label; see the repository setup section of docs/releasing.md" ;;
+              *) echo "::error::could not verify the 'autorelease: pending' label: ${label}" ;;
+            esac
+            exit 1
+          fi
           version="${VERSION#v}"
           notes=$(for file in "${fragments[@]}"; do yq -r '"- " + .body' "${file}"; done)
           grep -q '<!-- next-release -->' CHANGELOG.md || { echo "::error::missing changelog insertion marker"; exit 1; }
@@ -50,7 +63,14 @@ jobs:
           git commit -m "chore: release ${VERSION}"
           git push --force origin release/next
           printf '%s\n' "${RELEASE_BODY}" > release-pr-body.md
-          gh pr create --base main --head release/next --title "chore: release ${VERSION}" \
-            --label "autorelease: pending" --body-file release-pr-body.md 2>/dev/null ||
-            gh pr edit release/next --title "chore: release ${VERSION}" \
+          # Branch on whether the PR already exists rather than falling back from
+          # a failed create: a bare `create || edit` swallows the create's error
+          # and reports whatever the edit then fails on instead.
+          existing=$(gh pr list --head release/next --base main --state open --json number --jq '.[0].number // ""')
+          if [ -n "${existing}" ]; then
+            gh pr edit "${existing}" --title "chore: release ${VERSION}" \
               --add-label "autorelease: pending" --body-file release-pr-body.md
+          else
+            gh pr create --base main --head release/next --title "chore: release ${VERSION}" \
+              --label "autorelease: pending" --body-file release-pr-body.md
+          fi

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -55,8 +55,34 @@ published release or a tag that points elsewhere.
 
 ## Repository setup
 
-Create the four `release/*` labels and `autorelease: pending`, and make **PR
-Release Metadata** a required status check. Protect `main` so the generated
+Create the four `release/*` labels and `autorelease: pending`:
+
+```sh
+for label in release/major release/minor release/patch release/skip; do
+  gh label create "$label" --force
+done
+gh label create 'autorelease: pending' --color ededed \
+  --description 'Generated release PR awaiting maintainer approval' --force
+```
+
+Prepare Release refuses to run without `autorelease: pending`, because a
+release PR that does not carry it can never be published by **Release**.
+
+Allow Actions to open the release pull request. Without this, Prepare Release
+pushes `release/next` and then fails on `gh pr create`, because `GITHUB_TOKEN`
+may push a branch but not open a PR:
+
+```sh
+gh api --method PUT "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
+  -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true
+```
+
+Keep `default_workflow_permissions` at `read`: every workflow here declares its
+own `permissions:` block. Note that the same flag also permits Actions to
+approve pull requests, so the review gate below is what keeps a release PR from
+being approved by automation.
+
+Make **PR Release Metadata** a required status check. Protect `main` so the generated
 release PR is reviewed like any other PR. New GHCR packages default to private;
 make the image and chart packages public, then follow [Artifact Hub](artifact-hub.md).
 

--- a/scripts/release-contract-check.sh
+++ b/scripts/release-contract-check.sh
@@ -26,6 +26,8 @@ grep -q 'release/next' .github/workflows/prepare-release.yml ||
 	fail "Prepare Release must own release/next"
 grep -q 'autorelease: pending' .github/workflows/prepare-release.yml ||
 	fail "release PR must carry autorelease: pending"
+grep -q 'labels/autorelease%3A%20pending' .github/workflows/prepare-release.yml ||
+	fail "Prepare Release must confirm the automation label exists before it pushes"
 
 grep -q "head.ref == 'release/next'" .github/workflows/release.yml ||
 	fail "Release must only accept the generated release branch"


### PR DESCRIPTION
## What went wrong

The [Prepare Release run](https://github.com/RafPe/pod-certificate-signer/actions/runs/32218969669)
failed with `no pull requests found for branch "release/next"` after it had
already force-pushed `release/next`. That message describes the fallback, not
the failure. `gh pr create` failed first, its stderr went to `/dev/null`, and
the `||` fallback then ran `gh pr edit` against a PR that had never been
created.

Two independent blockers were sitting behind that single masked command:

- the repository had no `autorelease: pending` label, and `gh` resolves label
  names before it creates a PR, so the create aborted outright;
- `can_approve_pull_request_reviews` was `false`, so `GITHUB_TOKEN` could push
  a branch under `contents: write` but not open a pull request.

Both are repository state and are already fixed — the label exists, the setting
is enabled (with `default_workflow_permissions` left at `read`), and
[#120](https://github.com/RafPe/pod-certificate-signer/pull/120) carries
v2.3.0. What this PR fixes is that neither blocker was diagnosable from the
failed run, and the second only surfaced after the first was cleared.

## Changes

**Branch on whether the release PR exists, instead of falling back from a
failed create.** The fallback had a legitimate job — re-running Prepare Release
has to update an open release PR rather than fail — but as written it discarded
the create's error and reported whatever the edit tripped on. An explicit
`gh pr list` check keeps the idempotency and lets a real create failure speak
for itself. No stderr redirection anywhere in the step.

**Confirm the label exists before `release/next` is pushed.** A missing label
otherwise aborts the create with the branch already force-pushed. The check
distinguishes a missing label from an API call that failed for another reason,
rather than asserting a diagnosis it has not made — which is the same mistake
as the masking it replaces. Reading labels needs the issues scope, so the job
gains `issues: read`; read-only, so it can report the label missing but not
create it.

**Document both setup steps** in the maintainer runbook. The Actions
pull-request permission was not written down anywhere, and the label was listed
without the command to create it.

`release-contract-check.sh` asserts the preflight is present. It is grep-only
and offline — which is exactly why it passed while the repository lacked the
label — so it cannot check GitHub state, but it can check that the workflow
does.

## Verification

`sh scripts/release-contract-check.sh` passes, the workflow YAML parses, and
the extracted `run:` script passes `bash -n`.

The hardened path is unexecuted. Re-dispatching Prepare Release would
force-push `release/next` underneath the open #120, so this is verified by the
next release cycle rather than now.

## Note

`main` is unprotected, so the review gate described in `docs/releasing.md` is
convention rather than enforcement. Enabling the Actions pull-request
permission also permits Actions to approve PRs. Out of scope here, but worth
recording.
