### PR TITLE
ci: let release:tag push a tag when main moved during the pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,18 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      # Required to push the tag, not to edit workflows. GitHub refuses a tag
+      # push from GITHUB_TOKEN when the tagged commit's .github/workflows/
+      # differ from the tip of every branch - and that is the normal case here,
+      # because this job runs after verify, check and E2E, so anything merged
+      # to main in those ~20 minutes moves the tip out from under the release
+      # commit. It is what broke v2.4.0: #127 landed 8 minutes after the
+      # release PR and changed 12 workflow files.
+      #
+      # The grant does not let this job change workflows on main - branch
+      # protection still applies, and its only steps are a SHA-pinned checkout
+      # and git. Keep it on this job rather than at workflow level.
+      workflows: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -48,10 +48,42 @@ If only skip changes have landed, no release should be prepared.
 ## Recovery
 
 Tags are immutable: never delete or move a release tag. If publication fails
-after the tag is created, fix the workflow on `main` and dispatch **Release**
-with the existing `vX.Y.Z` tag. Recovery verifies that the tag resolves to a
-commit on `main`, reruns checks and E2E, and resumes publication. It refuses a
-published release or a tag that points elsewhere.
+**after** the tag is created, fix the workflow on `main` and dispatch
+**Release** with the existing `vX.Y.Z` tag. Recovery verifies that the tag
+resolves to a commit on `main`, reruns checks and E2E, and resumes publication.
+It refuses a published release or a tag that points elsewhere.
+
+### When the tag was never created
+
+`workflow_dispatch` takes an *existing* tag, so it cannot recover a release that
+failed at `release:tag` itself. Create the tag by hand from a checkout that has
+`workflow` scope, then dispatch as above — pushing it also triggers
+`release-image.yml`, so the image and chart publish on their own and the
+dispatch only finishes the GitHub Release:
+
+```sh
+git fetch origin --tags
+# The SHA is the release PR's merge commit; the failed run logs it as SHA.
+git tag -a vX.Y.Z -m "Release vX.Y.Z" <merge-sha>
+git push origin refs/tags/vX.Y.Z
+gh workflow run release.yml -f tag=vX.Y.Z
+```
+
+The failure that makes this necessary is worth recognising:
+
+```
+! [remote rejected] vX.Y.Z -> vX.Y.Z (refusing to allow a GitHub App to
+  create or update workflow `.github/workflows/...` without `workflows`
+  permission)
+```
+
+`release:tag` runs after verify, check and E2E, so `main` can move during those
+~20 minutes. GitHub refuses a tag push from `GITHUB_TOKEN` whenever the tagged
+commit's `.github/workflows/` differ from the tip of every branch, which is
+exactly what a workflow change merged mid-pipeline produces. The job now holds
+`workflows: write` for this reason. Merging anything that touches
+`.github/workflows/` while a release is in flight is still best avoided — it is
+the only thing that makes the tagged commit diverge in the first place.
 
 ## Repository setup
 


### PR DESCRIPTION
v2.4.0 merged, passed verify, check and E2E, then failed at `release:tag` ([run](https://github.com/RafPe/pod-certificate-signer/actions/runs/32476751001/job/96759515380)):

```
! [remote rejected] v2.4.0 -> v2.4.0 (refusing to allow a GitHub App to create
  or update workflow `.github/workflows/codeql.yml` without `workflows` permission)
```

## What actually happened

The tag step is not trying to change a workflow. GitHub refuses a tag push from `GITHUB_TOKEN` whenever the tagged commit's `.github/workflows/` differ from the tip of **every** branch. `release:tag` runs after verify, check and E2E, so `main` has ~20 minutes to move:

| time | event |
|---|---|
| 11:20:21 | release PR #126 merged, pipeline starts, target `ae7407c` |
| 11:28:23 | #127 merged — 12 workflow files changed |
| 11:42:32 | `release:tag` pushes → rejected |

`git diff ae7407c origin/main -- .github/workflows/` is 12 files, 59 insertions. v2.3.0 tagged cleanly only because nothing touched workflows in its range; this was always going to happen on the first release that did.

## The fix

`workflows: write` on the `tag` job — the permission the error names.

Kept on the job rather than the workflow. The token is ephemeral and per-run, the job's only steps are a SHA-pinned `actions/checkout` and `git`, and the grant does not let anything modify workflows on `main` — branch protection still governs that. It permits creating the tag ref, nothing more.

Alternatives weighed: creating the tag through the Git Refs API would avoid widening the token, but I could not confirm it bypasses the restriction — the community thread matching this error exactly has nobody verifying it, and other sources state a bot cannot bypass the block at all. A PAT or App token with `workflow` scope also works but trades an ephemeral token for a long-lived secret to store and rotate.

## Docs

`docs/releasing.md` Recovery covers "publication failed **after** the tag was created" and says to dispatch **Release** with the existing tag. That cannot recover a release that failed *at* the tag step, since `workflow_dispatch` requires the tag to exist — which is the state v2.4.0 is in right now. The missing case is now written down, with the error to recognise it by and the note that merging workflow changes during a release is what makes the commit diverge.

`release/skip`, so no changelog fragment.