### PR TITLE
ci: bound every job with a timeout, supersede stale PR runs, finish rename

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,10 +16,17 @@ permissions:
   security-events: write
   actions: read
 
+concurrency:
+  # Cancel superseded pull request runs; never cancel a run on main or a
+  # scheduled run, whose results are recorded against the default branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: "scan:codeql"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded pull request runs; never cancel a run on main or a
+  # scheduled run, whose results are recorded against the default branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: "lint:go"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-release-metadata.yml
+++ b/.github/workflows/pr-release-metadata.yml
@@ -19,10 +19,17 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  # Cancel superseded pull request runs; never cancel a run on main or a
+  # scheduled run, whose results are recorded against the default branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-release-label:
-    name: Require exactly one release label
+    name: "meta:release-label"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check release label and changelog fragments

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,6 +18,7 @@ jobs:
   prepare:
     name: "release:prepare"
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -37,6 +37,7 @@ jobs:
   build-and-push:
     name: "image"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -112,6 +113,7 @@ jobs:
   push-chart:
     name: "chart"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Publish the chart only once its default image tag (the appVersion)
     # actually exists in the registry.
     needs: build-and-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository &&
        contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     outputs:
@@ -66,6 +67,7 @@ jobs:
     name: "release:check"
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -89,6 +91,7 @@ jobs:
     name: "release:tag"
     needs: [verify, check, e2e]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -124,6 +127,7 @@ jobs:
     name: "release:publish"
     needs: [verify, publish-artifacts]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,10 +16,17 @@ on:
 # needs. We do NOT trigger on pull_request, so fork PRs cannot read these tokens.
 permissions: read-all
 
+concurrency:
+  # Cancel superseded pull request runs; never cancel a run on main or a
+  # scheduled run, whose results are recorded against the default branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analysis:
     name: "scan:posture"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       # Needed to upload the SARIF results to the code-scanning dashboard.
       security-events: write

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,10 +9,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded pull request runs; never cancel a run on main or a
+  # scheduled run, whose results are recorded against the default branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gitleaks:
     name: "scan:secrets"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -14,10 +14,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded pull request runs; never cancel a run on main or a
+  # scheduled run, whose results are recorded against the default branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   govulncheck:
     name: "scan:vuln"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -15,6 +15,7 @@ jobs:
       contents: read
     name: "test:chart"
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,6 +20,7 @@ jobs:
   test-e2e:
     name: "test:e2e"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancel superseded pull request runs; never cancel a run on main or a
+  # scheduled run, whose results are recorded against the default branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: "test:unit"
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/release-contract-check.sh
+++ b/scripts/release-contract-check.sh
@@ -42,7 +42,12 @@ grep -q 'target_ref: \${{ needs.verify.outputs.sha }}' .github/workflows/release
 grep -q 'git tag -a' .github/workflows/release.yml ||
 	fail "Release must create an annotated tag only after verification"
 
-grep -q 'exactly one' .github/workflows/pr-release-metadata.yml ||
+# Pin the enforcement itself, not prose describing it. This previously
+# matched the string "exactly one", which lived only in the job's display
+# name -- so renaming that job to "meta:release-label", a purely cosmetic
+# change, failed the guard even though the enforcement was untouched. The
+# label-count rejection is the behaviour worth pinning.
+grep -q '"${count}" -ne 1' .github/workflows/pr-release-metadata.yml ||
 	fail "PR metadata must enforce exactly one release label"
 grep -q '.changes/unreleased' .github/workflows/pr-release-metadata.yml ||
 	fail "PR metadata must enforce changelog fragments"


### PR DESCRIPTION
Three CI-only changes, all `release/skip`.

## 1. Job timeouts — the six-hour release deadlock

**No job here set `timeout-minutes`**, so all 16 inherited GitHub's 360-minute default. `release.yml` runs under `concurrency: {group: release, cancel-in-progress: false}`, so one wedged job holds the group and **queues every subsequent release for up to six hours**.

Already merged in `kube-oidc-proxy` ([#106](https://github.com/RafPe/kube-oidc-proxy/pull/106)); `steampipe-plugin-youtrack` [#46](https://github.com/RafPe/steampipe-plugin-youtrack/pull/46) in parallel. All three shared it.

Values are ~4–6× each job's observed maximum:

| Job | Observed max | Timeout |
|---|---|---|
| `test-e2e.yml:test-e2e` | 1160s | 45m |
| `test-chart:test-e2e` | 239s | 20m |
| `test:test` | 216s | 20m |
| `codeql:analyze` | 182s | 30m |
| `lint:lint` | 127s | 15m |
| `scorecard:analysis` | 47s | 15m |
| `security:govulncheck` | 37s | 15m |
| `secret-scan:gitleaks` | 10s | 15m |
| `release:check` / `verify` / `tag` / `publish-release` | — | 30m / 15m / 10m / 10m |
| `release-image:build-and-push` / `push-chart` | — | 30m / 15m |
| `prepare-release:prepare` | 16s | 20m |

`release.yml`'s `e2e` and `publish-artifacts` are untouched — `timeout-minutes` is invalid on a job using `uses:`; the callees now carry the bound.

## 2. Concurrency

Added to the seven workflows that stack on a busy PR (`codeql`, `lint`, `pr-release-metadata`, `scorecard`, `secret-scan`, `security`, `test`):

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**`release-image.yml` deliberately excluded**: it is reached by `workflow_call` from `release.yml`, which already serializes on its own `release` group. A second group there would only add a queue.

## 3. Finish the rename

`check-release-label` → **`meta:release-label`**, completing #123 where this one job was missed. All three repos now expose the same check name.

### That rename broke a seam guard — and the guard was wrong

`release-contract-check.sh` asserted the literal string `exactly one`, which lived **only in the job's display name**. So a cosmetic rename failed a guard whose actual subject — the label-count enforcement — had not changed at all.

Repointed it at the enforcement itself (`"${count}" -ne 1`). Verified both ways: passes as written, and still fails when the count comparison is perturbed. Strictly more meaningful than what it replaced.

## Verification

- YAML parses for all 13 workflows; `actionlint` — 0 findings.
- `sh scripts/release-contract-check.sh` — ok, with the negative test above.
- Programmatic audit: no non-reusable job left unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)