### PR TITLE
ci: create the release tag through the API, not a tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,34 +94,56 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
-      # Required to push the tag, not to edit workflows. GitHub refuses a tag
-      # push from GITHUB_TOKEN when the tagged commit's .github/workflows/
-      # differ from the tip of every branch - and that is the normal case here,
-      # because this job runs after verify, check and E2E, so anything merged
-      # to main in those ~20 minutes moves the tip out from under the release
-      # commit. It is what broke v2.4.0: #127 landed 8 minutes after the
-      # release PR and changed 12 workflow files.
-      #
-      # The grant does not let this job change workflows on main - branch
-      # protection still applies, and its only steps are a SHA-pinned checkout
-      # and git. Keep it on this job rather than at workflow level.
-      workflows: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.verify.outputs.sha }}
-          fetch-depth: 0
+      # The tag is created through the REST API rather than `git push`.
+      #
+      # A tag push authenticated with GITHUB_TOKEN is refused whenever the
+      # tagged commit's .github/workflows/ differ from the tip of every branch:
+      #
+      #   ! [remote rejected] vX.Y.Z -> vX.Y.Z (refusing to allow a GitHub App
+      #     to create or update workflow `.github/workflows/...` without
+      #     `workflows` permission)
+      #
+      # That is the normal case here, not an edge one. This job runs after
+      # verify, check and E2E, so anything merged to main in those ~20 minutes
+      # moves the tip out from under the release commit. It is what broke
+      # v2.4.0: #127 landed 8 minutes after the release PR and changed 12
+      # workflow files.
+      #
+      # No permissions: key lifts that restriction - `workflows` is a PAT/OAuth
+      # scope, not an Actions permission, and setting it makes the whole
+      # workflow fail to parse. Creating the ref through the API sidesteps the
+      # push path: it points a new ref at a commit that is already on main, so
+      # no workflow file is created or updated.
       - env:
           TAG: ${{ needs.verify.outputs.tag }}
           SHA: ${{ needs.verify.outputs.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
-            [ "$(git rev-list -n 1 "${TAG}")" = "${SHA}" ] || { echo "::error::immutable tag points elsewhere"; exit 1; }
+          set -euo pipefail
+
+          # Resolve the tag from the API rather than a checkout, so the result
+          # is the remote's truth and not a function of what was fetched.
+          if ref=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" 2>/dev/null); then
+            target=$(echo "${ref}" | jq -r .object.sha)
+            # An annotated tag's ref points at the tag object, not the commit.
+            if [ "$(echo "${ref}" | jq -r .object.type)" = "tag" ]; then
+              target=$(gh api "repos/${REPO}/git/tags/${target}" --jq .object.sha)
+            fi
+            [ "${target}" = "${SHA}" ] || { echo "::error::immutable tag points elsewhere"; exit 1; }
+            echo "tag ${TAG} already points at ${SHA}"
           else
-            git config user.name github-actions[bot]
-            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-            git tag -a "${TAG}" -m "Release ${TAG}" "${SHA}"
-            git push origin "refs/tags/${TAG}"
+            obj=$(gh api "repos/${REPO}/git/tags" \
+              -f tag="${TAG}" \
+              -f message="Release ${TAG}" \
+              -f object="${SHA}" \
+              -f type=commit \
+              --jq .sha)
+            gh api "repos/${REPO}/git/refs" \
+              -f ref="refs/tags/${TAG}" \
+              -f sha="${obj}" >/dev/null
+            echo "created ${TAG} at ${SHA}"
           fi
 
   publish-artifacts:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -78,12 +78,20 @@ The failure that makes this necessary is worth recognising:
 ```
 
 `release:tag` runs after verify, check and E2E, so `main` can move during those
-~20 minutes. GitHub refuses a tag push from `GITHUB_TOKEN` whenever the tagged
-commit's `.github/workflows/` differ from the tip of every branch, which is
-exactly what a workflow change merged mid-pipeline produces. The job now holds
-`workflows: write` for this reason. Merging anything that touches
-`.github/workflows/` while a release is in flight is still best avoided — it is
-the only thing that makes the tagged commit diverge in the first place.
+~20 minutes. GitHub refuses a tag *push* authenticated with `GITHUB_TOKEN`
+whenever the tagged commit's `.github/workflows/` differ from the tip of every
+branch, which is exactly what a workflow change merged mid-pipeline produces.
+
+No `permissions:` key lifts that restriction — `workflows` is a PAT/OAuth scope,
+not an Actions permission, and putting it in a `permissions:` block makes the
+whole workflow fail to parse. `release:tag` therefore creates the tag through
+the REST API, which points a new ref at a commit already on `main` rather than
+pushing one. If that ever stops working, the fallback is a PAT or App token
+carrying the `workflow` scope, used only by that job.
+
+Merging anything that touches `.github/workflows/` while a release is in flight
+is still best avoided — it is the only thing that makes the tagged commit
+diverge in the first place.
 
 ## Repository setup
 


### PR DESCRIPTION
**#128 was wrong and left `release.yml` unparseable on `main`.** It added:

```yaml
permissions:
  workflows: write
```

`workflows` is not an Actions permission scope — it is a PAT/OAuth scope. GitHub rejects the file outright, so `gh workflow run release.yml -f tag=v2.4.0` currently returns:

```
HTTP 422: failed to parse workflow: (Line: 108, Col: 7): Unexpected value 'workflows'
```

`actionlint` says the same thing in one line:

```
unknown permission scope "workflows". all available permission scopes are "actions",
"artifact-metadata", "attestations", "checks", "contents", "deployments", "discussions",
"id-token", "issues", "models", "packages", "pages", "pull-requests",
"repository-projects", "security-events", "statuses"
```

No `permissions:` key can lift the restriction. That option never existed.

## What this does instead

The underlying problem is unchanged: a tag push authenticated with `GITHUB_TOKEN` is refused whenever the tagged commit's `.github/workflows/` differ from the tip of **every** branch, and `release:tag` runs after verify, check and E2E, so main has ~20 minutes to move out from under the release commit.

Creating the ref through the REST API sidesteps the push path — it points a new ref at a commit already on `main`, so no workflow file is created or updated. Needs only the `contents: write` the job already had.

The existence check moves to the API as well, so the recovery path reads the remote's truth rather than whatever the checkout happened to fetch, and resolves an annotated tag's object through to its commit before comparing. `actions/checkout` is dropped — nothing in the job needed a working tree.

## Honesty about confidence

I could not find a source confirming the Git Refs API bypasses the restriction for `GITHUB_TOKEN`; the community thread matching this error exactly has nobody verifying it either way. It is the only `GITHUB_TOKEN`-only option left now that the permission route is ruled out, and it is cheap to try. If it fails on the next release, the fallback is a PAT or App token with `workflow` scope scoped to this job — that is now written into `docs/releasing.md` rather than left to be rediscovered.

v2.4.0 does not depend on this working: its tag is already pushed and its image and chart are published.

## Follow-up

`actionlint` catches this class immediately and **is not run in CI**, which is how #128 merged green. Wiring it into the `internal/tools` module needs a `go mod tidy` there, so it is a separate PR rather than bundled into an urgent fix.

`release/skip`, so no changelog fragment.