### PR TITLE
ci: let the release contract check accept the API-created tag

### DIFF
--- a/scripts/release-contract-check.sh
+++ b/scripts/release-contract-check.sh
@@ -39,8 +39,13 @@ grep -q 'uses: ./.github/workflows/test-e2e.yml' .github/workflows/release.yml |
 	fail "Release must run the reusable E2E workflow before publishing"
 grep -q 'target_ref: \${{ needs.verify.outputs.sha }}' .github/workflows/release.yml ||
 	fail "Release E2E must test the resolved release commit"
-grep -q 'git tag -a' .github/workflows/release.yml ||
-	fail "Release must create an annotated tag only after verification"
+# Since #129 the tag is an annotated tag object created through the REST API
+# (a GITHUB_TOKEN tag push is refused when workflow files changed), so pin the
+# git/tags object creation, not a `git tag -a` invocation.
+grep -qF 'repos/${REPO}/git/tags' .github/workflows/release.yml ||
+	fail "Release must create an annotated tag object through the API"
+grep -qF 'needs: [verify, check, e2e]' .github/workflows/release.yml ||
+	fail "Release must tag only after check and E2E verification"
 
 # Pin the enforcement itself, not prose describing it. This previously
 # matched the string "exactly one", which lived only in the job's display


### PR DESCRIPTION
## Summary

The v3.0.0 release run failed in `release:check`: `scripts/release-contract-check.sh` still greps `release.yml` for `git tag -a`, but #129 replaced that invocation with an annotated tag object created through the REST API (a `GITHUB_TOKEN` tag push is refused when workflow files changed - the v2.4.0 failure). The guard pinned the retired mechanism, so every release now fails at the contract check.

This is the same failure class the script already warns about in its own comment (pinning a job's display name instead of the enforcement): the guard pinned an implementation detail rather than the behaviour. Replace the single grep with two that pin what actually matters:

- `repos/${REPO}/git/tags` - the annotated tag **object** is created through the API (a lightweight tag would skip this endpoint)
- `needs: [verify, check, e2e]` - the tag job runs only after verification

Verified: `sh scripts/release-contract-check.sh` reproduces the release failure on main and prints `ok` with this change; both new greps fire when their target is removed from `release.yml`.

The check only runs inside the Release workflow itself, which is why #129 merged green and the stale guard surfaced one release later.

## After merging

Re-dispatch **Prepare Release** so `release/next` is regenerated on top of this fix, then let the release PR run again.