### PR TITLE
ci: give every workflow job a colon-namespaced display name

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze Go
+    name: "scan:codeql"
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lint:
-    name: Run on Ubuntu
+    name: "lint:go"
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   prepare:
+    name: "release:prepare"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build-and-push:
-    name: Build and push multi-arch image
+    name: "image"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -110,7 +110,7 @@ jobs:
           cosign sign --yes "${IMAGE_REPO}@${DIGEST}"
 
   push-chart:
-    name: Package and push Helm chart
+    name: "chart"
     runs-on: ubuntu-latest
     # Publish the chart only once its default image tag (the appVersion)
     # actually exists in the registry.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   verify:
+    name: "release:verify"
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
@@ -62,6 +63,7 @@ jobs:
           echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
 
   check:
+    name: "release:check"
     needs: verify
     runs-on: ubuntu-latest
     steps:
@@ -75,6 +77,7 @@ jobs:
       - run: sh scripts/release-contract-check.sh
 
   e2e:
+    name: "release:e2e"
     needs: verify
     permissions:
       contents: read
@@ -83,6 +86,7 @@ jobs:
       target_ref: ${{ needs.verify.outputs.sha }}
 
   tag:
+    name: "release:tag"
     needs: [verify, check, e2e]
     runs-on: ubuntu-latest
     permissions:
@@ -106,6 +110,7 @@ jobs:
           fi
 
   publish-artifacts:
+    name: "release:artifact"
     needs: [verify, tag]
     permissions:
       contents: read
@@ -116,6 +121,7 @@ jobs:
       tag: ${{ needs.verify.outputs.tag }}
 
   publish-release:
+    name: "release:publish"
     needs: [verify, publish-artifacts]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ permissions: read-all
 
 jobs:
   analysis:
-    name: Scorecard analysis
+    name: "scan:posture"
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the SARIF results to the code-scanning dashboard.

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   gitleaks:
-    name: Scan for committed secrets
+    name: "scan:secrets"
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   govulncheck:
-    name: Go vulnerability scan
+    name: "scan:vuln"
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -13,7 +13,7 @@ jobs:
   test-e2e:
     permissions:
       contents: read
-    name: Run on Ubuntu
+    name: "test:chart"
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test-e2e-nightly.yml
+++ b/.github/workflows/test-e2e-nightly.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   test-e2e-nightly:
-    name: Run the full suite on Ubuntu
+    name: "test:e2e-full"
     runs-on: ubuntu-latest
     # Scheduled and manual runs always go ahead. A pull request runs only when
     # it carries the `run-nightly` label, so labelling a pull request anything

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test-e2e:
-    name: Run on Ubuntu
+    name: "test:e2e"
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: Run on Ubuntu
+    name: "test:unit"
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code


### PR DESCRIPTION
## Four different jobs all displayed as "Run on Ubuntu"

Unit tests, Go lint, the e2e suite and the Helm chart tests each rendered as a check literally named `Run on Ubuntu`:

| Workflow | Job id | Displayed as |
|---|---|---|
| `test.yml` | `test` | Run on Ubuntu |
| `lint.yml` | `lint` | Run on Ubuntu |
| `test-e2e.yml` | `test-e2e` | Run on Ubuntu |
| `test-chart.yml` | `test-e2e` | Run on Ubuntu |

GitHub matches required status checks by **display name**, not by job id. Four jobs sharing one name are one indistinguishable check to branch protection, so this repo could not express something as basic as "require lint, but do not require chart tests" — selecting one selected all four. Fixing the names is the point of this PR.

## Cross-repo goal

We are standardising job display names across three sibling repos onto one colon-namespaced scheme so all three can be governed by a single shared required-status-check set:

`test:unit`, `lint:go`, `scan:vuln`, `scan:codeql`, `scan:secrets`, `test:e2e`

## The mapping

Job ids are unchanged throughout; only the `name:` key is added or updated.

| File | Job id (unchanged) | New display name |
|---|---|---|
| `test.yml` | `test` | `test:unit` |
| `lint.yml` | `lint` | `lint:go` |
| `test-e2e.yml` | `test-e2e` | `test:e2e` |
| `test-chart.yml` | `test-e2e` | `test:chart` |
| `test-e2e-nightly.yml` | `test-e2e-nightly` | `test:e2e-full` |
| `secret-scan.yml` | `gitleaks` | `scan:secrets` |
| `security.yaml` | `govulncheck` | `scan:vuln` |
| `codeql.yml` | `analyze` | `scan:codeql` |
| `scorecard.yml` | `analysis` | `scan:posture` |
| `prepare-release.yml` | `prepare` | `release:prepare` |
| `release.yml` | `verify` | `release:verify` |
| `release.yml` | `check` | `release:check` |
| `release.yml` | `e2e` | `release:e2e` |
| `release.yml` | `tag` | `release:tag` |
| `release.yml` | `publish-artifacts` | `release:artifact` |
| `release.yml` | `publish-release` | `release:publish` |
| `release-image.yml` | `build-and-push` | `image` |
| `release-image.yml` | `push-chart` | `chart` |

