### PR TITLE
fix: guard Sign and CertificateNotAfter against a nil CA certificate

### DIFF
--- a/.changes/unreleased/fixed-nil-certificate-guards.yaml
+++ b/.changes/unreleased/fixed-nil-certificate-guards.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: '`Sign` and `CertificateNotAfter` no longer dereference the CA certificate without a nil guard. An authority that somehow holds no certificate - possible only through a construction path that defers the first load, since `New` fails closed - now refuses to sign with the same "CA unusable, requeue" classification as an expired signer, and reports its expiry as a zero timestamp instead of panicking. The second guard matters beyond signing: `CertificateNotAfter` runs on every metrics scrape, where a panic takes down the scrape rather than being recovered.'

--- a/internal/kubernetes/authority/authority.go
+++ b/internal/kubernetes/authority/authority.go
@@ -362,6 +362,16 @@ func (ca *CertificateAuthority) Sign(pcConfig *podcertificate.PodCertificateConf
 	ca.mu.Lock()
 	defer ca.mu.Unlock()
 
+	// New fails closed, so a loaded certificate is an invariant today - but
+	// nothing else defends it, and any construction path that defers the first
+	// load would turn the dereferences below into panics. Classified as
+	// ErrCASignerUnusable: like an expired signer, a CA rotation can make an
+	// identical request succeed, so callers requeue rather than record a
+	// terminal outcome.
+	if ca.certificate == nil {
+		return nil, fmt.Errorf("no CA certificate loaded: %w", ErrCASignerUnusable)
+	}
+
 	now := time.Now()
 	if ca.nowFunc != nil {
 		now = ca.nowFunc()
@@ -794,6 +804,15 @@ func (ca *CertificateAuthority) ReloadHealth() (int, time.Time) {
 func (ca *CertificateAuthority) CertificateNotAfter() time.Time {
 	ca.mu.Lock()
 	defer ca.mu.Unlock()
+
+	// This runs on every metrics scrape, which is not a reconcile: a panic
+	// here takes down the scrape rather than being recovered. With no
+	// certificate loaded, report the zero time - the collector renders it as
+	// a 0 gauge (see metrics.timestamp), which correctly fires the staleness
+	// alert.
+	if ca.certificate == nil {
+		return time.Time{}
+	}
 
 	return ca.certificate.NotAfter
 }

--- a/internal/kubernetes/authority/authority_unloaded_test.go
+++ b/internal/kubernetes/authority/authority_unloaded_test.go
@@ -1,0 +1,68 @@
+package authority
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// unloadedAuthority builds a CertificateAuthority that holds no certificate,
+// the state every construction path other than a fully successful New would
+// leave behind. New fails closed today, so this is the seam that reaches the
+// nil-certificate guards at all.
+func unloadedAuthority(t *testing.T) *CertificateAuthority {
+	t.Helper()
+	return &CertificateAuthority{
+		backDate: time.Minute,
+		nowFunc:  time.Now,
+	}
+}
+
+// Sign must fail closed, not panic, when the authority holds no certificate.
+// The invariant "an authority always holds a certificate" is enforced only by
+// New failing closed; any construction path that defers the first load would
+// otherwise turn this call into a nil-pointer panic. The error is classified
+// under ErrCASignerUnusable so callers treat it as "CA unusable, requeue",
+// exactly like an expired signer.
+func TestSignFailsClosedWhenNoCertificateLoaded(t *testing.T) {
+	ca := unloadedAuthority(t)
+
+	pc, err := ca.Sign(testConfig(t))
+	if err == nil {
+		t.Fatal("Sign() error = nil, want an error when no certificate is loaded")
+	}
+	if !errors.Is(err, ErrCASignerUnusable) {
+		t.Errorf("Sign() error = %v, want errors.Is(err, ErrCASignerUnusable)", err)
+	}
+	if pc != nil {
+		t.Errorf("Sign() = %v, want nil certificate on error", pc)
+	}
+}
+
+// CertificateNotAfter runs on every metrics scrape via the CA collector, which
+// is not a reconcile: a panic there takes down the scrape rather than being
+// recovered. With no certificate it must report the zero time, which the
+// collector already renders as a 0 gauge (see metrics.timestamp).
+func TestCertificateNotAfterIsZeroWhenNoCertificateLoaded(t *testing.T) {
+	ca := unloadedAuthority(t)
+
+	if got := ca.CertificateNotAfter(); !got.IsZero() {
+		t.Errorf("CertificateNotAfter() = %v, want the zero time", got)
+	}
+}
+
+// With a certificate loaded, CertificateNotAfter reports its expiry. Pinned
+// here because the method backs the ca_expiration_timestamp_seconds gauge and
+// had no covering test at all.
+func TestCertificateNotAfterReportsLoadedExpiry(t *testing.T) {
+	dir := t.TempDir()
+	kp := writeCA(t, dir, "ca.example.org", 24*time.Hour)
+	ca, err := New(dir+"/tls.crt", dir+"/tls.key")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if got, want := ca.CertificateNotAfter(), kp.Cert.NotAfter; !got.Equal(want) {
+		t.Errorf("CertificateNotAfter() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #138.

## What

`Sign` and `CertificateNotAfter` dereferenced `ca.certificate` unconditionally. The invariant "an authority always holds a certificate" is enforced only by `New` failing closed; nothing defended it at the point of use, and `CertificateNotAfter` runs on every metrics scrape via the CA collector, where a panic takes down the scrape rather than being recovered.

- `Sign` now fails closed with an error classified under `ErrCASignerUnusable` when no certificate is loaded — callers already treat that as "CA unusable, requeue", the same handling as an expired signer.
- `CertificateNotAfter` now reports the zero `time.Time`, which the collector's `timestamp` guard already renders as a `0` gauge, correctly firing the staleness alert.

Both checks sit under `ca.mu`, which the methods already take. This is defensive hardening per the issue: no known sequence reaches either method with a nil certificate today.

## Test evidence (TDD)

Developed red → green; the reproducer commit precedes the fix commit on this branch.

| # | Guarantee | Test | Result |
|---|-----------|------|--------|
| 1 | `Sign` on an unloaded authority returns an error matching `errors.Is(err, ErrCASignerUnusable)` instead of panicking | `TestSignFailsClosedWhenNoCertificateLoaded` | RED: nil-pointer panic at `authority.go:371` → GREEN |
| 2 | `CertificateNotAfter` on an unloaded authority returns the zero time instead of panicking | `TestCertificateNotAfterIsZeroWhenNoCertificateLoaded` | RED: nil-pointer panic at `authority.go:798` → GREEN |
| 3 | `CertificateNotAfter` reports the loaded certificate's expiry (previously untested) | `TestCertificateNotAfterReportsLoadedExpiry` | GREEN |

The nil path is exercised via a constructed-but-unloaded `&CertificateAuthority{}`, the state any construction path that defers the first load would leave behind.

Validation run:

- `go test -race ./internal/kubernetes/authority/ ./internal/metrics/` — pass
- `make test` (full suite, envtest) — pass, 0 failures
- `make lint` (incl. `--build-tags=e2e`) — 0 issues
- Coverage: authority package 86.5% of statements; `CertificateNotAfter` 100%, `Sign` 84.6%

No e2e addition: the kind-based e2e suite deploys through `New`, which fails closed, so the nil-certificate state is unreachable end-to-end by construction — the unit seam above is the covering test the issue asks for.