Eleven jobs had an existing `name:` replaced; seven had one added for the first time — 18 insertions, 11 deletions.

## Job ids are deliberately unchanged

Adding or changing `name:` is display-only. Job **ids** are load-bearing — they are referenced by `needs:` and by `scripts/release-contract-check.sh` — so none were touched. The whole diff is 18 added and 11 removed lines, every one of them a `name:` line.

The duplicate `test-e2e` job id shared by `test-e2e.yml` and `test-chart.yml` stays. Ids are scoped per workflow file, so it was never a real conflict; only the two *display* names needed to diverge, and now they do.

## Composite check names, and one tradeoff

GitHub renders a reusable-workflow job as `<caller name> / <callee name>`. After this change:

- `release.yml:e2e` calling `test-e2e.yml` renders as `release:e2e / test:e2e`
- `release.yml:publish-artifacts` calling `release-image.yml` renders as `release:artifact / image` and `release:artifact / chart`

That composition is why the `release-image.yml` callee jobs get the short names `image` and `chart` rather than fully-qualified ones — otherwise the rendered check reads as a doubly-namespaced mouthful.

Note these composite names are the documented GitHub rendering, not something this PR can demonstrate: `release.yml:verify` gates on `head.ref == 'release/next'`, so no `release:*` check runs on an ordinary PR. The first `release/next` PR is where they will actually be observed.

**The tradeoff:** `release-image.yml` also has its own `push: tags` trigger. When it runs standalone that way, its checks render as bare `image` and `chart` with no namespace prefix. That is the accepted cost of keeping the composite names readable in the path that matters more.

## `check-release-label` is intentionally left out

Under the scheme this job would become `meta:release-label`. It keeps its old name `Require exactly one release label` instead.

`scripts/release-contract-check.sh` asserts the release-label gate still exists by grepping `pr-release-metadata.yml` for the lowercase string `exactly one` — and that string appeared **only** in the job's display name. Renaming the job broke the seam guard (`release-contract-check: PR metadata must enforce exactly one release label`).

The clean fix is in the script, not the workflow: the guard should anchor on the actual enforcement logic, whose error message already reads `::error::Exactly one of release/major, ...` — so changing `grep -q` to `grep -qi` makes the guard assert what it claims to assert, and is more robust than depending on a display string. That change lives outside `.github/workflows/`, which this PR is scoped to exclude, so it is left for a follow-up.

The general lesson is worth recording: a seam-guard script had anchored a grep on a **job display name**. Any repo with a similar contract check should be swept for the old display strings outside `.github/` *before* its jobs are renamed.

This costs nothing today: `meta:release-label` is not part of the shared required-check set. Renaming it is a one-line follow-up once the guard is re-anchored.

## No ruleset changes needed

The `main` ruleset (id `8280061`, active) contains only `deletion`, `non_fast_forward` and `pull_request` — **no `required_status_checks`** — and `branches/main/protection` returns 404. So no required check is invalidated by renaming, and no ruleset update accompanies this PR.

## Validation

| Check | Result |
|---|---|
| All 13 workflows parse (`yaml.safe_load`) | pass — 19 jobs, all ids intact |
| `actionlint v1.7.12` | pass — exit 0, no findings |
| `sh scripts/release-contract-check.sh` | pass — `release-contract-check: ok` |
| `make test` (runs `generate vet`) | pass — exit 0, tree left clean |
| `make lint` (runs `lint-e2e`) | pass — 0 issues on both passes |
| Stale display names elsewhere in repo | none — unfiltered sweep clean |

The only remaining match for an old name anywhere in the repo is `scorecard.yml:37`, which is a *step* name (`Run Scorecard analysis`), not a job name, and is correctly untouched.

All six shared-set checks pass on this PR under their new names — `test:unit`, `lint:go`, `scan:vuln`, `scan:codeql`, `scan:secrets`, `test:e2e` — alongside `test:chart`, which is now a separately requireable check rather than a fourth `Run on Ubuntu`.

One name this PR does not control: the `CodeQL` check is a check run created by the CodeQL action itself, not a workflow job, so it cannot be renamed here. `scan:codeql` is the requireable job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
